### PR TITLE
Fix for `cells_group()` and it's use in `tab_style()`

### DIFF
--- a/R/utils_render_footnotes.R
+++ b/R/utils_render_footnotes.R
@@ -133,6 +133,7 @@ resolve_footnotes_styles <- function(output_df,
         by = c("grpname" = "group")
       ) %>%
       dplyr::mutate(rownum = row - 0.1) %>%
+      dplyr::mutate(colnum = 1) %>%
       dplyr::select(-row, -row_end)
 
     # Re-combine `tbl_not_stub_groups`

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -621,19 +621,37 @@ create_body_component_h <- function(row_splits_body,
     if (!is.null(groups_rows_df) &&
         i %in% groups_rows_df$row) {
 
-      # Process "group" rows
+      group_name <-
+        groups_rows_df %>%
+        dplyr::filter(row == i) %>%
+        dplyr::pull(group)
+
+      group_style <-
+        styles_resolved %>%
+        filter(locname == "stub_groups") %>%
+        dplyr::filter(grpname == group_name) %>%
+        dplyr::pull(text)
+
+      # Process `group` rows
       body_rows <-
         c(body_rows,
           paste0(
-            "<tr class='gt_group_heading_row'>\n",
+            "<tr class='gt_group_heading_row'",
+            ">\n",
             "<td colspan='", n_cols, "' ",
             "class='",
             ifelse(
               groups_rows_df[which(groups_rows_df$row %in% i), "group_label"][[1]] == "",
-              "gt_empty_group_heading", "gt_group_heading"), "'>",
+              "gt_empty_group_heading", "gt_group_heading"),
+            "'",
+            ifelse(
+              length(group_style) > 0,
+              paste0(" style='", paste(group_style, collapse = ","), "'"), ""),
+            ">",
             groups_rows_df[which(groups_rows_df$row %in% i), "group_label"][[1]],
             "</td>\n",
-            "</tr>\n"))
+            "</tr>\n")
+        )
     }
 
     if (stub_available) {

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -395,6 +395,13 @@ test_that("a gt table contains custom styles at the correct locations", {
     rvest::html_text() %>%
     expect_equal("gear_carb_cyl")
 
+  # Expect that the `Mazdas` row group label
+  # cell has a red background and white text
+  tbl_html %>%
+    rvest::html_nodes("[style='background-color:red;color:white;']") %>%
+    rvest::html_text() %>%
+    expect_equal("Mazdas")
+
   # Expect that the table title is formatted to the left
   tbl_html %>%
     rvest::html_nodes("[class='gt_heading gt_title gt_font_normal gt_center'][style='text-align:left;']") %>%


### PR DESCRIPTION
This PR addresses a bug where custom styles cannot be applied to stub row labels through `tab_style()` and `cells_group()`. For example, with

```r
exibble %>%
  gt(rowname_col = "row", groupname_col = "group") %>%
  tab_style(
    locations = cells_group(groups = "grp_a"),
    style = cells_styles(text_align = "center", bkgd_color = "lightblue")
  )
```

we would get the error:

```
Error in arrange_impl(.data, dots) : 
  Evaluation error: object 'colnum' not found. 
```

With the changes proposed here, we now get to style row group label cells.

```r
exibble %>%
  gt(rowname_col = "row", groupname_col = "group") %>%
  tab_style(
    locations = cells_group(groups = "grp_a"),
    style = cells_styles(text_align = "center", bkgd_color = "lightblue")
  )
```

<img width="753" alt="fix_row_group_label_style" src="https://user-images.githubusercontent.com/5612024/53097814-52f39000-34f0-11e9-815c-6e540a2b8162.png">

A testthat test was added to verify that custom styles could now be applied to this location.

Fixes  https://github.com/rstudio/gt/issues/182.