### PR TITLE
Fix for `fmt_date()` that allows `Date` columns to work

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -1037,11 +1037,12 @@ fmt_currency <- function(data,
 
 #' Format values as dates
 #'
-#' Format input date values that are character-based and expressed according to
-#' the ISO 8601 date format (\code{YYYY-MM-DD}). Once the appropriate data cells
-#' are targeted with \code{columns} (and, optionally, \code{rows}), we can
-#' simply apply a preset date style (see table in
-#' \code{\link{info_date_style}()} for info) to format the dates.
+#' Format input date values that are either of the \code{Date} type, or, are
+#' character-based and expressed according to the ISO 8601 date format
+#' (\code{YYYY-MM-DD}). Once the appropriate data cells are targeted with
+#' \code{columns} (and, optionally, \code{rows}), we can simply apply a preset
+#' date style (see table in \code{\link{info_date_style}()} for info) to format
+#' the dates.
 #'
 #' The following date styles are available for simpler formatting of ISO dates
 #' (all using the input date of \code{2000-02-29} in the example output dates):

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -1144,6 +1144,12 @@ fmt_date <- function(data,
       fns = list(
         default = function(x) {
 
+          # If `x` is of the `Date` type, simply make
+          # that a character vector
+          if (inherits(x, "Date")) {
+            x <- as.character(x)
+          }
+
           ifelse(grepl("^[0-9]*?\\:[0-9]*?", x), paste("1970-01-01", x), x) %>%
             strftime(format = date_format_str) %>%
             tidy_gsub("^0", "") %>%

--- a/man/fmt_date.Rd
+++ b/man/fmt_date.Rd
@@ -35,11 +35,12 @@ presets.}
 an object of class \code{gt_tbl}.
 }
 \description{
-Format input date values that are character-based and expressed according to
-the ISO 8601 date format (\code{YYYY-MM-DD}). Once the appropriate data cells
-are targeted with \code{columns} (and, optionally, \code{rows}), we can
-simply apply a preset date style (see table in
-\code{\link{info_date_style}()} for info) to format the dates.
+Format input date values that are either of the \code{Date} type, or, are
+character-based and expressed according to the ISO 8601 date format
+(\code{YYYY-MM-DD}). Once the appropriate data cells are targeted with
+\code{columns} (and, optionally, \code{rows}), we can simply apply a preset
+date style (see table in \code{\link{info_date_style}()} for info) to format
+the dates.
 }
 \details{
 The following date styles are available for simpler formatting of ISO dates

--- a/tests/testthat/test-fmt_date_time.R
+++ b/tests/testthat/test-fmt_date_time.R
@@ -8,7 +8,7 @@ test_that("the `fmt_date()` function works correctly", {
     dplyr::tibble(date = c(
       "2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10"))
 
-  # Create a `gt_tbl` object with `gt()` and the
+  # Create a `tab` object with `gt()` and the
   # `data_tbl` dataset
   tab <- gt(data = data_tbl)
 
@@ -36,6 +36,110 @@ test_that("the `fmt_date()` function works correctly", {
   # that does not exist
   expect_error(
     tab %>% fmt_date(columns = "num_1", date_style = 1))
+
+  #
+  # Format `date` in various date formats and verify the output
+  #
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 1) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 2) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("Sunday, October 15, 2017", "Friday, February 22, 2013",
+      "Monday, September 22, 2014", "Wednesday, January 10, 2018"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 3) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("Sun, Oct 15, 2017", "Fri, Feb 22, 2013",
+      "Mon, Sep 22, 2014", "Wed, Jan 10, 2018"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 4) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("Sunday 15 October 2017", "Friday 22 February 2013",
+      "Monday 22 September 2014", "Wednesday 10 January 2018"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 5) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("October 15, 2017", "February 22, 2013",
+      "September 22, 2014", "January 10, 2018"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 6) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("Oct 15, 2017", "Feb 22, 2013",
+      "Sep 22, 2014", "Jan 10, 2018"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 7) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("15 Oct 2017", "22 Feb 2013", "22 Sep 2014", "10 Jan 2018"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 8) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("15 October 2017", "22 February 2013",
+      "22 September 2014", "10 January 2018"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 9) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("15 October", "22 February", "22 September", "10 January"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 10) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("2017", "2013", "2014", "2018"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 11) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("October", "February", "September", "January"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 12) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("15", "22", "22", "10"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 13) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("2017/10/15", "2013/02/22", "2014/09/22", "2018/01/10"))
+
+  expect_equal(
+    (tab %>%
+       fmt_date(columns = "date", date_style = 14) %>%
+       render_formats_test(context = "html"))[["date"]],
+    c("17/10/15", "13/02/22", "14/09/22", "18/01/10"))
+
+  # Create an input tibble frame with a single column
+  # that contains dates as `Date` values
+  data_tbl <-
+    dplyr::tibble(date = as.Date(c(
+      "2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10")))
+
+  # Create a `tab` object with `gt()` and the
+  # `data_tbl` dataset
+  tab <- gt(data = data_tbl)
 
   #
   # Format `date` in various date formats and verify the output

--- a/tests/testthat/test-l_fmt_date_time.R
+++ b/tests/testthat/test-l_fmt_date_time.R
@@ -105,6 +105,111 @@ test_that("the `fmt_date()` function works correctly", {
        fmt_date(columns = "date", date_style = 14) %>%
        render_formats_test(context = "latex"))[["date"]],
     c("17/10/15", "13/02/22", "14/09/22", "18/01/10"))
+
+  # Create an input tibble frame with a single column
+  # that contains dates as `Date` values
+  data_tbl <-
+    dplyr::tibble(date = as.Date(c(
+      "2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10")))
+
+  # Create a `tbl_latex` object with `gt()` and the
+  # `data_tbl` dataset
+  tbl_latex <- gt(data = data_tbl)
+
+  #
+  # Format `date` in various date formats and verify the output
+  #
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 1) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 2) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("Sunday, October 15, 2017", "Friday, February 22, 2013",
+      "Monday, September 22, 2014", "Wednesday, January 10, 2018"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 3) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("Sun, Oct 15, 2017", "Fri, Feb 22, 2013",
+      "Mon, Sep 22, 2014", "Wed, Jan 10, 2018"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 4) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("Sunday 15 October 2017", "Friday 22 February 2013",
+      "Monday 22 September 2014", "Wednesday 10 January 2018"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 5) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("October 15, 2017", "February 22, 2013",
+      "September 22, 2014", "January 10, 2018"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 6) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("Oct 15, 2017", "Feb 22, 2013",
+      "Sep 22, 2014", "Jan 10, 2018"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 7) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("15 Oct 2017", "22 Feb 2013", "22 Sep 2014", "10 Jan 2018"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 8) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("15 October 2017", "22 February 2013",
+      "22 September 2014", "10 January 2018"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 9) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("15 October", "22 February", "22 September", "10 January"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 10) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("2017", "2013", "2014", "2018"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 11) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("October", "February", "September", "January"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 12) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("15", "22", "22", "10"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 13) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("2017/10/15", "2013/02/22", "2014/09/22", "2018/01/10"))
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 14) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("17/10/15", "13/02/22", "14/09/22", "18/01/10"))
+
 })
 
 test_that("the `fmt_time()` function works correctly", {


### PR DESCRIPTION
Currently, the `fmt_date()` function only works with character-based columns with an ISO formatted date or date-time. This PR makes it possible to also use values of type `Date` (as in the `sp500` dataset). The example in the `README` sidesteps the problem by mutating a date column (with `Date`s) to a `character` column:

```r
sp500 %>%
  dplyr::filter(date >= start_date & date <= end_date) %>%
  dplyr::select(-adj_close) %>%
  dplyr::mutate(date = as.character(date)) %>%
  gt() %>%
  tab_header(
    title = "S&P 500",
    subtitle = glue::glue("{start_date} to {end_date}")
  ) %>%
  fmt_date(
    columns = vars(date),
    date_style = 3
  ) %>%
  fmt_currency(
    columns = vars(open, high, low, close),
    currency = "USD"
  ) %>%
  fmt_number(
    columns = vars(volume),
    scale_by = 1 / 1E9,
    pattern = "{x}B"
  )
```
The PR makes this work without that `mutate()` call.

Fixes https://github.com/rstudio/gt/issues/202.