### PR TITLE
Fix for `cell_borders()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Imports:
     sass (>= 0.1.1),
     stringr (>= 1.3.1),
     tibble (>= 1.4.2),
-    tidyr (>= 0.8.2),
     tidyselect (>= 0.2.5)
 Suggests:
     knitr,
@@ -47,6 +46,7 @@ Suggests:
     rmarkdown,
     rvest,
     shiny,
+    tidyr,
     webshot,
     xml2
 VignetteBuilder: knitr

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -80,6 +80,8 @@
 #'   the locales that are supported.
 #' @return An object of class `gt_tbl`.
 #' @examples
+#' library(tidyr)
+#'
 #' # Use `exibble` to create a gt table;
 #' # format the `num` column as numeric
 #' # with three decimal places and with no

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -846,6 +846,55 @@ cell_style_to_html.cell_fill <- function(style) {
 #'   any defined `sides` can be removed by supplying `NULL` to any of `color`,
 #'   `style`, or `weight`.
 #'
+#' @examples
+#' # Add horizontal border lines for
+#' # all table body rows in `exibble`
+#' tab_1 <-
+#'   exibble %>%
+#'     gt() %>%
+#'     tab_options(row.striping.include_table_body = FALSE) %>%
+#'     tab_style(
+#'       style = cell_borders(
+#'         sides = c("top", "bottom"),
+#'         color = "gray", weight = px(0.5), style = "solid"
+#'       ),
+#'       locations = cells_data(
+#'         columns = everything(),
+#'         rows = everything()
+#'       )
+#'     )
+#'
+#' # Incorporate different horizontal and
+#' # vertical borders at several locations;
+#' # this uses multiple `cell_borders()` and
+#' # `cells_data()` calls within `list()`s
+#' tab_2 <-
+#'   exibble %>%
+#'     gt() %>%
+#'     tab_style(
+#'       style = list(
+#'         cell_borders(
+#'           sides = c("top", "bottom"),
+#'           color = "red",
+#'           weight = px(2)
+#'         ),
+#'         cell_borders(
+#'           sides = c("left", "right"),
+#'           color = "blue",
+#'           weight = px(2)
+#'         )
+#'       ),
+#'       locations = list(
+#'         cells_data(
+#'           columns = vars(num),
+#'           rows = is.na(num)
+#'         ),
+#'         cells_data(
+#'           columns = vars(currency),
+#'           rows = is.na(currency)
+#'         )
+#'       )
+#'     )
 #' @family helper functions
 #' @export
 cell_borders <- function(sides = "all",

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -559,7 +559,7 @@ currency <- function(...,
 #' [tab_style()] will reliably apply those styles to the targeted element.
 #'
 #' This function is now soft-deprecated, which means it will soon be removed.
-#' Please consider using the [cell_fill()] (where `bkgd_color` is `fill`) and
+#' Please consider using the [cell_fill()] (where `bkgd_color` is `color`) and
 #' [cell_text()] (contains all other arguments here without the leading
 #' `text_`).
 #'

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -905,8 +905,40 @@ cell_borders <- function(selection,
   )
 
   list(cell_borders = style_vals)
+
+  cell_style_structure("cell_borders", style_vals)
 }
 
+cell_style_to_html.cell_borders <- function(style) {
+
+  css <- style %>% unclass()
+
+  directions <- css$selection
+
+  if (any(c("all", "everything") %in% directions)) {
+    directions <- c("left", "right", "top", "bottom")
+  }
+
+  multiple <- length(directions)
+
+  css$selection <- NULL
+
+  html_names <- c("color", "style", "width")
+
+  # Repeat the list components `multiple` times
+  css <- rep(css, multiple)
+
+  html_names <-
+    paste0(
+      "border-",
+      rep(directions, each = 3), "-",
+      html_names %>% rep(multiple)
+    )
+
+  names(css) <- html_names
+
+  css
+}
 
 cell_style_structure <- function(.subclass, obj) {
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -42,6 +42,8 @@
 #'   function (see Details for information on these functions).
 #'
 #' @examples
+#' library(tidyr)
+#'
 #' # Use `sp500` to create a gt table; add
 #' # a header (with a title and a subtitle),
 #' # and then add a footnote to the subtitle

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -837,11 +837,14 @@ cell_style_to_html.cell_fill <- function(style) {
 #' @param sides The border sides to be modified. Options include `"left"`,
 #'   `"right"`, `"top"`, and `"bottom"`. For all borders surrounding the
 #'   selected cells, we can use the `"all"` option.
-#' @param color The border color. The default `"#000000"` (black) will be used
-#'   as a default.
-#' @param style The border style. Can be one of either `"solid"` (the default),
-#'   `"dashed"`, or `"dotted"`.
-#' @param weight The weight of the border lines. The default value is `"1px"`.
+#' @param color,style,weight The border color, style, and weight. The `color`
+#'   can be defined with a color name or with a hexadecimal color code. The
+#'   default `color` value is `"#000000"` (black). The `style` can be one of
+#'   either `"solid"` (the default), `"dashed"`, or `"dotted"`. The `weight` of
+#'   the border lines is to be given in pixel values (the [px()] helper function
+#'   is useful for this. The default value for `weight` is `"1px"`. Borders for
+#'   any defined `sides` can be removed by supplying `NULL` to any of `color`,
+#'   `style`, or `weight`.
 #'
 #' @family helper functions
 #' @export
@@ -862,7 +865,6 @@ cell_borders <- function(sides = "all",
     color <- "transparent"
   }
 
-  # TODO: change back to length 1 exactly
   validate_length_one(weight, "weight")
   validate_length_one(style, "style")
   validate_length_one(color, "color")

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -905,7 +905,7 @@ cell_borders <- function(sides = "all",
     style_vals <-
       list(
         side = side,
-        weight = weight,
+        width = weight,
         style = style,
         color = color
       )

--- a/R/utils.R
+++ b/R/utils.R
@@ -914,9 +914,9 @@ stop_if_not_gt <- function(data) {
 #' Resolve the selection of border elements for a table cell
 #'
 #' @noRd
-resolve_selection <- function(selection) {
+resolve_border_side <- function(side) {
 
-  switch(selection,
+  switch(side,
          l = "left",
          left = "left",
          r = "right",
@@ -970,4 +970,11 @@ flatten_list <- function(x) {
 rep_vec_as_list <- function(x, length_out) {
 
   rep_len(list(x), length_out)
+}
+
+validate_length_one <- function(x, name) {
+  if (length(x) != 1) {
+    stop("The value for `", name, "` should have a length of one",
+         call. = FALSE)
+  }
 }

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -554,7 +554,7 @@ create_summary_dfs <- function(summary_list,
       summary_df_display_list[[i]] %>%
       dplyr::select(-groupname) %>%
       dplyr::group_by(rowname) %>%
-      dplyr::summarize_all(coalesce_by_column)
+      dplyr::summarize_all(last_non_na)
 
     summary_df_display_list[[i]] <-
       summary_df_display_list[[i]][
@@ -866,7 +866,7 @@ replace_na_groups_rows_df <- function(groups_rows_df,
   groups_rows_df
 }
 
-coalesce_by_column <- function(vect) {
+last_non_na <- function(vect) {
 
   # Retrieve last non-NA value
   positions <- which(!is.na(vect))

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -554,10 +554,7 @@ create_summary_dfs <- function(summary_list,
       summary_df_display_list[[i]] %>%
       dplyr::select(-groupname) %>%
       dplyr::group_by(rowname) %>%
-      tidyr::fill(dplyr::everything(), .direction = "down") %>%
-      tidyr::fill(dplyr::everything(), .direction = "up") %>%
-      dplyr::slice(1) %>%
-      dplyr::ungroup()
+      dplyr::summarize_all(coalesce_by_column)
 
     summary_df_display_list[[i]] <-
       summary_df_display_list[[i]][
@@ -867,4 +864,8 @@ replace_na_groups_rows_df <- function(groups_rows_df,
   }
 
   groups_rows_df
+}
+
+coalesce_by_column <- function(df) {
+  return(dplyr::coalesce(!!! as.list(df)))
 }

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -866,6 +866,14 @@ replace_na_groups_rows_df <- function(groups_rows_df,
   groups_rows_df
 }
 
-coalesce_by_column <- function(df) {
-  return(dplyr::coalesce(!!! as.list(df)))
+coalesce_by_column <- function(vect) {
+
+  # Retrieve last non-NA value
+  positions <- which(!is.na(vect))
+
+  if (length(positions) == 0) {
+    return(NA_character_)
+  } else {
+    return(vect[max(positions)])
+  }
 }

--- a/man/cell_borders.Rd
+++ b/man/cell_borders.Rd
@@ -12,13 +12,14 @@ cell_borders(sides = "all", color = "#000000", style = "solid",
 \code{"right"}, \code{"top"}, and \code{"bottom"}. For all borders surrounding the
 selected cells, we can use the \code{"all"} option.}
 
-\item{color}{The border color. The default \code{"#000000"} (black) will be used
-as a default.}
-
-\item{style}{The border style. Can be one of either \code{"solid"} (the default),
-\code{"dashed"}, or \code{"dotted"}.}
-
-\item{weight}{The weight of the border lines. The default value is \code{"1px"}.}
+\item{color, style, weight}{The border color, style, and weight. The \code{color}
+can be defined with a color name or with a hexadecimal color code. The
+default \code{color} value is \code{"#000000"} (black). The \code{style} can be one of
+either \code{"solid"} (the default), \code{"dashed"}, or \code{"dotted"}. The \code{weight} of
+the border lines is to be given in pixel values (the \code{\link[=px]{px()}} helper function
+is useful for this. The default value for \code{weight} is \code{"1px"}. Borders for
+any defined \code{sides} can be removed by supplying \code{NULL} to any of \code{color},
+\code{style}, or \code{weight}.}
 }
 \description{
 The \code{cell_borders()} helper function is to be used with the \code{\link[=tab_style]{tab_style()}}

--- a/man/cell_borders.Rd
+++ b/man/cell_borders.Rd
@@ -30,6 +30,56 @@ define which borders should be modified (e.g., \code{"left"}, \code{"right"}, et
 With that selection, the \code{color}, \code{style}, and \code{weight} of the selected
 borders can then be modified.
 }
+\examples{
+# Add horizontal border lines for
+# all table body rows in `exibble`
+tab_1 <-
+  exibble \%>\%
+    gt() \%>\%
+    tab_options(row.striping.include_table_body = FALSE) \%>\%
+    tab_style(
+      style = cell_borders(
+        sides = c("top", "bottom"),
+        color = "gray", weight = px(0.5), style = "solid"
+      ),
+      locations = cells_data(
+        columns = everything(),
+        rows = everything()
+      )
+    )
+
+# Incorporate different horizontal and
+# vertical borders at several locations;
+# this uses multiple `cell_borders()` and
+# `cells_data()` calls within `list()`s
+tab_2 <-
+  exibble \%>\%
+    gt() \%>\%
+    tab_style(
+      style = list(
+        cell_borders(
+          sides = c("top", "bottom"),
+          color = "red",
+          weight = px(2)
+        ),
+        cell_borders(
+          sides = c("left", "right"),
+          color = "blue",
+          weight = px(2)
+        )
+      ),
+      locations = list(
+        cells_data(
+          columns = vars(num),
+          rows = is.na(num)
+        ),
+        cells_data(
+          columns = vars(currency),
+          rows = is.na(currency)
+        )
+      )
+    )
+}
 \seealso{
 Other helper functions: \code{\link{cell_fill}},
   \code{\link{cell_text}}, \code{\link{cells_styles}},

--- a/man/cell_borders.Rd
+++ b/man/cell_borders.Rd
@@ -4,22 +4,21 @@
 \alias{cell_borders}
 \title{Helper for defining custom borders for table cells}
 \usage{
-cell_borders(selection, color = NULL, style = NULL, weight = NULL)
+cell_borders(sides = "all", color = "#000000", style = "solid",
+  weight = px(1))
 }
 \arguments{
-\item{selection}{The selection of borders to be modified. Options include
-\code{"left"}, \code{"right"}, \code{"top"}, and \code{"bottom"}. For all borders surrounding
-the selected cells, we can use the \code{"all"} option.}
+\item{sides}{The border sides to be modified. Options include \code{"left"},
+\code{"right"}, \code{"top"}, and \code{"bottom"}. For all borders surrounding the
+selected cells, we can use the \code{"all"} option.}
 
-\item{color}{The border color. If nothing is provided, then \code{"#000000"}
-(black) will be used as a default.}
+\item{color}{The border color. The default \code{"#000000"} (black) will be used
+as a default.}
 
 \item{style}{The border style. Can be one of either \code{"solid"} (the default),
-\code{"dashed"}, or \code{"dotted"}. If nothing is provided, then \code{"solid"} will be
-used as a default.}
+\code{"dashed"}, or \code{"dotted"}.}
 
-\item{weight}{The weight of the border lines. If nothing is provided, then
-\code{"1px"} will be used as a default.}
+\item{weight}{The weight of the border lines. The default value is \code{"1px"}.}
 }
 \description{
 The \code{cell_borders()} helper function is to be used with the \code{\link[=tab_style]{tab_style()}}

--- a/man/cells_styles.Rd
+++ b/man/cells_styles.Rd
@@ -58,7 +58,7 @@ also define several styles within a single call of \code{cells_styles()} and
 }
 \details{
 This function is now soft-deprecated, which means it will soon be removed.
-Please consider using the \code{\link[=cell_fill]{cell_fill()}} (where \code{bkgd_color} is \code{fill}) and
+Please consider using the \code{\link[=cell_fill]{cell_fill()}} (where \code{bkgd_color} is \code{color}) and
 \code{\link[=cell_text]{cell_text()}} (contains all other arguments here without the leading
 \code{text_}).
 }

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -111,6 +111,8 @@ argument. See the Arguments section for more information on this.
 }
 
 \examples{
+library(tidyr)
+
 # Use `exibble` to create a gt table;
 # format the `num` column as numeric
 # with three decimal places and with no

--- a/man/location_cells.Rd
+++ b/man/location_cells.Rd
@@ -91,6 +91,8 @@ intersections of \code{columns} and \code{rows}.
 }
 
 \examples{
+library(tidyr)
+
 # Use `sp500` to create a gt table; add
 # a header (with a title and a subtitle),
 # and then add a footnote to the subtitle


### PR DESCRIPTION
This is a fix `cell_borders()` being non-functional (https://github.com/rstudio/gt/issues/320).

Closes https://github.com/rstudio/gt/issues/320.
Closes https://github.com/rstudio/gt/issues/324.