### PR TITLE
Fix spelling errors within the documentation

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -3,7 +3,7 @@
 #' With numeric values in a \pkg{gt} table, we can perform number-based
 #' formatting so that the targeted values are rendered with a higher
 #' consideration for tabular presentation. Furthermore, there is finer control
-#' over numeric foramtting with the following options:
+#' over numeric formatting with the following options:
 #' \itemize{
 #' \item decimals: choice of the number of decimal places, option to drop
 #' trailing zeros, and a choice of the decimal symbol
@@ -414,9 +414,9 @@ fmt_scientific <- function(data,
 #'
 #' With numeric values in a \pkg{gt} table, we can perform percentage-based
 #' formatting. It is assumed the input numeric values are in a fractional format
-#' since the will be automatically multplied by \code{100} before decorating
-#' with a percent sign. For more control over percentage formatting, we can use
-#' the following options:
+#' since the numbers will be automatically multiplied by \code{100} before
+#' decorating with a percent sign. For more control over percentage formatting,
+#' we can use the following options:
 #' \itemize{
 #' \item percent sign placement: the percent sign can be placed after or
 #' before the values and a space can be inserted between the symbol and the

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -86,7 +86,7 @@ an object of class \code{gt_tbl}.
 With numeric values in a \pkg{gt} table, we can perform number-based
 formatting so that the targeted values are rendered with a higher
 consideration for tabular presentation. Furthermore, there is finer control
-over numeric foramtting with the following options:
+over numeric formatting with the following options:
 \itemize{
 \item decimals: choice of the number of decimal places, option to drop
 trailing zeros, and a choice of the decimal symbol

--- a/man/fmt_percent.Rd
+++ b/man/fmt_percent.Rd
@@ -73,9 +73,9 @@ an object of class \code{gt_tbl}.
 \description{
 With numeric values in a \pkg{gt} table, we can perform percentage-based
 formatting. It is assumed the input numeric values are in a fractional format
-since the will be automatically multplied by \code{100} before decorating
-with a percent sign. For more control over percentage formatting, we can use
-the following options:
+since the numbers will be automatically multiplied by \code{100} before
+decorating with a percent sign. For more control over percentage formatting,
+we can use the following options:
 \itemize{
 \item percent sign placement: the percent sign can be placed after or
 before the values and a space can be inserted between the symbol and the


### PR DESCRIPTION
This addresses two spelling errors in the documentation. They were discovered variously by manual inspection and through use of `devtools::spell_check()`.