### PR TITLE
Remove a unicode character from roxygen documentation

### DIFF
--- a/R/datasets.R
+++ b/R/datasets.R
@@ -179,7 +179,7 @@
 #' \item \code{southw_ckn}: The Southwest Chicken Pizza (Chicken, Tomatoes, Red
 #' Peppers, Red Onions, Jalapeno Peppers, Corn, Cilantro, Chipotle Sauce)
 #' \item \code{cali_ckn}: The California Chicken Pizza (Chicken, Artichoke,
-#' Spinach, Garlic, Jalapeño Peppers, Fontina Cheese, Gouda Cheese)
+#' Spinach, Garlic, Jalapeno Peppers, Fontina Cheese, Gouda Cheese)
 #' \item \code{ckn_pesto}: The Chicken Pesto Pizza (Chicken, Tomatoes, Red
 #' Peppers, Spinach, Garlic, Pesto Sauce)
 #' \item \code{ckn_alfredo}: The Chicken Alfredo Pizza (Chicken, Red Onions,

--- a/man/pizzaplace.Rd
+++ b/man/pizzaplace.Rd
@@ -70,7 +70,7 @@ Peppers, Green Peppers, Tomatoes, Red Onions, Barbecue Sauce)
 \item \code{southw_ckn}: The Southwest Chicken Pizza (Chicken, Tomatoes, Red
 Peppers, Red Onions, Jalapeno Peppers, Corn, Cilantro, Chipotle Sauce)
 \item \code{cali_ckn}: The California Chicken Pizza (Chicken, Artichoke,
-Spinach, Garlic, Jalapeño Peppers, Fontina Cheese, Gouda Cheese)
+Spinach, Garlic, Jalapeno Peppers, Fontina Cheese, Gouda Cheese)
 \item \code{ckn_pesto}: The Chicken Pesto Pizza (Chicken, Tomatoes, Red
 Peppers, Spinach, Garlic, Pesto Sauce)
 \item \code{ckn_alfredo}: The Chicken Alfredo Pizza (Chicken, Red Onions,


### PR DESCRIPTION
This replaces a unicode character with its ascii equivalent. Solves a reported installation issue and is required by CRAN guidelines.

Fixes https://github.com/rstudio/gt/issues/216