### PR TITLE
Fix for using of `fmt_scientific()` on columns with NA values

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -143,8 +143,11 @@ fmt_number <- function(data,
           # Determine which of `x` are not NA
           non_na_x <- !is.na(x)
 
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
           # Format all non-NA x values
-          x[non_na_x] <-
+          x_str[non_na_x] <-
             formatC(
               x = x[non_na_x] * scale_by,
               digits = decimals,
@@ -162,13 +165,13 @@ fmt_number <- function(data,
 
             # Apply parentheses to the formatted value and remove
             # the minus sign
-            x[negative_x] <- paste0("(", gsub("^-", "", x[negative_x]), ")")
+            x_str[negative_x] <- paste0("(", gsub("^-", "", x_str[negative_x]), ")")
           }
 
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x[non_na_x] <- paste0(pre_post_txt[1], x[non_na_x], pre_post_txt[2])
-          x
+          x_str[non_na_x] <- paste0(pre_post_txt[1], x_str[non_na_x], pre_post_txt[2])
+          x_str
         }
       ))
 }
@@ -256,8 +259,8 @@ fmt_scientific <- function(data,
            (x <= -1 & x > -10) |
            is_equal_to(x, 0)) & !is.na(x)
 
-      # Copy `x` into `x_str`
-      x_str <- x
+      # Create `x_str` with same length as `x`
+      x_str <- rep(NA_character_, length(x))
 
       # Format the number component as a character vector
       x_str[non_na_x] <-
