### PR TITLE
Store empty-string value in `sep` vector

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -759,6 +759,9 @@ cols_merge <- function(data,
     attr(data, "col_merge")[["pattern"]] <-
       c(attr(data, "col_merge")[["pattern"]], pattern)
 
+    attr(data, "col_merge")[["sep"]] <-
+      c(attr(data, "col_merge")[["sep"]], "")
+
     attr(data, "col_merge")[["col_1"]] <-
       c(attr(data, "col_merge")[["col_1"]], col_1)
 
@@ -877,6 +880,9 @@ cols_merge_uncert <- function(data,
 
     attr(data, "col_merge")[["pattern"]] <-
       c(attr(data, "col_merge")[["pattern"]], pattern)
+
+    attr(data, "col_merge")[["sep"]] <-
+      c(attr(data, "col_merge")[["sep"]], "")
 
     attr(data, "col_merge")[["col_1"]] <-
       c(attr(data, "col_merge")[["col_1"]], col_val)

--- a/tests/testthat/test-cols_merge.R
+++ b/tests/testthat/test-cols_merge.R
@@ -42,6 +42,9 @@ test_that("the function `cols_merge()` works correctly", {
   attr(tbl_html, "col_merge", exact = TRUE)$pattern %>%
     expect_equal("{1} ({2})")
 
+  attr(tbl_html, "col_merge", exact = TRUE)$sep %>%
+    expect_equal("")
+
   attr(tbl_html, "col_merge", exact = TRUE)$col_1 %>%
     names() %>%
     expect_equal("wt")
@@ -62,6 +65,9 @@ test_that("the function `cols_merge()` works correctly", {
   # Expect that merging statements are stored in `col_merge`
   attr(tbl_html, "col_merge", exact = TRUE)$pattern %>%
     expect_equal("{1} ({2})")
+
+  attr(tbl_html, "col_merge", exact = TRUE)$sep %>%
+    expect_equal("")
 
   attr(tbl_html, "col_merge", exact = TRUE)$col_1 %>%
     names() %>%
@@ -88,6 +94,9 @@ test_that("the function `cols_merge()` works correctly", {
   attr(tbl_html, "col_merge", exact = TRUE)$pattern[[1]] %>%
     expect_equal("{1} ({2})")
 
+  attr(tbl_html, "col_merge", exact = TRUE)$sep[[1]] %>%
+    expect_equal("")
+
   attr(tbl_html, "col_merge", exact = TRUE)$col_1[1] %>%
     names() %>%
     expect_equal("wt")
@@ -98,6 +107,9 @@ test_that("the function `cols_merge()` works correctly", {
 
   attr(tbl_html, "col_merge", exact = TRUE)$pattern[[2]] %>%
     expect_equal("{1}-{2}")
+
+  attr(tbl_html, "col_merge", exact = TRUE)$sep[[2]] %>%
+    expect_equal("")
 
   attr(tbl_html, "col_merge", exact = TRUE)$col_1[2] %>%
     names() %>%
@@ -125,6 +137,9 @@ test_that("the `cols_merge_uncert()` function works correctly", {
   attr(tbl_html, "col_merge", exact = TRUE)$pattern %>%
     expect_equal("{1} ± {2}")
 
+  attr(tbl_html, "col_merge", exact = TRUE)$sep %>%
+    expect_equal("")
+
   attr(tbl_html, "col_merge", exact = TRUE)$col_1 %>%
     names() %>%
     expect_equal("col_2")
@@ -144,6 +159,9 @@ test_that("the `cols_merge_uncert()` function works correctly", {
   # Expect that merging statements are stored in `col_merge`
   attr(tbl_html, "col_merge", exact = TRUE)$pattern %>%
     expect_equal("{1} ± {2}")
+
+  attr(tbl_html, "col_merge", exact = TRUE)$sep %>%
+    expect_equal("")
 
   attr(tbl_html, "col_merge", exact = TRUE)$col_1 %>%
     names() %>%
@@ -168,6 +186,9 @@ test_that("the `cols_merge_uncert()` function works correctly", {
   attr(tbl_html, "col_merge", exact = TRUE)$pattern[[1]] %>%
     expect_equal("{1} ± {2}")
 
+  attr(tbl_html, "col_merge", exact = TRUE)$sep[[1]] %>%
+    expect_equal("")
+
   attr(tbl_html, "col_merge", exact = TRUE)$col_1[1] %>%
     names() %>%
     expect_equal("col_2")
@@ -178,6 +199,9 @@ test_that("the `cols_merge_uncert()` function works correctly", {
 
   attr(tbl_html, "col_merge", exact = TRUE)$pattern[[2]] %>%
     expect_equal("{1} ± {2}")
+
+  attr(tbl_html, "col_merge", exact = TRUE)$sep[[2]] %>%
+    expect_equal("")
 
   attr(tbl_html, "col_merge", exact = TRUE)$col_1[2] %>%
     names() %>%
@@ -205,6 +229,9 @@ test_that("the `cols_merge_range()` function works correctly", {
   attr(tbl_html, "col_merge", exact = TRUE)$pattern %>%
     expect_equal("{1} {sep} {2}")
 
+  attr(tbl_html, "col_merge", exact = TRUE)$sep %>%
+    expect_equal("---")
+
   attr(tbl_html, "col_merge", exact = TRUE)$col_1 %>%
     names() %>%
     expect_equal("col_2")
@@ -224,6 +251,9 @@ test_that("the `cols_merge_range()` function works correctly", {
   # Expect that merging statements are stored in `col_merge`
   attr(tbl_html, "col_merge", exact = TRUE)$pattern %>%
     expect_equal("{1} {sep} {2}")
+
+  attr(tbl_html, "col_merge", exact = TRUE)$sep %>%
+    expect_equal("---")
 
   attr(tbl_html, "col_merge", exact = TRUE)$col_1 %>%
     names() %>%


### PR DESCRIPTION
This is a small fix that inserts an empty string separator in the `sep` list component. This is important for the `cols_merge()` and `cols_merge_uncert()` functions as the `""` separator serves as a dummy value (whereas the `cols_merge_range()` function uses a non-empty separator).