### PR TITLE
Refactor code related to the `suffixing` feature of `fmt_number()` and `fmt_currency()`

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -157,7 +157,7 @@ fmt_number <- function(data,
   }
 
   # Get the `suffixing_inputs`
-  suffixing_inputs <- get_suffixing_inputs(suffixing)
+  suffixing_inputs <- normalize_suffixing_inputs(suffixing)
 
   # If choosing to perform large-number suffixing
   # of numeric values, force `scale_by` to be 1.0
@@ -758,7 +758,7 @@ fmt_currency <- function(data,
   }
 
   # Get the `suffixing_inputs`
-  suffixing_inputs <- get_suffixing_inputs(suffixing)
+  suffixing_inputs <- normalize_suffixing_inputs(suffixing)
 
   # If choosing to perform large-number suffixing
   # of numeric values, force `scale_by` to be 1.0

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -189,17 +189,21 @@ fmt_number <- function(data,
           # Determine which of `x` are not NA
           non_na_x <- !is.na(x)
 
+          # Create a tibble with scaled values for
+          # `x[non_na_x]` and the suffix labels to
+          # use for character formatting
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
               suffixes = suffix_labels
             )
 
-          # Get local variables `scale_by` and `suffixes`
+          # If choosing to perform large-number suffixing
+          # of numeric values, replace `scale_by` with
+          # a vector of scaling values (of equal length
+          # with `x[non_na_x]`)
           if (!is.null(suffix_labels)) {
-
             scale_by <- suffix_df$scale_by[non_na_x]
-            suffixes <- suffix_df$suffix[non_na_x]
           }
 
           # Create `x_str` with same length as `x`
@@ -222,7 +226,7 @@ fmt_number <- function(data,
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
-              paste0(x_str[non_na_x], suffixes)
+              paste0(x_str[non_na_x], suffix_df$suffix[non_na_x])
           }
 
           # Handle negative values
@@ -798,17 +802,21 @@ fmt_currency <- function(data,
           # Create `x_str` with same length as `x`
           x_str <- rep(NA_character_, length(x))
 
+          # Create a tibble with scaled values for
+          # `x[non_na_x]` and the suffix labels to
+          # use for character formatting
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
               suffixes = suffix_labels
             )
 
-          # Get local variables `scale_by` and `suffixes`
+          # If choosing to perform large-number suffixing
+          # of numeric values, replace `scale_by` with
+          # a vector of scaling values (of equal length
+          # with `x[non_na_x]`)
           if (!is.null(suffix_labels)) {
-
             scale_by <- suffix_df$scale_by[non_na_x]
-            suffixes <- suffix_df$suffix[non_na_x]
           }
 
           # Format all non-NA x values
@@ -828,7 +836,7 @@ fmt_currency <- function(data,
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
-              paste0(x_str[non_na_x], suffixes)
+              paste0(x_str[non_na_x], suffix_df$suffix[non_na_x])
           }
 
           # Handle placement of the currency symbol
@@ -873,17 +881,21 @@ fmt_currency <- function(data,
           # Create `x_str` with same length as `x`
           x_str <- rep(NA_character_, length(x))
 
+          # Create a tibble with scaled values for
+          # `x[non_na_x]` and the suffix labels to
+          # use for character formatting
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
               suffixes = suffix_labels
             )
 
-          # Get local variables `scale_by` and `suffixes`
+          # If choosing to perform large-number suffixing
+          # of numeric values, replace `scale_by` with
+          # a vector of scaling values (of equal length
+          # with `x[non_na_x]`)
           if (!is.null(suffix_labels)) {
-
             scale_by <- suffix_df$scale_by[non_na_x]
-            suffixes <- suffix_df$suffix[non_na_x]
           }
 
           # Format all non-NA x values
@@ -903,7 +915,7 @@ fmt_currency <- function(data,
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
-              paste0(x_str[non_na_x], suffixes)
+              paste0(x_str[non_na_x], suffix_df$suffix[non_na_x])
           }
 
           # Handle placement of the currency symbol
@@ -948,17 +960,21 @@ fmt_currency <- function(data,
           # Create `x_str` with same length as `x`
           x_str <- rep(NA_character_, length(x))
 
+          # Create a tibble with scaled values for
+          # `x[non_na_x]` and the suffix labels to
+          # use for character formatting
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
               suffixes = suffix_labels
             )
 
-          # Get local variables `scale_by` and `suffixes`
+          # If choosing to perform large-number suffixing
+          # of numeric values, replace `scale_by` with
+          # a vector of scaling values (of equal length
+          # with `x[non_na_x]`)
           if (!is.null(suffix_labels)) {
-
             scale_by <- suffix_df$scale_by[non_na_x]
-            suffixes <- suffix_df$suffix[non_na_x]
           }
 
           # Format all non-NA x values