@@ -280,8 +283,6 @@ fmt_scientific <- function(data,
       # For any non-NA numbers that do have an exponent, format
       # those according to the output context
       if (any(!small_pos)) {
-
-        x_str[non_na_x & !small_pos]
 
         sci_parts <- split_scientific_notn(x_str[non_na_x & !small_pos])
 
@@ -433,8 +434,11 @@ fmt_percent <- function(data,
           # Determine which of `x` are not NA
           non_na_x <- !is.na(x)
 
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
           # Format all non-NA x values
-          x[non_na_x] <-
+          x_str[non_na_x] <-
             formatC(
               x = x[non_na_x] * 100.0,
               digits = decimals,
@@ -445,13 +449,20 @@ fmt_percent <- function(data,
               drop0trailing = drop_trailing_zeros)
 
           if (placement == "right") {
-            x[non_na_x] <- paste0(
-              x[non_na_x],
-              ifelse(incl_space, " \\%", "\\%"))
+
+            x_str[non_na_x] <-
+              paste0(
+                x_str[non_na_x],
+                ifelse(incl_space, " \\%", "\\%")
+              )
+
           } else {
-            x[non_na_x] <- paste0(
-              ifelse(incl_space, "\\% ", "\\%"),
-              x[non_na_x])
+
+            x_str[non_na_x] <-
+              paste0(
+                ifelse(incl_space, "\\% ", "\\%"),
+                x_str[non_na_x]
+              )
           }
 
           # Handle negative values
@@ -462,22 +473,24 @@ fmt_percent <- function(data,
 
             # Apply parentheses to the formatted value and remove
             # the minus sign
-            x[negative_x] <- paste0("(", gsub("^-", "", x[negative_x]), ")")
+            x_str[negative_x] <- paste0("(", gsub("^-", "", x_str[negative_x]), ")")
           }
 
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x[non_na_x] <- paste0(pre_post_txt[1], x[non_na_x], pre_post_txt[2])
-
-          x
+          x_str[non_na_x] <- paste0(pre_post_txt[1], x_str[non_na_x], pre_post_txt[2])
+          x_str
         },
         default = function(x) {
 
           # Determine which of `x` are not NA
           non_na_x <- !is.na(x)
 
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
           # Format all non-NA x values
-          x[non_na_x] <-
+          x_str[non_na_x] <-
             formatC(
               x = x[non_na_x] * 100.0,
               digits = decimals,
@@ -488,13 +501,20 @@ fmt_percent <- function(data,
               drop0trailing = drop_trailing_zeros)
 
           if (placement == "right") {
-            x[non_na_x] <- paste0(
-              x[non_na_x],
-              ifelse(incl_space, " %", "%"))
+
+            x_str[non_na_x] <-
+              paste0(
+                x_str[non_na_x],
+                ifelse(incl_space, " %", "%")
+              )
+
           } else {
-            x[non_na_x] <- paste0(
-              ifelse(incl_space, "% ", "%"),
-              x[non_na_x])
+
+            x_str[non_na_x] <-
+              paste0(
+                ifelse(incl_space, "% ", "%"),
+                x_str[non_na_x]
+              )
           }
 
           # Handle negative values
@@ -505,14 +525,13 @@ fmt_percent <- function(data,
 
             # Apply parentheses to the formatted value and remove
             # the minus sign
-            x[negative_x] <- paste0("(", gsub("^-", "", x[negative_x]), ")")
+            x_str[negative_x] <- paste0("(", gsub("^-", "", x_str[negative_x]), ")")
           }
 
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x[non_na_x] <- paste0(pre_post_txt[1], x[non_na_x], pre_post_txt[2])
-
-          x
+          x_str[non_na_x] <- paste0(pre_post_txt[1], x_str[non_na_x], pre_post_txt[2])
+          x_str
         }
       ))
 }
@@ -670,8 +689,11 @@ fmt_currency <- function(data,
           # Determine which of `x` are not NA and also negative
           negative_x <- x < 0 & !is.na(x)
 
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
           # Format all non-NA x values
-          x[non_na_x] <-
+          x_str[non_na_x] <-
             formatC(
               x = x[non_na_x] * scale_by,
               digits = decimals,
@@ -683,11 +705,20 @@ fmt_currency <- function(data,
 
           # Handle placement of the currency symbol
           if (placement == "left") {
-            x[non_na_x] <- paste0(
-              currency_str, ifelse(incl_space, " ", ""), x[non_na_x])
+
+            x_str[non_na_x] <-
+              paste0(
+                currency_str,
+                ifelse(incl_space, " ", ""), x_str[non_na_x]
+              )
+
           } else {
-            x[non_na_x] <- paste0(
-              x[non_na_x], ifelse(incl_space, " ", ""), currency_str)
+
+            x_str[non_na_x] <-
+              paste0(
+                x_str[non_na_x],
+                ifelse(incl_space, " ", ""), currency_str
+              )
           }
 
           # Handle negative values
@@ -695,13 +726,13 @@ fmt_currency <- function(data,
 
             # Apply parentheses to the formatted value and remove
             # the minus sign
-            x[negative_x] <- paste0("(", gsub("-", "", x[negative_x]), ")")
+            x_str[negative_x] <- paste0("(", gsub("-", "", x_str[negative_x]), ")")
           }
 
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x[non_na_x] <- paste0(pre_post_txt[1], x[non_na_x], pre_post_txt[2])
-          x
+          x_str[non_na_x] <- paste0(pre_post_txt[1], x_str[non_na_x], pre_post_txt[2])
+          x_str
         },
         html = function(x) {
 
@@ -711,7 +742,10 @@ fmt_currency <- function(data,
           # Determine which of `x` are not NA and also negative
           negative_x <- x < 0 & !is.na(x)
 
-          x[non_na_x] <-
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
+          x_str[non_na_x] <-
             formatC(
               x = x[non_na_x] * scale_by,
               digits = decimals,
@@ -723,11 +757,20 @@ fmt_currency <- function(data,
 
           # Handle placement of the currency symbol
           if (placement == "left") {
-            x[non_na_x] <- paste0(
-              currency_str_html, ifelse(incl_space, " ", ""), x[non_na_x])
+
+            x_str[non_na_x] <-
+              paste0(
+                currency_str_html,
+                ifelse(incl_space, " ", ""), x_str[non_na_x]
+              )
+
           } else {
-            x[non_na_x] <- paste0(
-              x[non_na_x], ifelse(incl_space, " ", ""), currency_str_html)
+
+            x_str[non_na_x] <-
+              paste0(
+                x_str[non_na_x],
+                ifelse(incl_space, " ", ""), currency_str_html
+              )
           }
 
           # Handle negative values
@@ -735,13 +778,13 @@ fmt_currency <- function(data,
 
             # Apply parentheses to the formatted value and remove
             # the minus sign
-            x[negative_x] <- paste0("(", gsub("-", "", x[negative_x]), ")")
+            x_str[negative_x] <- paste0("(", gsub("-", "", x_str[negative_x]), ")")
           }
 
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x[non_na_x] <- paste0(pre_post_txt[1], x[non_na_x], pre_post_txt[2])
-          x
+          x_str[non_na_x] <- paste0(pre_post_txt[1], x_str[non_na_x], pre_post_txt[2])
+          x_str
         },
         latex = function(x) {
 
@@ -751,8 +794,11 @@ fmt_currency <- function(data,
           # Determine which of `x` are not NA and also negative
           negative_x <- x < 0 & !is.na(x)
 
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
           # Format all non-NA x values
-          x[non_na_x] <-
+          x_str[non_na_x] <-
             formatC(
               x = x[non_na_x] * scale_by,
               digits = decimals,
@@ -764,11 +810,20 @@ fmt_currency <- function(data,
 
           # Handle placement of the currency symbol
           if (placement == "left") {
-            x[non_na_x] <- paste0(
-              markdown_to_latex(currency_str), ifelse(incl_space, " ", ""), x[non_na_x])
+
+            x_str[non_na_x] <-
+              paste0(
+                markdown_to_latex(currency_str),
+                ifelse(incl_space, " ", ""), x_str[non_na_x]
+              )
+
           } else {
-            x[non_na_x] <- paste0(
-              x[non_na_x], ifelse(incl_space, " ", ""), markdown_to_latex(currency_str))
+
+            x_str[non_na_x] <-
+              paste0(
+                x_str[non_na_x], ifelse(incl_space, " ", ""),
+                markdown_to_latex(currency_str)
+              )
           }
 
           # Handle negative values
@@ -776,13 +831,13 @@ fmt_currency <- function(data,
 
             # Apply parentheses to the formatted value and remove
             # the minus sign
-            x[negative_x] <- paste0("(", gsub("-", "", x[negative_x]), ")")
+            x_str[negative_x] <- paste0("(", gsub("-", "", x_str[negative_x]), ")")
           }
 
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x[non_na_x] <- paste0(pre_post_txt[1], x[non_na_x], pre_post_txt[2])
-          x
+          x_str[non_na_x] <- paste0(pre_post_txt[1], x_str[non_na_x], pre_post_txt[2])
+          x_str
         }
         ))
 }
@@ -1115,35 +1170,44 @@ fmt_passthrough <- function(data,
       fns = list(
         html = function(x) {
 
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x <- paste0(pre_post_txt[1], x, pre_post_txt[2])
+          x_str <- paste0(pre_post_txt[1], x, pre_post_txt[2])
 
           if (escape) {
-            x <- x %>% process_text(context = "html")
+            x_str <- x_str %>% process_text(context = "html")
           }
 
-          x
+          x_str
         },
         latex = function(x) {
 
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x <- paste0(pre_post_txt[1], x, pre_post_txt[2])
+          x_str <- paste0(pre_post_txt[1], x, pre_post_txt[2])
 
           if (escape) {
-            x <- x %>% process_text(context = "latex")
+            x_str <- x_str %>% process_text(context = "latex")
           }
 
-          x
+          x_str
         },
         default = function(x) {
 
+          # Create `x_str` with same length as `x`
+          x_str <- rep(NA_character_, length(x))
+
           # Handle formatting of pattern
           pre_post_txt <- get_pre_post_txt(pattern)
-          x <- paste0(pre_post_txt[1], x, pre_post_txt[2])
+          x_str <- paste0(pre_post_txt[1], x, pre_post_txt[2])
 
-          x
+          x_str
         }
       ))
 }
@@ -1194,6 +1258,7 @@ fmt_missing <- function(data,
       rows = !!rows,
       fns = list(
         html = function(x) {
+
           if (missing_text == "---") {
             missing_text <- "\u2014"
           } else if (missing_text == "--") {

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -119,7 +119,7 @@ fmt_number <- function(data,
     sep_mark <- get_locale_sep_mark(locale = locale)
     dec_mark <- get_locale_dec_mark(locale = locale)
   } else if (!is.null(locale) && !(locale %in% locales$base_locale_id)) {
-    stop("The supplied `locale` is not in the available in the list of supported locale list",
+    stop("The supplied `locale` is not available in the list of supported locales.",
          call. = FALSE)
   }
 
@@ -239,7 +239,7 @@ fmt_scientific <- function(data,
     sep_mark <- get_locale_sep_mark(locale = locale)
     dec_mark <- get_locale_dec_mark(locale = locale)
   } else if (!is.null(locale) && !(locale %in% locales$base_locale_id)) {
-    stop("The supplied `locale` is not in the available in the list of supported locale list",
+    stop("The supplied `locale` is not available in the list of supported locales.",
          call. = FALSE)
   }
 
@@ -409,7 +409,7 @@ fmt_percent <- function(data,
     sep_mark <- get_locale_sep_mark(locale = locale)
     dec_mark <- get_locale_dec_mark(locale = locale)
   } else if (!is.null(locale) && !(locale %in% locales$base_locale_id)) {
-    stop("The supplied `locale` is not in the available in the list of supported locale list",
+    stop("The supplied `locale` is not available in the list of supported locales.",
          call. = FALSE)
   }
 

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -247,10 +247,19 @@ fmt_scientific <- function(data,
 
     function(x) {
 
+      # Determine which of `x` are not NA
+      non_na_x <- !is.na(x)
+
+      small_pos <- (
+        (x[non_na_x] >= 1 & x[non_na_x] < 10) |
+          (x[non_na_x] <= -1 & x[non_na_x] > -10) |
+          is_equal_to(x[non_na_x], 0)
+      )
+
       # Format the number component as a character vector
-      x_str <-
+      x[non_na_x] <-
         formatC(
-          x = x * scale_by,
+          x = x[non_na_x] * scale_by,
           digits = decimals,
           mode = "double",
           big.mark = sep_mark,
@@ -258,31 +267,27 @@ fmt_scientific <- function(data,
           format = "e",
           drop0trailing = drop_trailing_zeros)
 
-      small_pos <- (
-        (x >= 1 & x < 10) |
-          (x <= -1 & x > -10) |
-          is_equal_to(x, 0)
-      )
-
       # For any numbers that shouldn't have an exponent, remove
       # that portion from the character version
       if (any(small_pos)) {
-        x_str[small_pos] <- split_scientific_notn(x_str[small_pos])$num
+        x[non_na_x][small_pos] <-
+          split_scientific_notn(x[non_na_x][small_pos])$num
       }
 
       if (any(!small_pos)) {
-        sci_parts <- split_scientific_notn(x_str[!small_pos])
+        sci_parts <- split_scientific_notn(x[non_na_x][!small_pos])
 
-        x_str[!small_pos] <- paste0(
-          sci_parts$num, exp_start_str,
-          sci_parts$exp, exp_end_str)
+        x[non_na_x][!small_pos] <-
+          paste0(
+            sci_parts$num, exp_start_str,
+            sci_parts$exp, exp_end_str
+          )
       }
 
       # Handle formatting of pattern
       pre_post_txt <- get_pre_post_txt(pattern)
-      x_str <- paste0(pre_post_txt[1], x_str, pre_post_txt[2])
-
-      x_str
+      x[non_na_x] <- paste0(pre_post_txt[1], x[non_na_x], pre_post_txt[2])
+      x
     }
   }
 

--- a/tests/testthat/test-fmt_scientific.R
+++ b/tests/testthat/test-fmt_scientific.R
@@ -11,7 +11,7 @@ test_that("the `fmt_scientific()` function works correctly", {
       char_2 = c("june", "july", "august", "september",
                  "october", "november", "december"),
       num_1 = c(1836.23, 2763.39, 937.29, 643.00, 2.232, 0, -23.24),
-      num_2 = c(34, 74, 23, 93, 35, 76, 57),
+      num_2 = c(34, 74, 23, 93, 35, 0.01, NA),
       stringsAsFactors = FALSE)
 
   # Create a `gt_tbl` object with `gt()` and the
@@ -69,6 +69,22 @@ test_that("the `fmt_scientific()` function works correctly", {
       "6.43 &times; 10<sup class='gt_super'>2</sup>",
       "2.23", "0.00",
       "-2.32 &times; 10<sup class='gt_super'>1</sup>"))
+
+  # Format the `num_2` column to 2 decimal places, use all
+  # other defaults; extract `output_df` in the HTML context
+  # and compare to expected values
+  expect_equal(
+    (tab %>%
+       fmt_scientific(columns = "num_2", decimals = 2) %>%
+       render_formats_test("html"))[["num_2"]],
+    c(
+      "3.40 &times; 10<sup class='gt_super'>1</sup>",
+      "7.40 &times; 10<sup class='gt_super'>1</sup>",
+      "2.30 &times; 10<sup class='gt_super'>1</sup>",
+      "9.30 &times; 10<sup class='gt_super'>1</sup>",
+      "3.50 &times; 10<sup class='gt_super'>1</sup>",
+      "1.00 &times; 10<sup class='gt_super'>-2</sup>",
+      NA))
 
   # Format the `num_1` column to 2 decimal places, use all
   # other defaults; extract `output_df` in the default context


### PR DESCRIPTION
Previously, this code...

```r
dplyr::tibble(x = c(-15.0, -1.5, -0.001, NA, 0, 0.001, 1.5, 22.5, 333.5)) %>%
  gt() %>%
  fmt_scientific(columns = vars(x))
```

...would result in this error:

```
 Error in FUN(X[[i]], ...) : subscript out of bounds 
```

The error occurred because there was no treatment of `NA`s as with the other `fmt*()` functions. With the changes here, we don't get an error and gt table output is correct:

<img width="737" alt="after" src="https://user-images.githubusercontent.com/5612024/49562290-dd145b00-f8e8-11e8-97ae-5660078a4acf.png">

A test was added to check the `fmt_scientific()` function for resilience to `NA` values.

This fixes #80.