### PR TITLE
Use `sass` package from CRAN (not GitHub)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,8 +39,6 @@ Imports:
     tibble (>= 1.4.2),
     tidyr (>= 0.8.2),
     tidyselect (>= 0.2.5)
-Remotes:
-    rstudio/sass
 Suggests:
     knitr,
     paletteer,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     magrittr (>= 1.5),
     rlang (>= 0.3.0),
     scales (>= 1.0.0),
-    sass (>= 0.1.0),
+    sass (>= 0.1.1),
     stringr (>= 1.3.1),
     tibble (>= 1.4.2),
     tidyr (>= 0.8.2),

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -32,6 +32,8 @@
 #'   document.
 #'
 #' @examples
+#' library(shiny)
+#'
 #' # Here is a Shiny app (contained within
 #' # a single file) that (1) prepares a
 #' # gt table, (2) sets up the `ui` with
@@ -147,6 +149,8 @@ render_gt <- function(expr,
 #' @param outputId An output variable from which to read the table.
 #'
 #' @examples
+#' library(shiny)
+#'
 #' # Here is a Shiny app (contained within
 #' # a single file) that (1) prepares a
 #' # gt table, (2) sets up the `ui` with

--- a/man/gt_output.Rd
+++ b/man/gt_output.Rd
@@ -25,6 +25,8 @@ is easily by using \code{install.packages("shiny")}. More information on creatin
 Shiny apps can be found at the \href{https://shiny.rstudio.com}{Shiny Site}.
 }
 \examples{
+library(shiny)
+
 # Here is a Shiny app (contained within
 # a single file) that (1) prepares a
 # gt table, (2) sets up the `ui` with

--- a/man/render_gt.Rd
+++ b/man/render_gt.Rd
@@ -47,6 +47,8 @@ is easily by using \code{install.packages("shiny")}. More information on creatin
 Shiny apps can be found at the \href{https://shiny.rstudio.com}{Shiny Site}.
 }
 \examples{
+library(shiny)
+
 # Here is a Shiny app (contained within
 # a single file) that (1) prepares a
 # gt table, (2) sets up the `ui` with


### PR DESCRIPTION
This change enables to use of the `sass` package from CRAN and not from GitHub.

Fixes https://github.com/rstudio/gt/issues/83.
Fixes https://github.com/rstudio/gt/issues/254.