### PR TITLE
Add `latex_dependency()` packages

### DIFF
--- a/R/as_latex.R
+++ b/R/as_latex.R
@@ -111,8 +111,7 @@ as_latex <- function(data) {
         source_note_component,
         table_end,
         collapse = "") %>%
-      knitr::asis_output(meta = latex_packages) %>%
-      knitr::knit_print()
+      knitr::asis_output(meta = latex_packages)
 
     latex_table
   })


### PR DESCRIPTION
This removes the need for the user to declare the Latex packages `booktabs` and `caption` when rendering Latex tables. 

Within the `as_latex()` function (the 2nd pipeline step after the common part) the Latex table is generated and `knitr::asis_output()` is called on it. The `meta` argument is now used in that function, accepting a list of `rmarkdown::latex_dependency()` calls (with `booktabs` and `caption`).

Closes https://github.com/rstudio/gt/issues/63.