### PR TITLE
Additional refactoring for `format_*()` functions

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -167,7 +167,6 @@ fmt_number <- function(data,
         x_str <- character(length(x))
 
         # Define the marks by context
-        minus_mark <- context_minus_mark(context)
         parens_marks <- context_parens_marks_number(context)
 
         # Create the `suffix_df` object
@@ -178,8 +177,8 @@ fmt_number <- function(data,
           scale_x_values(suffix_df$scale_by) %>%
           # Format numeric values to character-based numbers
           format_num_to_str(
-            decimals = decimals, sep_mark = sep_mark, dec_mark = dec_mark,
-            drop_trailing_zeros = drop_trailing_zeros, minus_mark = minus_mark
+            context = context, decimals = decimals, sep_mark = sep_mark,
+            dec_mark = dec_mark, drop_trailing_zeros = drop_trailing_zeros
           ) %>%
           # With large-number suffixing support, we paste the
           # vector of suffixes to the right of the values
@@ -281,8 +280,10 @@ fmt_scientific <- function(data,
       format_fn = function(x, context) {
 
         # Define the marks by context
-        minus_mark <- context_minus_mark(context)
         exp_marks <- context_exp_marks(context)
+
+        # Create the minus mark for the context
+        minus_mark <- context_minus_mark(context)
 
         # Define the `replace_minus()` function
         replace_minus <- function(x) {
@@ -299,8 +300,8 @@ fmt_scientific <- function(data,
           x %>%
           # Format numeric values to character-based numbers
           format_num_to_str(
-            decimals = decimals, sep_mark = sep_mark, dec_mark = dec_mark,
-            drop_trailing_zeros = drop_trailing_zeros, minus_mark = minus_mark,
+            context = context, decimals = decimals, sep_mark = sep_mark,
+            dec_mark = dec_mark, drop_trailing_zeros = drop_trailing_zeros,
             format = "e", replace_minus_mark = FALSE
           )
 
@@ -384,7 +385,6 @@ fmt_symbol <- function(data,
         x_str <- character(length(x))
 
         # Define the marks by context
-        minus_mark <- context_minus_mark(context)
         parens_marks <- context_parens_marks_number(context)
         symbol_str <- context_symbol_str(context, symbol)
 
@@ -403,8 +403,8 @@ fmt_symbol <- function(data,
             x[is_not_negative_x] %>%
             # Format numeric values to character-based numbers
             format_num_to_str_c(
-              decimals = decimals, sep_mark = sep_mark, dec_mark = dec_mark,
-              drop_trailing_zeros = drop_trailing_zeros, minus_mark = minus_mark
+              context = context, decimals = decimals, sep_mark = sep_mark,
+              dec_mark = dec_mark, drop_trailing_zeros = drop_trailing_zeros
             )
         }
 
@@ -417,20 +417,23 @@ fmt_symbol <- function(data,
             abs() %>%
             # Format numeric values to character-based numbers
             format_num_to_str_c(
-              decimals = decimals, sep_mark = sep_mark, dec_mark = dec_mark,
-              drop_trailing_zeros = drop_trailing_zeros, minus_mark = minus_mark
+              context = context, decimals = decimals, sep_mark = sep_mark,
+              dec_mark = dec_mark, drop_trailing_zeros = drop_trailing_zeros
             )
         }
 
         x_str <-
           # Format values with a symbol string
           format_symbol_str(
-            x_abs_str = x_abs_str, x = x, symbol_str = symbol_str,
-            incl_space = incl_space, placement = placement,
-            minus_mark = minus_mark
+            context = context, x_abs_str = x_abs_str, x = x,
+            symbol_str = symbol_str, incl_space = incl_space,
+            placement = placement
           ) %>%
           # Format values in accounting style
-          format_as_accounting(x, accounting, minus_mark, parens_marks) %>%
+          format_as_accounting(
+            x = x, context = context, accounting = accounting,
+            parens_marks = parens_marks
+          ) %>%
           # With large-number suffixing support, we paste the
           # vector of suffixes to the right of the values
           paste_right(suffix_df$suffix)

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -166,9 +166,6 @@ fmt_number <- function(data,
 
         x_str <- character(length(x))
 
-        # Define the marks by context
-        parens_marks <- context_parens_marks_number(context)
-
         # Create the `suffix_df` object
         suffix_df <- create_suffix_df(x, decimals, suffix_labels, scale_by)
 
@@ -385,7 +382,6 @@ fmt_symbol <- function(data,
         x_str <- character(length(x))
 
         # Define the marks by context
-        parens_marks <- context_parens_marks_number(context)
         symbol_str <- context_symbol_str(context, symbol)
 
         # Create the `suffix_df` object
@@ -431,8 +427,7 @@ fmt_symbol <- function(data,
           ) %>%
           # Format values in accounting style
           format_as_accounting(
-            x = x, context = context, accounting = accounting,
-            parens_marks = parens_marks
+            x = x, context = context, accounting = accounting
           ) %>%
           # With large-number suffixing support, we paste the
           # vector of suffixes to the right of the values

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -278,8 +278,6 @@ fmt_scientific <- function(data,
 
         # Define the marks by context
         exp_marks <- context_exp_marks(context)
-
-        # Create the minus mark for the context
         minus_mark <- context_minus_mark(context)
 
         # Define the `replace_minus()` function
@@ -381,9 +379,6 @@ fmt_symbol <- function(data,
         # Create the `x_str` vector
         x_str <- character(length(x))
 
-        # Define the marks by context
-        symbol_str <- context_symbol_str(context, symbol)
-
         # Create the `suffix_df` object
         suffix_df <- create_suffix_df(x, decimals, suffix_labels, scale_by)
 
@@ -422,7 +417,7 @@ fmt_symbol <- function(data,
           # Format values with a symbol string
           format_symbol_str(
             context = context, x_abs_str = x_abs_str, x = x,
-            symbol_str = symbol_str, incl_space = incl_space,
+            symbol = symbol, incl_space = incl_space,
             placement = placement
           ) %>%
           # Format values in accounting style

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -353,9 +353,7 @@ context_symbol_str <- function(context,
 #' @param x_abs_str Absolute numeric values in `character` form.
 #' @param x Numeric values in `numeric` form.
 #' @param context The output context.
-#' @param symbol_str The string that represents the symbol. It can be placed to
-#'   the left or to the right of the numeric values. If on the left, it can take
-#'   on a negative value.
+#' @param symbol The symbol.
 #' @param incl_space A logical value indicating whether a single space character
 #'   should separate the symbols and the formatted values.
 #' @param placement Either `left` or `right` (this is the placement of the
@@ -364,9 +362,12 @@ context_symbol_str <- function(context,
 format_symbol_str <- function(x_abs_str,
                               x,
                               context,
-                              symbol_str,
+                              symbol,
                               incl_space,
                               placement) {
+
+
+  symbol_str <- context_symbol_str(context, symbol)
 
   if (symbol_str == "") {
     return(x_abs_str)

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -289,7 +289,7 @@ context_percent_mark <- function(context) {
 #'
 #' @param context The output context.
 #' @noRd
-context_parens_marks_number <- function(context) {
+context_parens_marks <- function(context) {
 
   switch(context,
          latex = c("(", ")"),
@@ -437,13 +437,11 @@ format_minus <- function(x_str,
 #' @param context The output context.
 #' @param accounting A logical value that indicates whether accounting style
 #'   should be used.
-#' @param parens_marks The contextually correct pair of parentheses.
 #' @noRd
 format_as_accounting <- function(x_str,
                                  x,
                                  context,
-                                 accounting,
-                                 parens_marks) {
+                                 accounting) {
 
   # TODO: Handle using `x_abs_str` instead
 
@@ -458,8 +456,9 @@ format_as_accounting <- function(x_str,
   # Handle case where negative values are to be placed within parentheses
   if (accounting) {
 
-    # Create the minus mark for the context
+    # Create the minus and parens marks for the context
     minus_mark <- context_minus_mark(context)
+    parens_marks <- context_parens_marks(context)
 
     # Selectively remove minus sign and paste between parentheses
     x_str[x_lt0] <-

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -189,21 +189,21 @@ scale_x_values <- function(x,
 #' A `formatC()` call for `fmt_number()` and `fmt_percent()`
 #'
 #' @param x A vector of numeric values.
+#' @param context The output context.
 #' @param decimals The number of decimal places (`digits`).
 #' @param sep_mark The separator for number groups (`big.mark`).
 #' @param dec_mark The decimal separator mark (`decimal.mark`).
 #' @param drop_trailing_zeros Option to exclude trailing decimal zeros.
-#' @param minus_mark The contextually correct minus mark.
 #' @param format The numeric format for `formatC()`.
 #' @param replace_minus_mark An option for whether the minus sign should be
 #'   replaced with the minus mark.
 #' @noRd
 format_num_to_str <- function(x,
+                              context,
                               decimals,
                               sep_mark,
                               dec_mark,
                               drop_trailing_zeros,
-                              minus_mark,
                               format = "f",
                               replace_minus_mark = TRUE) {
 
@@ -219,7 +219,7 @@ format_num_to_str <- function(x,
     )
 
   if (replace_minus_mark) {
-    x_str <- format_minus(x_str = x_str, x = x, minus_mark = minus_mark)
+    x_str <- format_minus(x_str = x_str, x = x, context = context)
   }
 
   x_str
@@ -230,19 +230,19 @@ format_num_to_str <- function(x,
 #' @inheritParams format_num_to_str
 #' @noRd
 format_num_to_str_c <- function(x,
+                                context,
                                 decimals,
                                 sep_mark,
                                 dec_mark,
-                                minus_mark,
                                 drop_trailing_zeros = FALSE) {
 
   format_num_to_str(
     x = x,
+    context = context,
     decimals = decimals,
     sep_mark = sep_mark,
     dec_mark = dec_mark,
     drop_trailing_zeros = drop_trailing_zeros,
-    minus_mark = minus_mark,
     format = "f"
   )
 }
@@ -352,6 +352,7 @@ context_symbol_str <- function(context,
 #'
 #' @param x_abs_str Absolute numeric values in `character` form.
 #' @param x Numeric values in `numeric` form.
+#' @param context The output context.
 #' @param symbol_str The string that represents the symbol. It can be placed to
 #'   the left or to the right of the numeric values. If on the left, it can take
 #'   on a negative value.
@@ -359,14 +360,13 @@ context_symbol_str <- function(context,
 #'   should separate the symbols and the formatted values.
 #' @param placement Either `left` or `right` (this is the placement of the
 #'   symbol string relative to the formatted, numeric values).
-#' @param minus_mark The contextually correct minus mark.
 #' @noRd
 format_symbol_str <- function(x_abs_str,
                               x,
+                              context,
                               symbol_str,
                               incl_space,
-                              placement,
-                              minus_mark) {
+                              placement) {
 
   if (symbol_str == "") {
     return(x_abs_str)
@@ -391,6 +391,9 @@ format_symbol_str <- function(x_abs_str,
         direction = placement
       )
 
+    # Create the minus mark for the context
+    minus_mark <- context_minus_mark(context)
+
     # Place the `minus_mark` onto the formatted strings
     if (x_i < 0) {
       x_str_i <-
@@ -406,11 +409,11 @@ format_symbol_str <- function(x_abs_str,
 #'
 #' @param x_str Numeric values in `character` form.
 #' @param x Numeric values in `numeric` form.
-#' @param minus_mark The contextually correct minus mark.
+#' @param context The output context.
 #' @noRd
 format_minus <- function(x_str,
                          x,
-                         minus_mark) {
+                         context) {
 
   # Store logical vector of `x_vals` < 0
   x_lt0 <- x < 0
@@ -420,6 +423,9 @@ format_minus <- function(x_str,
     return(x_str)
   }
 
+  # Create the minus mark for the context
+  minus_mark <- context_minus_mark(context)
+
   # Handle replacement of the minus mark
   x_str %>% tidy_gsub("-", minus_mark, fixed = TRUE)
 }
@@ -428,15 +434,15 @@ format_minus <- function(x_str,
 #'
 #' @param x_str Numeric values in `character` form.
 #' @param x Numeric values in `numeric` form.
+#' @param context The output context.
 #' @param accounting A logical value that indicates whether accounting style
 #'   should be used.
-#' @param minus_mark The contextually correct minus mark.
 #' @param parens_marks The contextually correct pair of parentheses.
 #' @noRd
 format_as_accounting <- function(x_str,
                                  x,
+                                 context,
                                  accounting,
-                                 minus_mark,
                                  parens_marks) {
 
   # TODO: Handle using `x_abs_str` instead
@@ -452,6 +458,9 @@ format_as_accounting <- function(x_str,
   # Handle case where negative values are to be placed within parentheses
   if (accounting) {
 
+    # Create the minus mark for the context
+    minus_mark <- context_minus_mark(context)
+
     # Selectively remove minus sign and paste between parentheses
     x_str[x_lt0] <-
       x_str[x_lt0] %>%
@@ -465,16 +474,16 @@ format_as_accounting <- function(x_str,
 #' Provide a nicer format for numbers in scientific notation
 #'
 #' @param x Numeric values in `character` form.
+#' @param context The output context.
 #' @param small_pos A logical vector the length of `x` that indicates whether
 #'   values should be decorated.
 #' @param exp_marks A character vector (length of two) that encloses the
 #'   exponential power value.
-#' @param minus_mark The contextually correct minus mark.
 #' @noRd
 prettify_scientific_notation <- function(x,
+                                         context,
                                          small_pos,
-                                         exp_marks,
-                                         minus_mark) {
+                                         exp_marks) {
 
   if (!any(grepl("e|E", x))) {
     return(x)
@@ -494,6 +503,9 @@ prettify_scientific_notation <- function(x,
       sci_parts$num, exp_marks[1],
       sci_parts$exp, exp_marks[2]
     )
+
+  # Create the minus mark for the context
+  minus_mark <- context_minus_mark(context)
 
   # Handle replacement of the minus mark in number
   # and exponent parts


### PR DESCRIPTION
This leaf branch makes a few additional changes to the PR of https://github.com/rstudio/gt/pull/244. Here we generate the textual marks right before usage using the supplied `context`.