### PR TITLE
Improvements to documentation for the `info_paletteer()` function

### DIFF
--- a/R/info_tables.R
+++ b/R/info_tables.R
@@ -226,7 +226,7 @@ info_currencies <- function(type = c("code", "symbol"),
   }
 }
 
-#' View a table with info on many different color palettes
+#' View a table with info on color palettes
 #'
 #' While the \code{\link{data_color}()} function allows us to flexibly color
 #' data cells in our \pkg{gt} table, the harder part of this process is

--- a/R/info_tables.R
+++ b/R/info_tables.R
@@ -245,6 +245,33 @@ info_currencies <- function(type = c("code", "symbol"),
 #' the content of this information table by supplying a vector of such package
 #' names to \code{color_pkgs}.
 #'
+#' Colors from the following color packages (all supported by \pkg{paletteer})
+#' are shown by default with \code{info_paletteer()}:
+#' \itemize{
+#' \item awtools, 5 palettes
+#' \item dichromat, 17 palettes
+#' \item dutchmasters, 6 palettes
+#' \item ggpomological, 2 palettes
+#' \item ggsci, 42 palettes
+#' \item ggthemes, 31 palettes
+#' \item ghibli, 27 palettes
+#' \item grDevices, 1 palette
+#' \item jcolors, 13 palettes
+#' \item LaCroixColoR, 21 palettes
+#' \item NineteenEightyR, 12 palettes
+#' \item nord, 16 palettes
+#' \item ochRe, 16 palettes
+#' \item palettetown, 389 palettes
+#' \item pals, 8 palettes
+#' \item Polychrome, 7 palettes
+#' \item quickpalette, 17 palettes
+#' \item rcartocolor, 34 palettes
+#' \item RColorBrewer, 35 palettes
+#' \item Redmonder, 41 palettes
+#' \item wesanderson, 19 palettes
+#' \item yarrr, 21 palettes
+#' }
+#'
 #' @param color_pkgs a vector of color packages that determines which sets of
 #'   palettes should be displayed in the information table. If this is
 #'   \code{NULL} (the default) then all of the discrete palettes from all of the

--- a/R/info_tables.R
+++ b/R/info_tables.R
@@ -234,7 +234,7 @@ info_currencies <- function(type = c("code", "symbol"),
 #' output. We can make this process much easier in two ways: (1) by using the
 #' \pkg{paletteer} package, which makes a wide range of palettes from various R
 #' packages readily available, and (2) calling the \code{info_paletteer()}
-#' function to give us an information table that serves as quick reference for
+#' function to give us an information table that serves as a quick reference for
 #' all of the discrete color palettes available in \pkg{paletteer}.
 #'
 #' The palettes displayed are organized by package and by palette name. These
@@ -242,8 +242,8 @@ info_currencies <- function(type = c("code", "symbol"),
 #' colors), from the the \code{paletteer::paletteer_d()} function. Once we are
 #' familiar with the names of the color palette packages (e.g.,
 #' \pkg{RColorBrewer}, \pkg{ggthemes}, \pkg{wesanderson}), we can narrow down
-#' the content of this information table by supplying a vector package names to
-#' \code{color_pkgs}.
+#' the content of this information table by supplying a vector of such package
+#' names to \code{color_pkgs}.
 #'
 #' @param color_pkgs a vector of color packages that determines which sets of
 #'   palettes should be displayed in the information table. If this is

--- a/man/info_paletteer.Rd
+++ b/man/info_paletteer.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/info_tables.R
 \name{info_paletteer}
 \alias{info_paletteer}
-\title{View a table with info on many different color palettes}
+\title{View a table with info on color palettes}
 \usage{
 info_paletteer(color_pkgs = NULL)
 }
@@ -19,7 +19,7 @@ discovering and choosing color palettes that are suitable for the table
 output. We can make this process much easier in two ways: (1) by using the
 \pkg{paletteer} package, which makes a wide range of palettes from various R
 packages readily available, and (2) calling the \code{info_paletteer()}
-function to give us an information table that serves as quick reference for
+function to give us an information table that serves as a quick reference for
 all of the discrete color palettes available in \pkg{paletteer}.
 }
 \details{
@@ -28,8 +28,35 @@ values are required when obtaining a palette (as a vector of hexadecimal
 colors), from the the \code{paletteer::paletteer_d()} function. Once we are
 familiar with the names of the color palette packages (e.g.,
 \pkg{RColorBrewer}, \pkg{ggthemes}, \pkg{wesanderson}), we can narrow down
-the content of this information table by supplying a vector package names to
-\code{color_pkgs}.
+the content of this information table by supplying a vector of such package
+names to \code{color_pkgs}.
+
+Colors from the following color packages (all supported by \pkg{paletteer})
+are shown by default with \code{info_paletteer()}:
+\itemize{
+\item awtools, 5 palettes
+\item dichromat, 17 palettes
+\item dutchmasters, 6 palettes
+\item ggpomological, 2 palettes
+\item ggsci, 42 palettes
+\item ggthemes, 31 palettes
+\item ghibli, 27 palettes
+\item grDevices, 1 palette
+\item jcolors, 13 palettes
+\item LaCroixColoR, 21 palettes
+\item NineteenEightyR, 12 palettes
+\item nord, 16 palettes
+\item ochRe, 16 palettes
+\item palettetown, 389 palettes
+\item pals, 8 palettes
+\item Polychrome, 7 palettes
+\item quickpalette, 17 palettes
+\item rcartocolor, 34 palettes
+\item RColorBrewer, 35 palettes
+\item Redmonder, 41 palettes
+\item wesanderson, 19 palettes
+\item yarrr, 21 palettes
+}
 }
 \section{Figures}{
 


### PR DESCRIPTION
This PR makes modifications to the help document for the `info_paletteer()` function, which provides a large table of color palettes that are potentially useful when using the `data_color()` function.

The title is changed here to be more consistent with those of the other `info_*()` functions. There were a few grammatical mistakes in the Description and Details sections that have now been addressed. A listing of color packages (and the count of discrete color palettes) has been added to the Details section.