### PR TITLE
Add option to gather columns in `tab_spanner()`

### DIFF
--- a/R/resolver.R
+++ b/R/resolver.R
@@ -139,12 +139,24 @@ resolve_vars <- function(var_expr, var_names, data_df) {
 
   } else if (is.character(resolved)) {
 
+    if (!all(resolved %in% var_names)) {
+      stop("One or more column names provided not available in the table",
+           call. = FALSE)
+    }
+
     resolved <- tidyselect::vars_select(var_names, !!!rlang::syms(resolved))
     resolved <- which(var_names %in% resolved)
 
   } else if (is_quosures(resolved)) {
 
-    resolved <- vapply(resolved, function(x) as.character(quo_get_expr(x)), character(1))
+    resolved <-
+      vapply(resolved, function(x) as.character(quo_get_expr(x)), character(1))
+
+    if (!all(resolved %in% var_names)) {
+      stop("One or more column names provided not available in the table",
+           call. = FALSE)
+    }
+
     resolved <- tidyselect::vars_select(var_names, !!!rlang::syms(resolved))
     resolved <- which(var_names %in% resolved)
   }

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -225,6 +225,9 @@ tab_row_group <- function(data,
 #' @inheritParams fmt_number
 #' @param label the text to use for the spanner column label.
 #' @param columns the columns to be components of the spanner heading.
+#' @param gather an option to move the specified \code{columns} such that they
+#'   are unified under the spanner column label. Ordering of the
+#'   moved-into-place columns will be preserved in all cases.
 #' @return an object of class \code{gt_tbl}.
 #' @examples
 #' # Use `gtcars` to create a gt table;

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -280,6 +280,54 @@ tab_spanner <- function(data,
   # Set the `grp_labels` attr with the `grp_labels` object
   attr(data, "grp_labels") <- grp_labels
 
+  # Gather columns not part of the group of columns under
+  # the spanner heading
+  if (gather) {
+
+    # Extract the internal `boxh_df` table
+    boxh_df <- attr(data, "boxh_df", exact = TRUE)
+
+    # Get the sequence of columns available in `boxh_df`
+    all_columns <- colnames(boxh_df)
+
+    # Get the vector positions of the `columns` in
+    # `all_columns`
+    matching_vec <- match(columns, all_columns) %>% sort()
+
+    # Reassign `columns` as a sorted vector of columns
+    columns <- all_columns[matching_vec]
+
+    # Gather columns if there are gaps between index positions
+    if (length(which(diff(matching_vec) != 1)) != 0) {
+
+      # Determine the name of the column in `columns` that is
+      # in the rightmost position in the main group
+      last_column <-
+        columns[which(diff(matching_vec) != 1)][1]
+
+      # Determine which column in `columns` is the first to
+      # be separated from the main group
+      separated_start <- (which(diff(matching_vec) != 1) + 1)[1]
+
+      for (i in separated_start:length(seq(columns))) {
+
+        # Perform a single-column move (separated column
+        # moving to the right of the right-most column
+        # in the main group)
+        data <-
+          data %>%
+          cols_move(
+            columns = columns[i],
+            after = last_column
+          )
+
+        # Reassign the `last_column` as the column moved
+        # into the main group
+        last_column <- columns[i]
+      }
+    }
+  }
+
   data
 }
 

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -253,7 +253,8 @@ tab_row_group <- function(data,
 #' @export
 tab_spanner <- function(data,
                         label,
-                        columns) {
+                        columns,
+                        gather = TRUE) {
   checkmate::assert_character(
     label, len = 1, any.missing = FALSE, null.ok = FALSE)
 

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -301,7 +301,17 @@ tab_spanner <- function(data,
 
     # Get the vector positions of the `columns` in
     # `all_columns`
-    matching_vec <- match(resolved_columns, all_columns) %>% sort()
+    matching_vec <-
+      match(resolved_columns, all_columns) %>%
+      sort() %>%
+      unique()
+
+    # Issue a warning if duplicate values were given
+    # in resolved columns
+    if (any(duplicated(resolved_columns))) {
+      warning("Duplicate column names should not be provided in `columns`.",
+              call. = FALSE)
+    }
 
     # Get a vector of column names
     columns_sorted <- all_columns[matching_vec]

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -261,17 +261,18 @@ tab_spanner <- function(data,
   checkmate::assert_character(
     label, len = 1, any.missing = FALSE, null.ok = FALSE)
 
+  # TODO: The five statements below will become refactored
+  # in a later PR (the `resolve-quosures` branch has improvements
+  # and helper functions for resolving); we will also handle the
+  # case of duplicate columns within that PR
   data_df <- as.data.frame(data)
   colnames <- colnames(data_df)
-
   columns <- enquo(columns)
-
   resolved_columns <-
     resolve_vars(var_expr = columns, var_names = colnames, data_df = data_df)
-
-  # Translate the column indices to column names
   resolved_columns <- colnames[resolved_columns]
 
+  # Get the `grp_labels` list from `data`
   grp_labels <- attr(data, "grp_labels", exact = TRUE)
 
   # Apply the `label` value to the relevant components

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -306,13 +306,6 @@ tab_spanner <- function(data,
       sort() %>%
       unique()
 
-    # Issue a warning if duplicate values were given
-    # in resolved columns
-    if (any(duplicated(resolved_columns))) {
-      warning("Duplicate column names should not be provided in `columns`.",
-              call. = FALSE)
-    }
-
     # Get a vector of column names
     columns_sorted <- all_columns[matching_vec]
 

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -282,9 +282,9 @@ tab_spanner <- function(data,
 
   grp_labels <- attr(data, "grp_labels", exact = TRUE)
 
-  for (i in seq(resolved_columns)) {
-    grp_labels[[resolved_columns[i]]] <- label
-  }
+  # Apply the `label` value to the relevant components
+  # of the `grp_labels` list
+  grp_labels[resolved_columns] <- label
 
   # Set the `grp_labels` attr with the `grp_labels` object
   attr(data, "grp_labels") <- grp_labels

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -272,14 +272,6 @@ tab_spanner <- function(data,
   # Translate the column indices to column names
   resolved_columns <- colnames[resolved_columns]
 
-  # Filter the vector of column names by the
-  # column names actually in `input_df`
-  resolved_columns <- resolved_columns[which(resolved_columns %in% colnames)]
-
-  if (length(resolved_columns) == 0) {
-    return(data)
-  }
-
   grp_labels <- attr(data, "grp_labels", exact = TRUE)
 
   # Apply the `label` value to the relevant components

--- a/R/table_parts.R
+++ b/R/table_parts.R
@@ -291,7 +291,7 @@ tab_spanner <- function(data,
 
   # Gather columns not part of the group of columns under
   # the spanner heading
-  if (gather) {
+  if (gather && length(resolved_columns) > 1) {
 
     # Extract the internal `boxh_df` table
     boxh_df <- attr(data, "boxh_df", exact = TRUE)
@@ -303,38 +303,16 @@ tab_spanner <- function(data,
     # `all_columns`
     matching_vec <- match(resolved_columns, all_columns) %>% sort()
 
-    # Reassign `columns` as a sorted vector of columns
-    columns <- all_columns[matching_vec]
+    # Get a vector of column names
+    columns_sorted <- all_columns[matching_vec]
 
-    # Gather columns if there are gaps between index positions
-    if (length(which(diff(matching_vec) != 1)) != 0) {
-
-      # Determine the name of the column in `columns` that is
-      # in the rightmost position in the main group
-      last_column <-
-        columns[which(diff(matching_vec) != 1)][1]
-
-      # Determine which column in `columns` is the first to
-      # be separated from the main group
-      separated_start <- (which(diff(matching_vec) != 1) + 1)[1]
-
-      for (i in separated_start:length(seq(columns))) {
-
-        # Perform a single-column move (separated column
-        # moving to the right of the right-most column
-        # in the main group)
-        data <-
-          data %>%
-          cols_move(
-            columns = columns[i],
-            after = last_column
-          )
-
-        # Reassign the `last_column` as the column moved
-        # into the main group
-        last_column <- columns[i]
-      }
-    }
+    # Move columns into place
+    data <-
+      data %>%
+      cols_move(
+        columns = columns_sorted[-1],
+        after = columns_sorted[1]
+      )
   }
 
   data

--- a/man/tab_spanner.Rd
+++ b/man/tab_spanner.Rd
@@ -4,7 +4,7 @@
 \alias{tab_spanner}
 \title{Add a spanner column label}
 \usage{
-tab_spanner(data, label, columns)
+tab_spanner(data, label, columns, gather = TRUE)
 }
 \arguments{
 \item{data}{a table object that is created using the \code{\link{gt}()}
@@ -13,6 +13,10 @@ function.}
 \item{label}{the text to use for the spanner column label.}
 
 \item{columns}{the columns to be components of the spanner heading.}
+
+\item{gather}{an option to move the specified \code{columns} such that they
+are unified under the spanner column label. Ordering of the
+moved-into-place columns will be preserved in all cases.}
 }
 \value{
 an object of class \code{gt_tbl}.

--- a/tests/testthat/test-l_table_parts.R
+++ b/tests/testthat/test-l_table_parts.R
@@ -102,25 +102,14 @@ test_that("a gt table contains the expected column spanner labels", {
       as_latex() %>% as.character()) %>%
     expect_true()
 
-  # Create a `tbl_latex` object with `gt()`; this table
-  # contains the spanner heading `perimeter` over the
-  # `peris` and `shapes` column labels (which don't exist)
-  tbl_latex <-
+  # Expect an error when using column labels
+  # that don't exist
+  expect_error(
     gt(data = rock) %>%
     tab_spanner(
       label = "perimeter",
       columns = vars(peris, shapes))
-
-  # Expect a characteristic pattern
-  grepl(
-    paste0(
-      ".*.toprule",
-      ".*area & peri & shape & perm ",
-      ".*"),
-    tbl_latex %>%
-      as_latex() %>% as.character()) %>%
-    expect_true()
-
+  )
 })
 
 test_that("a gt table contains the expected source note", {

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -143,22 +143,14 @@ test_that("a gt table contains the expected spanner column labels", {
     selection_text("[class='gt_col_heading gt_column_spanner gt_center']") %>%
     expect_equal("perimeter")
 
-  # Create a `gt_tbl` object with `gt()`; this table
-  # contains the spanner heading `perimeter` over the
-  # `peris` and `shapes` column labels (which don't exist)
-  tbl_html <-
+  # Expect an error when using column labels
+  # that don't exist
+  expect_error(
     gt(data = rock) %>%
-    tab_spanner(
-      label = "perimeter",
-      columns = vars(peris, shapes)) %>%
-    render_as_html() %>%
-    xml2::read_html()
-
-  # Expect that the content in the column headings only includes
-  # the column labels
-  tbl_html %>%
-    selection_text("[class='gt_col_heading gt_right']") %>%
-    expect_equal(c("area", "peri", "shape", "perm"))
+      tab_spanner(
+        label = "perimeter",
+        columns = vars(peris, shapes))
+  )
 })
 
 test_that("a gt table contains the expected source note", {


### PR DESCRIPTION
Currently, `tab_spanner()` will not move columns to create a contiguous block of columns under a spanner heading. While this is acceptable when you want a repeating spanner column label across the top of the column labels, it's likely not the most common use case. 

This change adds a `gather` argument that's set to `TRUE`. This makes it convenient for automatically gathering the columns that are part of a single spanner column label. Before the change, the user would have to carefully ensure the columns are contiguous before entry in `gt()`, or, would need to use some of the `cols_move*()` functions for manual movement of columns.

Here is an example where columns are automatically moved under the spanner column label

```r
gtcars %>%
  dplyr::select(
    -mfr, -trim, bdy_style, drivetrain,
    -drivetrain, -trsmn, -ctry_origin
  ) %>%
  dplyr::slice(1:8) %>%
  gt(rowname_col = "model") %>%
  tab_header(title = "gtcars") %>%
  tab_spanner(
    label = "performance",
    columns = vars(
      hp, hp_rpm, trq, trq_rpm,
      mpg_c, mpg_h)
  ) %>%
  tab_spanner(
    label = "model info",
    columns = vars(
      bdy_style, year, msrp)
  )
```

and this yields the following **gt** output table:

<img width="792" alt="tab_spanner_arrange" src="https://user-images.githubusercontent.com/5612024/51266229-4a9fb680-1980-11e9-9e6a-588bc44c7b45.png">

The key thing to note here is that the `msrp` column in the second `tab_spanner()` call is separated from the `bdy_style` and `year` set of columns. The function now recognizes these gaps and moves columns together whilst preserving the ordering of columns in the group. 

Fixes https://github.com/rstudio/gt/issues/110.
Fixes https://github.com/rstudio/gt/issues/127.
Fixes https://github.com/rstudio/gt/issues/102.