@@ -978,7 +994,7 @@ fmt_currency <- function(data,
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
-              paste0(x_str[non_na_x], suffixes)
+              paste0(x_str[non_na_x], suffix_df$suffix[non_na_x])
           }
 
           # Handle placement of the currency symbol

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -156,12 +156,14 @@ fmt_number <- function(data,
     sep_mark <- ""
   }
 
-  # Get the `suffixing_inputs`
-  suffixing_inputs <- normalize_suffixing_inputs(suffixing)
+  # Normalize the `suffixing` input to either return a
+  # character vector of suffix labels, or NULL (the
+  # case where `suffixing` is FALSE)
+  suffix_labels <- normalize_suffixing_inputs(suffixing)
 
   # If choosing to perform large-number suffixing
   # of numeric values, force `scale_by` to be 1.0
-  if (!is.null(suffixing_inputs)) {
+  if (!is.null(suffix_labels)) {
 
     if (!missing(scale_by) && !identical(scale_by, 1.0)) {
       warning("The value for `scale_by` can't be changed if `suffixing` is ",
@@ -190,11 +192,11 @@ fmt_number <- function(data,
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
-              suffixes = suffixing_inputs
+              suffixes = suffix_labels
             )
 
           # Get local variables `scale_by` and `suffixes`
-          if (!is.null(suffixing_inputs)) {
+          if (!is.null(suffix_labels)) {
 
             scale_by <- suffix_df$scale_by[non_na_x]
             suffixes <- suffix_df$suffix[non_na_x]
@@ -216,7 +218,7 @@ fmt_number <- function(data,
 
           # Apply large-number suffixes to scaled and
           # formatted values if that option is taken
-          if (!is.null(suffixing_inputs)) {
+          if (!is.null(suffix_labels)) {
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
@@ -757,12 +759,14 @@ fmt_currency <- function(data,
     sep_mark <- ""
   }
 
-  # Get the `suffixing_inputs`
-  suffixing_inputs <- normalize_suffixing_inputs(suffixing)
+  # Normalize the `suffixing` input to either return a
+  # character vector of suffix labels, or NULL (the
+  # case where `suffixing` is FALSE)
+  suffix_labels <- normalize_suffixing_inputs(suffixing)
 
   # If choosing to perform large-number suffixing
   # of numeric values, force `scale_by` to be 1.0
-  if (!is.null(suffixing_inputs)) {
+  if (!is.null(suffix_labels)) {
 
     if (!missing(scale_by) && !identical(scale_by, 1.0)) {
       warning("The value for `scale_by` can't be changed if `suffixing` is ",
@@ -797,11 +801,11 @@ fmt_currency <- function(data,
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
-              suffixes = suffixing_inputs
+              suffixes = suffix_labels
             )
 
           # Get local variables `scale_by` and `suffixes`
-          if (!is.null(suffixing_inputs)) {
+          if (!is.null(suffix_labels)) {
 
             scale_by <- suffix_df$scale_by[non_na_x]
             suffixes <- suffix_df$suffix[non_na_x]
@@ -820,7 +824,7 @@ fmt_currency <- function(data,
 
           # Apply large-number suffixes to scaled and
           # formatted values if that option is taken
-          if (!is.null(suffixing_inputs)) {
+          if (!is.null(suffix_labels)) {
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
@@ -872,11 +876,11 @@ fmt_currency <- function(data,
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
-              suffixes = suffixing_inputs
+              suffixes = suffix_labels
             )
 
           # Get local variables `scale_by` and `suffixes`
-          if (!is.null(suffixing_inputs)) {
+          if (!is.null(suffix_labels)) {
 
             scale_by <- suffix_df$scale_by[non_na_x]
             suffixes <- suffix_df$suffix[non_na_x]
@@ -895,7 +899,7 @@ fmt_currency <- function(data,
 
           # Apply large-number suffixes to scaled and
           # formatted values if that option is taken
-          if (!is.null(suffixing_inputs)) {
+          if (!is.null(suffix_labels)) {
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
@@ -947,11 +951,11 @@ fmt_currency <- function(data,
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
-              suffixes = suffixing_inputs
+              suffixes = suffix_labels
             )
 
           # Get local variables `scale_by` and `suffixes`
-          if (!is.null(suffixing_inputs)) {
+          if (!is.null(suffix_labels)) {
 
             scale_by <- suffix_df$scale_by[non_na_x]
             suffixes <- suffix_df$suffix[non_na_x]
@@ -970,7 +974,7 @@ fmt_currency <- function(data,
 
           # Apply large-number suffixes to scaled and
           # formatted values if that option is taken
-          if (!is.null(suffixing_inputs)) {
+          if (!is.null(suffix_labels)) {
 
             # Apply vector of suffixes
             x_str[non_na_x] <-

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -161,7 +161,7 @@ fmt_number <- function(data,
 
   # If choosing to perform large-number suffixing
   # of numeric values, force `scale_by` to be 1.0
-  if (!is.null(suffixing_inputs$num_suffixes)) {
+  if (!is.null(suffixing_inputs)) {
 
     if (!missing(scale_by) && !identical(scale_by, 1.0)) {
       warning("The value for `scale_by` can't be changed if `suffixing` is ",
@@ -190,11 +190,11 @@ fmt_number <- function(data,
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
-              suffixes = suffixing_inputs$num_suffixes
+              suffixes = suffixing_inputs
             )
 
           # Get local variables `scale_by` and `suffixes`
-          if (!is.null(suffixing_inputs$num_suffixes)) {
+          if (!is.null(suffixing_inputs)) {
 
             scale_by <- suffix_df$scale_by[non_na_x]
             suffixes <- suffix_df$suffix[non_na_x]
@@ -216,7 +216,7 @@ fmt_number <- function(data,
 
           # Apply large-number suffixes to scaled and
           # formatted values if that option is taken
-          if (!is.null(suffixing_inputs$num_suffixes)) {
+          if (!is.null(suffixing_inputs)) {
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
@@ -762,7 +762,7 @@ fmt_currency <- function(data,
 
   # If choosing to perform large-number suffixing
   # of numeric values, force `scale_by` to be 1.0
-  if (!is.null(suffixing_inputs$num_suffixes)) {
+  if (!is.null(suffixing_inputs)) {
 
     if (!missing(scale_by) && !identical(scale_by, 1.0)) {
       warning("The value for `scale_by` can't be changed if `suffixing` is ",
@@ -797,11 +797,11 @@ fmt_currency <- function(data,
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
-              suffixes = suffixing_inputs$num_suffixes
+              suffixes = suffixing_inputs
             )
 
           # Get local variables `scale_by` and `suffixes`
-          if (!is.null(suffixing_inputs$num_suffixes)) {
+          if (!is.null(suffixing_inputs)) {
 
             scale_by <- suffix_df$scale_by[non_na_x]
             suffixes <- suffix_df$suffix[non_na_x]
@@ -820,7 +820,7 @@ fmt_currency <- function(data,
 
           # Apply large-number suffixes to scaled and
           # formatted values if that option is taken
-          if (!is.null(suffixing_inputs$num_suffixes)) {
+          if (!is.null(suffixing_inputs)) {
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
@@ -872,11 +872,11 @@ fmt_currency <- function(data,
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
-              suffixes = suffixing_inputs$num_suffixes
+              suffixes = suffixing_inputs
             )
 
           # Get local variables `scale_by` and `suffixes`
-          if (!is.null(suffixing_inputs$num_suffixes)) {
+          if (!is.null(suffixing_inputs)) {
 
             scale_by <- suffix_df$scale_by[non_na_x]
             suffixes <- suffix_df$suffix[non_na_x]
@@ -895,7 +895,7 @@ fmt_currency <- function(data,
 
           # Apply large-number suffixes to scaled and
           # formatted values if that option is taken
-          if (!is.null(suffixing_inputs$num_suffixes)) {
+          if (!is.null(suffixing_inputs)) {
 
             # Apply vector of suffixes
             x_str[non_na_x] <-
@@ -947,11 +947,11 @@ fmt_currency <- function(data,
           suffix_df <-
             num_suffix(
               x = round(x[non_na_x], decimals),
-              suffixes = suffixing_inputs$num_suffixes
+              suffixes = suffixing_inputs
             )
 
           # Get local variables `scale_by` and `suffixes`
-          if (!is.null(suffixing_inputs$num_suffixes)) {
+          if (!is.null(suffixing_inputs)) {
 
             scale_by <- suffix_df$scale_by[non_na_x]
             suffixes <- suffix_df$suffix[non_na_x]
@@ -970,7 +970,7 @@ fmt_currency <- function(data,
 
           # Apply large-number suffixes to scaled and
           # formatted values if that option is taken
-          if (!is.null(suffixing_inputs$num_suffixes)) {
+          if (!is.null(suffixing_inputs)) {
 
             # Apply vector of suffixes
             x_str[non_na_x] <-

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -60,15 +60,15 @@
 #'   this transformation and \code{TRUE} will apply thousands (\code{K}),
 #'   millions (\code{M}), billions (\code{B}), and trillions (\code{T}) suffixes
 #'   after automatic value scaling. We can also specify which symbols to use for
-#'   each of the value ranges by using a 4-element character vector of preferred
+#'   each of the value ranges by using a character vector of the preferred
 #'   symbols to replace the defaults (e.g., \code{c("k", "Ml", "Bn", "Tr")}).
-#'   Including NA values in the vector will ensure that the particular range
-#'   will either not be included in the transformation (e.g, \code{c(NA, "M",
-#'   "B", "T")} won't modify numbers in the thousands range) or the range will
-#'   inherit a previous suffix (e.g., with \code{c("K", "M", "B", NA)}, all
-#'   numbers above one billion will be in terms of billions). Any use of
-#'   \code{suffixing} (where not \code{FALSE}) means that any value provided to
-#'   \code{scale_by} will be ignored.
+#'   Including \code{NA} values in the vector will ensure that the particular
+#'   range will either not be included in the transformation (e.g, \code{c(NA,
+#'   "M", "B", "T")} won't modify numbers in the thousands range) or the range
+#'   will inherit a previous suffix (e.g., with \code{c("K", "M", NA, "T")}, all
+#'   numbers in the range of millions and billions will be in terms of
+#'   millions). Any use of \code{suffixing} (where not \code{FALSE}) means that
+#'   any value provided to \code{scale_by} will be ignored.
 #' @param pattern a formatting pattern that allows for decoration of the
 #'   formatted value. The value itself is represented by \code{{x}} and all
 #'   other characters are taken to be string literals.

--- a/R/utils.R
+++ b/R/utils.R
@@ -496,7 +496,7 @@ is_false = function(x) {
 # character vector which is later appended to scaled
 # numerical values; the input can either be a single
 # logical value or a character vector
-get_suffixing_inputs <- function(suffixing) {
+normalize_suffixing_inputs <- function(suffixing) {
 
   # Determine whether large-number suffixing is being
   # used and set the appropriate inputs

--- a/R/utils.R
+++ b/R/utils.R
@@ -498,47 +498,47 @@ is_false = function(x) {
 # logical value or a character vector
 normalize_suffixing_inputs <- function(suffixing) {
 
-  # Determine whether large-number suffixing is being
-  # used and set the appropriate inputs
-  if (isTRUE(suffixing)) {
+  if (is_false(suffixing)) {
 
-    # If `suffixing` is TRUE, the `num_suffixes`
-    # logical will also be set to TRUE and the
-    # default set of symbols will be assigned
-    # to `num_suffixes`
-    num_suffixes <- c("K", "M", "B", "T")
+    # If `suffixing` is FALSE, then return `NULL`;
+    # this will be used to signal there is nothing
+    # to be done in terms of scaling/suffixing
+    return(NULL)
 
-  } else if (is_x_false(suffixing)) {
+  } else if (isTRUE(suffixing)) {
 
-    # If `suffixing` is FALSE, the `num_suffixes`
-    # will also given as NULL
-    num_suffixes <- NULL
+    # If `suffixing` is TRUE, return the default
+    # set of suffixes
+    return(c("K", "M", "B", "T"))
 
-  } else if (is.character(suffixing)){
+  } else if (is.character(suffixing)) {
 
-    # Stop function if the character vector `suffixing`
-    # contains any names
+    # In the case that a character vector is provided
+    # to `suffixing`, we first want to check if there
+    # are any names provided
+
+    # TODO: found that the conditional below seems
+    # better than other solutions to determine whether
+    # the vector is even partially named
     if (!is.null(names(suffixing))) {
       stop("The character vector supplied to `suffixed` cannot contain names.",
            call. = FALSE)
     }
 
-    # In the case of a character vector, we copy
-    # those values into `num_suffixes`
-    num_suffixes <- suffixing
+    # We can now return the character vector, having
+    # adequately tested for improper cases
+    return(suffixing)
 
   } else {
 
-    # Stop function if the input to `suffixing` isn't valid
+    # Stop function if the input to `suffixing` isn't
+    # valid (i.e., isn't logical and isn't a valid
+    # character vector)
     stop("The value provided to `suffixing` must either be:\n",
          " * `TRUE` or `FALSE` (the default)\n",
          " * a character vector with suffixing labels",
          call. = FALSE)
   }
-
-  list(
-    num_suffixes = num_suffixes
-  )
 }
 
 # Derive a label based on a formula or a function name

--- a/R/utils.R
+++ b/R/utils.R
@@ -498,7 +498,10 @@ is_x_false = function(x) {
   }
 }
 
-# Get large-number suffixing inputs
+# This function normalizes the `suffixing` input to a
+# character vector which is later appended to scaled
+# numerical values; the input can either be a single
+# logical value or a character vector
 get_suffixing_inputs <- function(suffixing) {
 
   # Determine whether large-number suffixing is being

--- a/R/utils.R
+++ b/R/utils.R
@@ -484,18 +484,12 @@ num_suffix <- function(x, suffixes = c("K", "M", "B", "T"), base = 1000) {
   )
 }
 
-# Create an `isFALSE` helper function that
-# works with earlier versions of R
-is_x_false = function(x) {
+# Create an `isFALSE`-based helper function that
+# works with earlier versions of R (the `isFALSE()`
+# function was introduced in R 3.5.0)
+is_false = function(x) {
 
-  if (getRversion() >= 3.5) {
-
-    isFALSE(x)
-
-  } else {
-
-    is.logical(x) && length(x) == 1L && !is.na(x) && !x
-  }
+  is.logical(x) && length(x) == 1L && !is.na(x) && !x
 }
 
 # This function normalizes the `suffixing` input to a

--- a/man/fmt_currency.Rd
+++ b/man/fmt_currency.Rd
@@ -63,15 +63,15 @@ accept a logical value, where \code{FALSE} (the default) will not perform
 this transformation and \code{TRUE} will apply thousands (\code{K}),
 millions (\code{M}), billions (\code{B}), and trillions (\code{T}) suffixes
 after automatic value scaling. We can also specify which symbols to use for
-each of the value ranges by using a 4-element character vector of preferred
+each of the value ranges by using a character vector of the preferred
 symbols to replace the defaults (e.g., \code{c("k", "Ml", "Bn", "Tr")}).
-Including NA values in the vector will ensure that the particular range
-will either not be included in the transformation (e.g, \code{c(NA, "M",
-"B", "T")} won't modify numbers in the thousands range) or the range will
-inherit a previous suffix (e.g., with \code{c("K", "M", "B", NA)}, all
-numbers above one billion will be in terms of billions). Any use of
-\code{suffixing} (where not \code{FALSE}) means that any value provided to
-\code{scale_by} will be ignored.}
+Including \code{NA} values in the vector will ensure that the particular
+range will either not be included in the transformation (e.g, \code{c(NA,
+"M", "B", "T")} won't modify numbers in the thousands range) or the range
+will inherit a previous suffix (e.g., with \code{c("K", "M", NA, "T")}, all
+numbers in the range of millions and billions will be in terms of
+millions). Any use of \code{suffixing} (where not \code{FALSE}) means that
+any value provided to \code{scale_by} will be ignored.}
 
 \item{pattern}{a formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -51,15 +51,15 @@ accept a logical value, where \code{FALSE} (the default) will not perform
 this transformation and \code{TRUE} will apply thousands (\code{K}),
 millions (\code{M}), billions (\code{B}), and trillions (\code{T}) suffixes
 after automatic value scaling. We can also specify which symbols to use for
-each of the value ranges by using a 4-element character vector of preferred
+each of the value ranges by using a character vector of the preferred
 symbols to replace the defaults (e.g., \code{c("k", "Ml", "Bn", "Tr")}).
-Including NA values in the vector will ensure that the particular range
-will either not be included in the transformation (e.g, \code{c(NA, "M",
-"B", "T")} won't modify numbers in the thousands range) or the range will
-inherit a previous suffix (e.g., with \code{c("K", "M", "B", NA)}, all
-numbers above one billion will be in terms of billions). Any use of
-\code{suffixing} (where not \code{FALSE}) means that any value provided to
-\code{scale_by} will be ignored.}
+Including \code{NA} values in the vector will ensure that the particular
+range will either not be included in the transformation (e.g, \code{c(NA,
+"M", "B", "T")} won't modify numbers in the thousands range) or the range
+will inherit a previous suffix (e.g., with \code{c("K", "M", NA, "T")}, all
+numbers in the range of millions and billions will be in terms of
+millions). Any use of \code{suffixing} (where not \code{FALSE}) means that
+any value provided to \code{scale_by} will be ignored.}
 
 \item{pattern}{a formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all


### PR DESCRIPTION
This PR is meant for refactoring code relating to the scaling/suffixing of larger numbers. Two formatter functions (`fmt_number()` and `fmt_currency()`) have the `suffixing` argument that allows for this.