### PR TITLE
Fix for `fmt_scientific()` when using very large or small numbers

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -330,7 +330,7 @@ fmt_scientific <- function(data,
       small_pos <-
         ((x >= 1 & x < 10) |
            (x <= -1 & x > -10) |
-           is_equal_to(x, 0)) & !is.na(x)
+           x == 0) & !is.na(x)
 
       # Create `x_str` with same length as `x`
       x_str <- rep(NA_character_, length(x))

--- a/R/utils.R
+++ b/R/utils.R
@@ -751,7 +751,7 @@ inline_html_styles <- function(html, css_tbl) {
 }
 
 is_equal_to <- function(x, y) {
-  vapply(x, function(a, b) isTRUE(all.equal(a, b)), logical(1), y)
+  vapply(x, function(a, b) isTRUE(identical(a, b)), logical(1), y)
 }
 
 split_scientific_notn <- function(x_str) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -750,10 +750,6 @@ inline_html_styles <- function(html, css_tbl) {
   html
 }
 
-is_equal_to <- function(x, y) {
-  vapply(x, function(a, b) isTRUE(identical(a, b)), logical(1), y)
-}
-
 split_scientific_notn <- function(x_str) {
 
   exp_parts <- strsplit(x_str, "e|E")

--- a/tests/testthat/test-fmt_scientific.R
+++ b/tests/testthat/test-fmt_scientific.R
@@ -283,3 +283,59 @@ test_that("the `fmt_scientific()` function works correctly", {
       "2,23", "0,00",
       "-2,32 &times; 10<sup class='gt_super'>1</sup>"))
 })
+
+test_that("`fmt_scientific()` can handle extremely large and small values", {
+
+  # Create an input data frame with very
+  # large and very small numbers (both
+  # positive and negative)
+  data_tbl <-
+    data.frame(
+      num = c(
+        -1.5E200, -1.5E100, -2.5E0, -3.5E-100, -3.5E-200,
+        1.5E-200, 1.5E-100, 2.5E0, 3.5E100, 3.5E200
+      )
+    )
+
+  # Create a `gt_tbl` object with `gt()` and the
+  # `data_tbl` dataset
+  tab <- gt(data = data_tbl)
+
+  # Format the `num` column to 5 decimal places, use all
+  # other defaults; extract values in the default context
+  # and compare to expected values
+  expect_equal(
+    (tab %>%
+       fmt_scientific(columns = "num", decimals = 5) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-1.50000 x 10(200)", "-1.50000 x 10(100)",
+      "-2.50000",
+      "-3.50000 x 10(-100)", "-3.50000 x 10(-200)",
+      "1.50000 x 10(-200)", "1.50000 x 10(-100)",
+      "2.50000",
+      "3.50000 x 10(100)", "3.50000 x 10(200)"
+    )
+  )
+
+  # Format the `num` column to 5 decimal places, use all
+  # other defaults; extract values in the HTML context
+  # and compare to expected values
+  expect_equal(
+    (tab %>%
+       fmt_scientific(columns = "num", decimals = 5) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "-1.50000 &times; 10<sup class='gt_super'>200</sup>",
+      "-1.50000 &times; 10<sup class='gt_super'>100</sup>",
+      "-2.50000",
+      "-3.50000 &times; 10<sup class='gt_super'>-100</sup>",
+      "-3.50000 &times; 10<sup class='gt_super'>-200</sup>",
+      "1.50000 &times; 10<sup class='gt_super'>-200</sup>",
+      "1.50000 &times; 10<sup class='gt_super'>-100</sup>",
+      "2.50000",
+      "3.50000 &times; 10<sup class='gt_super'>100</sup>",
+      "3.50000 &times; 10<sup class='gt_super'>200</sup>"
+    )
+  )
+})


### PR DESCRIPTION
This fix modifies the `is_equal_to()` util function, which now uses an `identical()` comparison (instead of `all.equal()`) between two numbers. This has important implications for the `fmt_scientific()` formatter function because we compare whether a number is equal to zero and apply scientific notation when a number isn't zero (among other conditions not mentioned here).

Very small numbers would erroneously be deemed equal to zero before this change, resulting in incorrect formatting of such numbers in scientific notation.

Now, if we apply scientific notation to these numbers

`-1.5E200`, `-1.5E100`, `-2.5E0`, `-3.5E-100`, `-3.5E-200`, `1.5E-200`, `1.5E-100`, `2.5E0`, `3.5E100`, `3.5E200`

we get (in the default context)

`-1.50000 x 10(200)`, `-1.50000 x 10(100)`, `-2.50000`, `-3.50000 x 10(-100)`, `-3.50000 x 10(-200)`, `1.50000 x 10(-200)`, `1.50000 x 10(-100)`, `2.50000`, `3.50000 x 10(100)`, `3.50000 x 10(200)`

Tests have been added to ensure that very large or small numbers are formatted correctly in scientific notation.
