### PR TITLE
Include option to hide all column labels

### DIFF
--- a/R/gt_options_default.R
+++ b/R/gt_options_default.R
@@ -17,6 +17,7 @@ gt_options_default <- function() {
     "column_labels_background_color",     TRUE,  "columns",             NA_character_,
     "column_labels_font_size",            TRUE,  "columns",             "16px",
     "column_labels_font_weight",          TRUE,  "columns",             "initial",
+    "column_labels_hidden",               FALSE,  "columns",            "FALSE",
     "row_group_background_color",         TRUE,  "row_group",           NA_character_,
     "row_group_font_size",                TRUE,  "row_group",           "16px",
     "row_group_font_weight",              TRUE,  "row_group",           "initial",

--- a/R/render_as_html.R
+++ b/R/render_as_html.R
@@ -63,7 +63,7 @@ render_as_html <- function(data) {
     columns_component <-
       create_columns_component_h(
         boxh_df, output_df, stub_available, spanners_present,
-        styles_resolved, stubhead_label, col_alignment)
+        styles_resolved, stubhead_label, col_alignment, opts_df)
 
     # Create the body component of the table
     body_component <-

--- a/R/tab_options.R
+++ b/R/tab_options.R
@@ -58,6 +58,7 @@
 #'   when striping rows.
 #' @param row.striping.include_table_body an option for whether to include the
 #'   table body when striping rows.
+#' @param column_labels.hidden an option to hide the column labels.
 #' @return an object of class \code{gt_tbl}.
 #' @examples
 #' # Use `exibble` to create a gt table with
@@ -169,6 +170,7 @@ tab_options <- function(data,
                         column_labels.background.color = NULL,
                         column_labels.font.size = NULL,
                         column_labels.font.weight = NULL,
+                        column_labels.hidden = NULL,
                         row_group.background.color = NULL,
                         row_group.font.size = NULL,
                         row_group.font.weight = NULL,
@@ -327,6 +329,13 @@ tab_options <- function(data,
   if (!is.null(column_labels.font.weight)) {
 
     opts_df <- opts_df_set(opts_df, "column_labels_font_weight", column_labels.font.weight)
+  }
+
+  # column_labels.hidden
+  if (!is.null(column_labels.hidden)) {
+
+    opts_df <- opts_df_set(
+      opts_df, "column_labels_hidden", column_labels.hidden)
   }
 
   # row_group.background.color

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -394,7 +394,18 @@ create_columns_component_h <- function(boxh_df,
                                        spanners_present,
                                        styles_resolved,
                                        stubhead_label,
-                                       col_alignment) {
+                                       col_alignment,
+                                       opts_df) {
+
+  # Should the column labels be hidden?
+  column_labels_hidden <-
+    opts_df %>%
+    opts_df_get(option = "column_labels_hidden") %>%
+    as.logical()
+
+  if (column_labels_hidden) {
+    return("")
+  }
 
   # Get the style attrs for the spanner column headings
   spanner_style_attrs <-

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -14,9 +14,10 @@ tab_options(data, table.width = NULL, table.font.size = NULL,
   heading.border.bottom.color = NULL,
   column_labels.background.color = NULL,
   column_labels.font.size = NULL, column_labels.font.weight = NULL,
-  row_group.background.color = NULL, row_group.font.size = NULL,
-  row_group.font.weight = NULL, row_group.border.top.style = NULL,
-  row_group.border.top.width = NULL, row_group.border.top.color = NULL,
+  column_labels.hidden = NULL, row_group.background.color = NULL,
+  row_group.font.size = NULL, row_group.font.weight = NULL,
+  row_group.border.top.style = NULL, row_group.border.top.width = NULL,
+  row_group.border.top.color = NULL,
   row_group.border.bottom.style = NULL,
   row_group.border.bottom.width = NULL,
   row_group.border.bottom.color = NULL,
@@ -65,6 +66,8 @@ color code should be provided.}
 
 \item{column_labels.font.weight, row_group.font.weight}{the font weight of the
 \code{columns} and \code{row_group} text element.}
+
+\item{column_labels.hidden}{an option to hide the column labels.}
 
 \item{row_group.border.top.style, row_group.border.top.width, row_group.border.top.color}{the style, width, and color of the row group's top border.}
 

--- a/tests/testthat/test-cols_label.R
+++ b/tests/testthat/test-cols_label.R
@@ -117,3 +117,29 @@ test_that("the function `cols_label()` works correctly", {
     gt(tbl) %>%
       cols_label(col_a = "col_1"))
 })
+
+test_that("all column labels can be entirely hidden from view", {
+
+  # Expect that the option `column_labels.hidden = TRUE` will
+  # remove the expected node with the classes of `gt_col_heading`
+  # and `gt_right` (i.e., the column labels)
+  expect_length(
+    tbl %>%
+      gt() %>%
+      tab_options(column_labels.hidden = TRUE) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_right']"),
+    0)
+
+  # Expect that not hiding the column labels yields a length
+  # four vector when using the same search
+  expect_length(
+    tbl %>%
+      gt() %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_right']"),
+    4)
+})
+


### PR DESCRIPTION
Sometimes it can be very useful not to have column labels at all. This PR makes that possible by providing the `column_labels.hide` argument in `tab_options()`. Here is a working example: 

```r
# Create a few Markdown-based
# text snippets
text_1a <- "
 ### This is Markdown.

 Markdown’s syntax is comprised entirely of
 punctuation characters, which punctuation
 characters have been carefully chosen so as
 to look like what they mean... assuming
 you’ve ever used email.
 "

text_1b <- "
 Info on Markdown syntax can be found
 [here](https://daringfireball.net/projects/markdown/).
 "

text_1c <- "<img src=\"https://i.imgur.com/3RqWtfL.gif\" width=\"200\">"

text_2a <- "
 The **gt** package has these datasets:

  - `countrypops`
  - `sza`
  - `gtcars`
  - `sp500`
  - `pizzaplace`
  - `exibble`
 "

text_2b <- "
 There's a quick reference [here](https://commonmark.org/help/).
 "

text_2c <- "
 Yes, gifs should work.
 "

# Arrange the text snippets as a tibble
# using the `dplyr::tribble()` function;
# then, create a gt table and format
# all columns with `fmt_markdown()`
dplyr::tribble(
  ~Markdown, ~md,
  text_1a,   text_2a,
  text_1b,   text_2b,
  text_1c,   text_2c,
) %>%
  gt() %>%
  fmt_markdown(columns = TRUE) %>%
  tab_options(
    table.width = px(500),
    column_labels.hide = TRUE
  )
```

<img width="677" alt="no_column_labels" src="https://user-images.githubusercontent.com/5612024/55271738-3c2b2080-5288-11e9-905a-199dd862140d.png">

Closes https://github.com/rstudio/gt/issues/225.