### PR TITLE
Simple README updates

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -13,11 +13,6 @@ knitr::opts_chunk$set(
 )
 ```
 
-```{r packages, message=FALSE, warning=FALSE, include=FALSE}
-library(gt)
-library(tidyverse)
-```
-
 # gt <img src="man/figures/logo.svg" align="right" height="250px" />
 
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
@@ -50,7 +45,6 @@ end_date <- "2010-06-14"
 sp500 %>%
   dplyr::filter(date >= start_date & date <= end_date) %>%
   dplyr::select(-adj_close) %>%
-  dplyr::mutate(date = as.character(date)) %>%
   gt() %>%
   tab_header(
     title = "S&P 500",
@@ -66,8 +60,7 @@ sp500 %>%
   ) %>%
   fmt_number(
     columns = vars(volume),
-    scale_by = 1 / 1E9,
-    pattern = "{x}B"
+    suffixing = TRUE
   )
 ```
 
@@ -86,7 +79,6 @@ Want to try this out? First and foremost, the **gt** package is used in an R env
 You can install the development version of **gt** from **GitHub**. Use the following in the R console to install **gt**.
 
 ```{r eval=FALSE}
-install.packages("devtools")
 remotes::install_github("rstudio/gt")
 ```
 
@@ -105,4 +97,3 @@ If you encounter a bug, have usage questions, or want to share ideas to make thi
 <h4 align="center">License</h4>
 
 <h6 align="center">MIT &copy; RStudio, Inc.</h6>
-

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ end_date <- "2010-06-14"
 sp500 %>%
   dplyr::filter(date >= start_date & date <= end_date) %>%
   dplyr::select(-adj_close) %>%
-  dplyr::mutate(date = as.character(date)) %>%
   gt() %>%
   tab_header(
     title = "S&P 500",
@@ -72,8 +71,7 @@ sp500 %>%
   ) %>%
   fmt_number(
     columns = vars(volume),
-    scale_by = 1 / 1E9,
-    pattern = "{x}B"
+    suffixing = TRUE
   )
 ```
 
@@ -113,7 +111,6 @@ You can install the development version of **gt** from **GitHub**. Use
 the following in the R console to install **gt**.
 
 ``` r
-install.packages("devtools")
 remotes::install_github("rstudio/gt")
 ```
 


### PR DESCRIPTION
In these changes to the README, we:

- update the main example shown in the README (removes the `mutate()` line, uses the `suffixing` arg in `fmt_number()`)
- simplify the installation instructions
- remove the unneeded `library()` statements