### PR TITLE
Check for availability of the shiny package

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -15,6 +15,8 @@ render_gt <- function(expr,
                       quoted = FALSE,
                       outputArgs = list()) {
 
+  check_shiny()
+
   func <-
     shiny::installExprFunction(
       expr, "func", eval.env = env, quoted = quoted)
@@ -50,5 +52,16 @@ render_gt <- function(expr,
 #' @export
 gt_output <- function(outputId) {
 
+  check_shiny()
+
   shiny::htmlOutput(outputId)
+}
+
+check_shiny <- function() {
+
+  if (!requireNamespace("shiny", quietly = TRUE)) {
+
+    stop("Please install the shiny package before using this function\n\n\t",
+         "install.packages(\"shiny\")", call. = FALSE)
+  }
 }


### PR DESCRIPTION
This modifies the Shiny-based functions so that they always perform an availability check for the `shiny` package. If `shiny` is not present then these functions will `stop()` with a message to obtain `shiny` from CRAN.