### PR TITLE
Bugfix: fmt_scientific() didn't show exp value for small numbers.

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -264,7 +264,7 @@ fmt_scientific <- function(data,
       small_pos <-
         ((x >= 1 & x < 10) |
            (x <= -1 & x > -10) |
-           is_equal_to(x, 0)) & !is.na(x)
+           is_equal_to(as.numeric(split_scientific_notn(formatC(x,format = "e"))$num),0)) & !is.na(x)
 
       # Create `x_str` with same length as `x`
       x_str <- rep(NA_character_, length(x))

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -264,7 +264,7 @@ fmt_scientific <- function(data,
       small_pos <-
         ((x >= 1 & x < 10) |
            (x <= -1 & x > -10) |
-           is_equal_to(as.numeric(split_scientific_notn(formatC(x,format = "e"))$num),0)) & !is.na(x)
+           is_equal_to(x, 0)) & !is.na(x)
 
       # Create `x_str` with same length as `x`
       x_str <- rep(NA_character_, length(x))

--- a/R/utils.R
+++ b/R/utils.R
@@ -565,7 +565,7 @@ inline_html_styles <- function(html, css_tbl) {
 }
 
 is_equal_to <- function(x, y) {
-  vapply(x, function(a, b) isTRUE(all.equal(a, b)), logical(1), y)
+  vapply(x, function(a, b) isTRUE(identical(a, b)), logical(1), y)
 }
 
 split_scientific_notn <- function(x_str) {


### PR DESCRIPTION
Here is an example:

```{r}
library("gt")
data <- data.frame(sci=c(0.000137036,3.23166e-94,0,273669))
data %>% gt() %>% fmt_scientific(columns=vars("sci"),decimals = 2)
```

Before fixing, it showed as 3.23 for 3.23e-94.

![image](https://user-images.githubusercontent.com/107597/51358062-a8f1a400-1afc-11e9-8902-6a7f689dad46.png)

