### PR TITLE
Path expand all file inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     checkmate (>= 1.8.5),
     commonmark (>= 1.7),
     dplyr (>= 0.7.8),
+    fs (>= 1.2.6),
     ggplot2 (>= 3.1.0),
     glue (>= 1.3.0),
     htmltools (>= 0.3.6),

--- a/R/gtsave.R
+++ b/R/gtsave.R
@@ -102,6 +102,9 @@ gt_save_webshot <- function(data,
                             zoom = 2,
                             expand = 5) {
 
+  # Normalize file path
+  filename <- filename %>% path_expand()
+
   # Create a temporary file with the `html` extension
   tempfile_ <- tempfile(fileext = ".html")
 

--- a/R/image.R
+++ b/R/image.R
@@ -21,7 +21,7 @@
 #' where a height of `30px` is a default height chosen to work well within the
 #' heights of most table rows.
 #'
-#' @param file A path to an image file.
+#' @param filename A path to an image file.
 #' @param height The absolute height (px) of the image in the table cell.
 #' @return a character object with an HTML fragment that can be placed inside of
 #'   a cell.
@@ -43,7 +43,7 @@
 #'     locations = cells_data(vars(image)),
 #'     fn = function(x) {
 #'       local_image(
-#'         file = test_image(type = "png"),
+#'         filename = test_image(type = "png"),
 #'         height = as.numeric(x)
 #'       )
 #'     }
@@ -55,8 +55,11 @@
 #' @family image addition functions
 #' @importFrom glue glue
 #' @export
-local_image <- function(file,
+local_image <- function(filename,
                         height = 30) {
+
+  # Normalize file path
+  filename <- filename %>% path_expand()
 
   if (is.numeric(height)) {
     height <- paste0(height, "px")
@@ -67,10 +70,10 @@ local_image <- function(file,
   cid <-
     paste0(
       sample(letters, 12) %>% paste(collapse = ""), "__",
-      basename(file))
+      basename(filename))
 
   # Create the image URI
-  uri <- get_image_uri(file)
+  uri <- get_image_uri(filename)
 
   # Generate the Base64-encoded image and place it
   # within <img> tags

--- a/R/utils.R
+++ b/R/utils.R
@@ -932,3 +932,11 @@ stop_if_not_gt <- function(data) {
     stop("The object to `data` is not a `gt_tbl` object.", call. = FALSE)
   }
 }
+
+
+#' Expand a path using fs::path_ex
+#' @noRd
+path_expand <- function(file) {
+
+  fs::path_expand(file)
+}

--- a/man/local_image.Rd
+++ b/man/local_image.Rd
@@ -4,10 +4,10 @@
 \alias{local_image}
 \title{Helper function for adding a local image}
 \usage{
-local_image(file, height = 30)
+local_image(filename, height = 30)
 }
 \arguments{
-\item{file}{A path to an image file.}
+\item{filename}{A path to an image file.}
 
 \item{height}{The absolute height (px) of the image in the table cell.}
 }
@@ -61,7 +61,7 @@ tab_1 <-
     locations = cells_data(vars(image)),
     fn = function(x) {
       local_image(
-        file = test_image(type = "png"),
+        filename = test_image(type = "png"),
         height = as.numeric(x)
       )
     }


### PR DESCRIPTION
This addresses https://github.com/rstudio/gt/issues/277, where file paths with `~`s aren't expanded. This also fixes other instances by normalizing file paths with `fs::path_expand()`.

Fixes: https://github.com/rstudio/gt/issues/277.