### PR TITLE
Remove Travis check on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ jobs:
       r: oldrel
     - r: release
     - r: devel
-    - os: osx
-      r: release
 
     - stage: deploy
       name: covr


### PR DESCRIPTION
This simply removes the R check on Mac since it is currently not working. I will look at this periodically using another repo and reinstate this check when the Mac build system builds without error.