### PR TITLE
Several `rlang`-based fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ cache:
   packages: true
 warnings_are_errors: false
 
+# This library is required for installing the `rgl` pkg dependency
+addons:
+  apt:
+    packages:
+    - libglu1-mesa-dev
+
 r:
   - oldrel
   - release

--- a/R/resolver.R
+++ b/R/resolver.R
@@ -200,9 +200,7 @@ resolve_data_vals_idx <- function(var_expr,
     # Define function to get an expression from a
     # quosure and translate it to a character vector
     quo_get_expr_char <- function(x) {
-      x %>%
-        rlang::quo_get_expr() %>%
-        as.character()
+      rlang::as_name(x)
     }
 
     resolved <- vapply(resolved, quo_get_expr_char, character(1))

--- a/R/tab_footnote.R
+++ b/R/tab_footnote.R
@@ -88,7 +88,7 @@ set_footnote <- function(loc, data, footnote) {
 
 set_footnote.cells_title <- function(loc, data, footnote) {
 
-  if ((loc$groups %>% as.character())[-1] == "title") {
+  if ((loc$groups %>% rlang::as_name()) == "title") {
 
     attr(data, "footnotes_df") <-
       add_location_row_footnotes(
@@ -98,7 +98,7 @@ set_footnote.cells_title <- function(loc, data, footnote) {
         rownum = NA_character_, footnotes = footnote
       )
 
-  } else if ((loc$groups %>% as.character())[-1] == "subtitle") {
+  } else if ((loc$groups %>% rlang::as_name()) == "subtitle") {
 
     attr(data, "footnotes_df") <-
       add_location_row_footnotes(
@@ -145,7 +145,7 @@ set_footnote.cells_column_labels <- function(loc, data, footnote) {
 
   } else if (!is.null(loc$groups)) {
 
-    groups <- (loc$groups %>% as.character())[-1]
+    groups <- loc$groups %>% rlang::as_name()
 
     attr(data, "footnotes_df") <-
       add_location_row_footnotes(
@@ -161,7 +161,7 @@ set_footnote.cells_column_labels <- function(loc, data, footnote) {
 
 set_footnote.cells_group <- function(loc, data, footnote) {
 
-  groups <- (loc$groups %>% as.character())[-1]
+  groups <- loc$groups %>% rlang::as_name()
 
   attr(data, "footnotes_df") <-
     add_location_row_footnotes(

--- a/R/tab_footnote.R
+++ b/R/tab_footnote.R
@@ -88,7 +88,7 @@ set_footnote <- function(loc, data, footnote) {
 
 set_footnote.cells_title <- function(loc, data, footnote) {
 
-  if ((loc$groups %>% rlang::as_name()) == "title") {
+  if ((loc$groups %>% rlang::eval_tidy()) == "title") {
 
     attr(data, "footnotes_df") <-
       add_location_row_footnotes(
@@ -98,7 +98,7 @@ set_footnote.cells_title <- function(loc, data, footnote) {
         rownum = NA_character_, footnotes = footnote
       )
 
-  } else if ((loc$groups %>% rlang::as_name()) == "subtitle") {
+  } else if ((loc$groups %>% rlang::eval_tidy()) == "subtitle") {
 
     attr(data, "footnotes_df") <-
       add_location_row_footnotes(
@@ -145,7 +145,7 @@ set_footnote.cells_column_labels <- function(loc, data, footnote) {
 
   } else if (!is.null(loc$groups)) {
 
-    groups <- loc$groups %>% rlang::as_name()
+    groups <- loc$groups %>% rlang::eval_tidy()
 
     attr(data, "footnotes_df") <-
       add_location_row_footnotes(
@@ -161,7 +161,7 @@ set_footnote.cells_column_labels <- function(loc, data, footnote) {
 
 set_footnote.cells_group <- function(loc, data, footnote) {
 
-  groups <- loc$groups %>% rlang::as_name()
+  groups <- loc$groups %>% rlang::eval_tidy()
 
   attr(data, "footnotes_df") <-
     add_location_row_footnotes(

--- a/R/tab_style.R
+++ b/R/tab_style.R
@@ -172,7 +172,7 @@ set_style <- function(loc, data, style) {
 
 set_style.cells_title <- function(loc, data, style) {
 
-  if ((loc$groups %>% as.character())[-1] == "title") {
+  if ((loc$groups %>% rlang::as_name()) == "title") {
 
     attr(data, "styles_df") <-
       add_location_row_styles(
@@ -182,7 +182,7 @@ set_style.cells_title <- function(loc, data, style) {
         rownum = NA_character_, styles = list(style)
       )
 
-  } else if ((loc$groups %>% as.character())[-1] == "subtitle") {
+  } else if ((loc$groups  %>% rlang::as_name()) == "subtitle") {
 
     attr(data, "styles_df") <-
       add_location_row_styles(
@@ -229,7 +229,7 @@ set_style.cells_column_labels <- function(loc, data, style) {
 
   } else if (!is.null(loc$groups)) {
 
-    groups <- (loc$groups %>% as.character())[-1]
+    groups <- loc$groups %>% rlang::as_name()
 
     attr(data, "styles_df") <-
       add_location_row_styles(
@@ -245,7 +245,7 @@ set_style.cells_column_labels <- function(loc, data, style) {
 
 set_style.cells_group <- function(loc, data, style) {
 
-  groups <- (loc$groups %>% as.character())[-1]
+  groups <- loc$groups %>% rlang::as_name()
 
   attr(data, "styles_df") <-
     add_location_row_styles(

--- a/R/tab_style.R
+++ b/R/tab_style.R
@@ -172,7 +172,7 @@ set_style <- function(loc, data, style) {
 
 set_style.cells_title <- function(loc, data, style) {
 
-  if ((loc$groups %>% rlang::as_name()) == "title") {
+  if ((loc$groups %>% rlang::eval_tidy()) == "title") {
 
     attr(data, "styles_df") <-
       add_location_row_styles(
@@ -182,7 +182,7 @@ set_style.cells_title <- function(loc, data, style) {
         rownum = NA_character_, styles = list(style)
       )
 
-  } else if ((loc$groups  %>% rlang::as_name()) == "subtitle") {
+  } else if ((loc$groups %>% rlang::eval_tidy()) == "subtitle") {
 
     attr(data, "styles_df") <-
       add_location_row_styles(
@@ -229,7 +229,7 @@ set_style.cells_column_labels <- function(loc, data, style) {
 
   } else if (!is.null(loc$groups)) {
 
-    groups <- loc$groups %>% rlang::as_name()
+    groups <- loc$groups %>% rlang::eval_tidy()
 
     attr(data, "styles_df") <-
       add_location_row_styles(
@@ -245,7 +245,7 @@ set_style.cells_column_labels <- function(loc, data, style) {
 
 set_style.cells_group <- function(loc, data, style) {
 
-  groups <- loc$groups %>% rlang::as_name()
+  groups <- loc$groups %>% rlang::eval_tidy()
 
   attr(data, "styles_df") <-
     add_location_row_styles(

--- a/R/utils.R
+++ b/R/utils.R
@@ -964,6 +964,27 @@ flatten_list <- function(x) {
   x %>% unlist(recursive = FALSE)
 }
 
+#' Prepend a vector
+#'
+#' @param x The vector to be modified.
+#' @param values The values to be included in the modified vector.
+#' @param before A subscript, before which the values are to be appended.
+#' @noRd
+prepend_vec <- function(x,
+                        values,
+                        before = 1) {
+
+  n <- length(x)
+
+  stopifnot(before > 0 && before <= n)
+
+  if (before == 1) {
+    c(values, x)
+  } else {
+    c(x[1:(before - 1)], values, x[before:n])
+  }
+}
+
 #' Convert a single-length vector to a repeating list of lists
 #'
 #' @noRd

--- a/R/utils.R
+++ b/R/utils.R
@@ -966,23 +966,13 @@ flatten_list <- function(x) {
 
 #' Prepend a vector
 #'
-#' @param x The vector to be modified.
-#' @param values The values to be included in the modified vector.
-#' @param before A subscript, before which the values are to be appended.
+#' @inheritParams append
 #' @noRd
 prepend_vec <- function(x,
                         values,
-                        before = 1) {
+                        after = 0) {
 
-  n <- length(x)
-
-  stopifnot(before > 0 && before <= n)
-
-  if (before == 1) {
-    c(values, x)
-  } else {
-    c(x[1:(before - 1)], values, x[before:n])
-  }
+  append(x, values, after = after)
 }
 
 #' Convert a single-length vector to a repeating list of lists

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -328,9 +328,9 @@ create_columns_component_h <- function(boxh_df,
   # If `stub_available` == TRUE, then replace with a set stubhead
   # label or nothing
   if (stub_available && length(stubhead) > 0) {
-    headings <- rlang::prepend(headings, stubhead$label)
+    headings <- prepend_vec(headings, stubhead$label)
   } else if (stub_available) {
-    headings <- rlang::prepend(headings, "")
+    headings <- prepend_vec(headings, "")
   }
 
   # Ensure that column headings for right-aligned content

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -77,11 +77,11 @@ create_columns_component_l <- function(boxh_df,
   #   caption or nothing
   if (stub_available && length(stubhead) > 0) {
 
-    headings <- rlang::prepend(headings, stubhead$label)
+    headings <- prepend_vec(headings, stubhead$label)
 
   } else if (stub_available) {
 
-    headings <- rlang::prepend(headings, "")
+    headings <- prepend_vec(headings, "")
   }
 
   table_col_headings <-

--- a/tests/testthat/test-location_cells.R
+++ b/tests/testthat/test-location_cells.R
@@ -267,15 +267,14 @@ test_that("the `cells_summary()` function works correctly", {
   # Expect the RHS of the first component formula to contain
   # the vector provided
   helper_cells_summary[[1]] %>%
-    rlang::quo_squash() %>%
+    rlang::eval_tidy() %>%
     expect_equal("group_a")
 
   # Expect the RHS of the second component formula to contain
   # the vector provided
   helper_cells_summary[[2]] %>%
-    rlang::quo_squash() %>%
-    as.character() %>%
-    expect_equal(c("c", "col_1", "col_2"))
+    rlang::eval_tidy() %>%
+    expect_equal(c("col_1", "col_2"))
 
   # Create a `cells_summary` object with
   # columns in `vars()` provided to `columns`

--- a/tests/testthat/test-location_cells.R
+++ b/tests/testthat/test-location_cells.R
@@ -101,9 +101,10 @@ test_that("the `cells_column_labels()` function works correctly", {
 
   # Expect the RHS of the second component formula to
   # contain the vector provided
-  helper_cells_column_labels[[2]][2] %>%
+  helper_cells_column_labels[[2]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("c(\"group_1\", \"group_2\")")
+    expect_equal(c("c", "group_1", "group_2"))
 
   # Expect an error if values provided to both `columns` and `groups`
   expect_error(
@@ -135,9 +136,10 @@ test_that("the `cells_group()` function works correctly", {
   helper_cells_group[[1]] %>% expect_is(c("quosure", "formula"))
 
   # Expect the RHS of the first component formula to contain the vector provided
-  helper_cells_group[[1]][2] %>%
+  helper_cells_group[[1]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("c(\"group_1\", \"group_2\")")
+    expect_equal(c("c", "group_1", "group_2"))
 })
 
 test_that("the `cells_stub()` function works correctly", {
@@ -163,9 +165,10 @@ test_that("the `cells_stub()` function works correctly", {
   helper_cells_stub[[1]] %>% expect_is(c("quosure", "formula"))
 
   # Expect the RHS of the first component formula to contain the vector provided
-  helper_cells_stub[[1]][2] %>%
+  helper_cells_stub[[1]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("c(\"row_1\", \"row_2\")")
+    expect_equal(c("row_1", "row_2"))
 })
 
 test_that("the `cells_data()` function works correctly", {
@@ -191,9 +194,10 @@ test_that("the `cells_data()` function works correctly", {
   helper_cells_data[[1]] %>% expect_is(c("quosure", "formula"))
 
   # Expect the RHS of the first component formula to contain the vector provided
-  helper_cells_data[[1]][2] %>%
+  helper_cells_data[[1]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("c(\"col_1\", \"col_2\")")
+    expect_equal(c("c", "col_1", "col_2"))
 
   # Create a `cells_data` object with names provided to `columns` and `rows`
   helper_cells_data <-
@@ -222,15 +226,17 @@ test_that("the `cells_data()` function works correctly", {
   helper_cells_data[[2]] %>% expect_is(c("quosure", "formula"))
 
   # Expect the RHS of the first component formula to contain the vector provided
-  helper_cells_data[[1]][2] %>%
+  helper_cells_data[[1]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("c(\"col_1\", \"col_2\")")
+    expect_equal(c("c", "col_1", "col_2"))
 
   # Expect the RHS of the second component formula to contain
   # the vector provided
-  helper_cells_data[[2]][2] %>%
+  helper_cells_data[[2]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("c(\"row_1\", \"row_2\")")
+    expect_equal(c("c", "row_1", "row_2"))
 })
 
 test_that("the `cells_summary()` function works correctly", {
@@ -267,15 +273,16 @@ test_that("the `cells_summary()` function works correctly", {
 
   # Expect the RHS of the first component formula to contain
   # the vector provided
-  helper_cells_summary[[1]][2] %>%
-    as.character() %>%
+  helper_cells_summary[[1]] %>%
+    rlang::quo_expr() %>%
     expect_equal("group_a")
 
   # Expect the RHS of the second component formula to contain
   # the vector provided
-  helper_cells_summary[[2]][2] %>%
+  helper_cells_summary[[2]] %>%
+    rlang::quo_expr() %>%
     as.character() %>%
-    expect_equal("c(\"col_1\", \"col_2\")")
+    expect_equal(c("c", "col_1", "col_2"))
 
   # Create a `cells_summary` object with
   # columns in `vars()` provided to `columns`
@@ -287,9 +294,10 @@ test_that("the `cells_summary()` function works correctly", {
 
   # Expect the RHS of the second component formula to contain
   # the vector provided
-  helper_cells_summary[[2]][2] %>%
+  helper_cells_summary[[2]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("vars(col_1, col_2)")
+    expect_equal(c("vars", "col_1", "col_2"))
 })
 
 test_that("the `cells_grand_summary()` function works correctly", {
@@ -322,9 +330,10 @@ test_that("the `cells_grand_summary()` function works correctly", {
 
   # Expect the RHS of the first component formula to contain
   # the vector provided
-  helper_cells_grand_summary[[1]][2] %>%
+  helper_cells_grand_summary[[1]] %>%
+    rlang::quo_expr() %>%
     as.character() %>%
-    expect_equal("c(\"col_1\", \"col_2\")")
+    expect_equal(c("c", "col_1", "col_2"))
 
   # Create a `cells_grand_summary` object with
   # columns in `vars()` provided to `columns`
@@ -335,9 +344,10 @@ test_that("the `cells_grand_summary()` function works correctly", {
 
   # Expect the RHS of the first component formula to contain
   # the vector provided
-  helper_cells_grand_summary[[1]][2] %>%
+  helper_cells_grand_summary[[1]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("vars(col_1, col_2)")
+    expect_equal(c("vars", "col_1", "col_2"))
 })
 
 test_that("the `cells_stubhead()` function works correctly", {

--- a/tests/testthat/test-location_cells.R
+++ b/tests/testthat/test-location_cells.R
@@ -19,7 +19,7 @@ test_that("the `cells_title()` function works correctly", {
 
   # Expect the RHS of the formula to be 'title'
   helper_cells_title[[1]] %>%
-    rlang::quo_get_expr() %>%
+    rlang::eval_tidy() %>%
     expect_equal("title")
 
   # Create a `cells_title` object with the `subtitle` option
@@ -39,7 +39,7 @@ test_that("the `cells_title()` function works correctly", {
 
   # Expect the RHS of the formula to be 'subtitle'
   helper_cells_title[[1]] %>%
-    rlang::quo_get_expr() %>%
+    rlang::eval_tidy() %>%
     expect_equal("subtitle")
 })
 
@@ -71,9 +71,8 @@ test_that("the `cells_column_labels()` function works correctly", {
 
   # Expect the RHS of the first component formula to contain the vector provided
   helper_cells_column_labels[[1]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("c", "col_1", "col_2"))
+    rlang::eval_tidy() %>%
+    expect_equal(c("col_1", "col_2"))
 
   # Create a `cells_column_labels` object with names provided to `groups`
   helper_cells_column_labels <-
@@ -102,9 +101,8 @@ test_that("the `cells_column_labels()` function works correctly", {
   # Expect the RHS of the second component formula to
   # contain the vector provided
   helper_cells_column_labels[[2]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("c", "group_1", "group_2"))
+    rlang::eval_tidy() %>%
+    expect_equal(c("group_1", "group_2"))
 
   # Expect an error if values provided to both `columns` and `groups`
   expect_error(
@@ -137,9 +135,8 @@ test_that("the `cells_group()` function works correctly", {
 
   # Expect the RHS of the first component formula to contain the vector provided
   helper_cells_group[[1]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("c", "group_1", "group_2"))
+    rlang::eval_tidy() %>%
+    expect_equal(c("group_1", "group_2"))
 })
 
 test_that("the `cells_stub()` function works correctly", {
@@ -166,8 +163,7 @@ test_that("the `cells_stub()` function works correctly", {
 
   # Expect the RHS of the first component formula to contain the vector provided
   helper_cells_stub[[1]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
+    rlang::eval_tidy() %>%
     expect_equal(c("row_1", "row_2"))
 })
 
@@ -195,9 +191,8 @@ test_that("the `cells_data()` function works correctly", {
 
   # Expect the RHS of the first component formula to contain the vector provided
   helper_cells_data[[1]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("c", "col_1", "col_2"))
+    rlang::eval_tidy() %>%
+    expect_equal(c("col_1", "col_2"))
 
   # Create a `cells_data` object with names provided to `columns` and `rows`
   helper_cells_data <-
@@ -227,16 +222,14 @@ test_that("the `cells_data()` function works correctly", {
 
   # Expect the RHS of the first component formula to contain the vector provided
   helper_cells_data[[1]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("c", "col_1", "col_2"))
+    rlang::eval_tidy() %>%
+    expect_equal(c("col_1", "col_2"))
 
   # Expect the RHS of the second component formula to contain
   # the vector provided
   helper_cells_data[[2]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("c", "row_1", "row_2"))
+    rlang::eval_tidy() %>%
+    expect_equal(c("row_1", "row_2"))
 })
 
 test_that("the `cells_summary()` function works correctly", {
@@ -295,9 +288,9 @@ test_that("the `cells_summary()` function works correctly", {
   # Expect the RHS of the second component formula to contain
   # the vector provided
   helper_cells_summary[[2]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("vars", "col_1", "col_2"))
+    rlang::eval_tidy() %>%
+    vapply(rlang::as_name, USE.NAMES = FALSE, character(1)) %>%
+    expect_equal(c("col_1", "col_2"))
 })
 
 test_that("the `cells_grand_summary()` function works correctly", {
@@ -331,9 +324,8 @@ test_that("the `cells_grand_summary()` function works correctly", {
   # Expect the RHS of the first component formula to contain
   # the vector provided
   helper_cells_grand_summary[[1]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("c", "col_1", "col_2"))
+    rlang::eval_tidy() %>%
+    expect_equal(c("col_1", "col_2"))
 
   # Create a `cells_grand_summary` object with
   # columns in `vars()` provided to `columns`
@@ -345,9 +337,9 @@ test_that("the `cells_grand_summary()` function works correctly", {
   # Expect the RHS of the first component formula to contain
   # the vector provided
   helper_cells_grand_summary[[1]] %>%
-    rlang::quo_get_expr() %>%
-    as.character() %>%
-    expect_equal(c("vars", "col_1", "col_2"))
+    rlang::eval_tidy() %>%
+    vapply(rlang::as_name, USE.NAMES = FALSE, character(1)) %>%
+    expect_equal(c("col_1", "col_2"))
 })
 
 test_that("the `cells_stubhead()` function works correctly", {

--- a/tests/testthat/test-location_cells.R
+++ b/tests/testthat/test-location_cells.R
@@ -274,13 +274,13 @@ test_that("the `cells_summary()` function works correctly", {
   # Expect the RHS of the first component formula to contain
   # the vector provided
   helper_cells_summary[[1]] %>%
-    rlang::quo_expr() %>%
+    rlang::quo_squash() %>%
     expect_equal("group_a")
 
   # Expect the RHS of the second component formula to contain
   # the vector provided
   helper_cells_summary[[2]] %>%
-    rlang::quo_expr() %>%
+    rlang::quo_squash() %>%
     as.character() %>%
     expect_equal(c("c", "col_1", "col_2"))
 
@@ -331,7 +331,7 @@ test_that("the `cells_grand_summary()` function works correctly", {
   # Expect the RHS of the first component formula to contain
   # the vector provided
   helper_cells_grand_summary[[1]] %>%
-    rlang::quo_expr() %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
     expect_equal(c("c", "col_1", "col_2"))
 

--- a/tests/testthat/test-location_cells.R
+++ b/tests/testthat/test-location_cells.R
@@ -38,8 +38,8 @@ test_that("the `cells_title()` function works correctly", {
   helper_cells_title[[1]] %>% expect_is(c("quosure", "formula"))
 
   # Expect the RHS of the formula to be 'subtitle'
-  helper_cells_title[[1]][2] %>%
-    as.character() %>%
+  helper_cells_title[[1]] %>%
+    rlang::quo_get_expr() %>%
     expect_equal("subtitle")
 })
 
@@ -70,9 +70,10 @@ test_that("the `cells_column_labels()` function works correctly", {
   is.null(helper_cells_column_labels[[2]]) %>% expect_true()
 
   # Expect the RHS of the first component formula to contain the vector provided
-  helper_cells_column_labels[[1]][2] %>%
+  helper_cells_column_labels[[1]] %>%
+    rlang::quo_get_expr() %>%
     as.character() %>%
-    expect_equal("c(\"col_1\", \"col_2\")")
+    expect_equal(c("c", "col_1", "col_2"))
 
   # Create a `cells_column_labels` object with names provided to `groups`
   helper_cells_column_labels <-


### PR DESCRIPTION
This PR addresses several deprecations warnings from **rlang**. The warnings were surfaced from running **testthat** tests. These warnings were:

- `prepend() is deprecated as of rlang 0.4.0.`
- `Subsetting quosures with [ is deprecated as of rlang 0.4.0 (Please use quo_get_expr() instead.)`
- `quo_expr() is deprecated as of rlang 0.2.0. (Please use quo_squash() instead.)`
- `Using as.character() on a quosure is deprecated as of rlang 0.3.0. (Please use as_label() or as_name() instead.)`

All problems fixed now and all tests pass without any warnings.

Fixes: https://github.com/rstudio/gt/issues/316.