### PR TITLE
Changes to grouped object attributes in dplyr

### DIFF
--- a/R/gt.R
+++ b/R/gt.R
@@ -110,7 +110,7 @@ gt <- function(data,
   # already in `stub_df$groupname`
   if (inherits(data, "grouped_df")) {
 
-    group_cols <- attr(data, "vars", exact = TRUE)
+    group_cols <- dplyr::group_vars(data)
     group_cols <- base::intersect(group_cols, colnames(data))
 
     group_labels <-


### PR DESCRIPTION
Changes to grouped object attributes in dplyr mean that we need to update the way we extract grouping columns

See Issue #124