### PR TITLE
Add `rstudio/sass` to Remotes list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,8 @@ Imports:
     stringr (>= 1.3.1),
     tibble (>= 1.4.2),
     tidyselect (>= 0.2.5)
+Remotes:
+    rstudio/sass
 Suggests:
     knitr,
     paletteer,


### PR DESCRIPTION
This change is necessary while **sass** is being fixed for resubmission to CRAN.

Fixes https://github.com/rstudio/gt/issues/325.