### PR TITLE
Title/subtitle fix for inlining with existing custom styles

### DIFF
--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -294,9 +294,14 @@ create_heading_component <- function(heading,
     heading_component <-
       paste0(
         "<thead>\n<tr>\n",
-        "<th class='gt_heading gt_title gt_font_normal gt_center' colspan='",
-        n_cols, "'", create_style_attrs(title_style_attrs), ">",
-        heading$title, footnote_title_glyphs, "</th>\n</tr>\n")
+        "<th ",
+        "colspan='", n_cols, "' ",
+        "class='gt_heading gt_title gt_font_normal gt_center' ",
+        create_style_attrs(title_style_attrs),
+        ">",
+        heading$title, footnote_title_glyphs,
+        "</th>\n</tr>\n"
+        )
 
     if ("subtitle" %in% names(heading)) {
 
@@ -306,13 +311,17 @@ create_heading_component <- function(heading,
           paste0(
             "<tr>\n",
             "<th ",
-            "class='gt_heading gt_subtitle gt_font_normal gt_center gt_bottom_border' colspan='",
-            n_cols, "'", create_style_attrs(subtitle_style_attrs), ">",
-            heading$subtitle, footnote_subtitle_glyphs, "</th>\n</tr>\n"))
+            "colspan='", n_cols, "' ",
+            "class='gt_heading gt_subtitle gt_font_normal gt_center gt_bottom_border' ",
+            create_style_attrs(subtitle_style_attrs),
+            ">",
+            heading$subtitle, footnote_subtitle_glyphs,
+            "</th>\n</tr>\n"
+          )
+        )
     }
 
-    heading_component <-
-      paste0(heading_component, "</thead>\n")
+    heading_component <- paste0(heading_component, "</thead>\n")
   }
 
   if (output == "rtf") {

--- a/tests/testthat/test-util_functions.R
+++ b/tests/testthat/test-util_functions.R
@@ -414,7 +414,9 @@ test_that("the `inline_html_styles()` function works correctly", {
   data <-
     data %>%
     tab_style(
-      style = "font-size:10px;", locations = cells_data(columns = TRUE))
+      style = "font-size:10px;",
+      locations = cells_data(columns = TRUE)
+    )
 
   # Get the CSS tibble and the raw HTML
   css_tbl <- data %>% get_css_tbl()
@@ -428,6 +430,37 @@ test_that("the `inline_html_styles()` function works correctly", {
   # the inlined rules derived from the CSS classes
   expect_true(
     grepl("style=\"padding:10px;margin:10px;vertical-align:middle;text-align:right;font-variant-numeric:tabular-nums;font-size:10px;\"", inlined_html)
+  )
+
+  # Create a gt table with a custom style in the title and subtitle
+  # (left alignment of text)
+  data <-
+    gt(mtcars) %>%
+    tab_header(
+      title = "The title",
+      subtitle = "The subtitle"
+    ) %>%
+    tab_style(
+      cells_styles(
+        text_align = "left"),
+        locations = list(
+          cells_title(groups = "title"),
+          cells_title(groups = "subtitle")
+          )
+    )
+
+  # Get the CSS tibble and the raw HTML
+  css_tbl <- data %>% get_css_tbl()
+  html <- data %>% as_raw_html()
+
+  # Get the inlined HTML using `inline_html_styles()`
+  inlined_html <-
+    inline_html_styles(html, css_tbl = css_tbl)
+
+  # Expect that the `colspan` attr is preserved in both <th> elements
+  # and that the `text-align:left` rule is present
+  expect_true(
+    grepl("th colspan='11' style=.*?text-align:left;", inlined_html)
   )
 })
 


### PR DESCRIPTION
When a table has a custom style applied to either the title or the subtitle (through `tab_style()`), and, the table is exported to an HTML with inlined CSS styles, the title or subtitle won't span across the width of the table. The following code will produce a correct table in the Viewer:

```r
gt(mtcars[1:2, ]) %>%
  tab_header(
    title = "The title",
    subtitle = "The subtitle"
  ) %>%
  tab_style(
    cells_styles(
      text_align = "left"),
    locations = list(
      cells_title(groups = "title"),
      cells_title(groups = "subtitle")
    )
  )
```

<img width="578" alt="table_in_viewer" src="https://user-images.githubusercontent.com/5612024/50311435-33e66c80-0473-11e9-8429-4d10a3c3a40f.png">

When it is exported to HTML via `as_raw_html()` and saved to disk, the viewed HTML won't have the `colspan` attr in the title or in the subtitle.

<img width="599" alt="table_in_viewer_before_fix" src="https://user-images.githubusercontent.com/5612024/50311589-ba9b4980-0473-11e9-8531-da9e4c1de2cd.png">

This PR fixes that erroneous result by preserving the `colspan` attr. A testthat test has also been added. 

Fixes https://github.com/rstudio/gt/issues/113