### PR TITLE
Fix for resolving row group cells

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ cache:
   packages: true
 warnings_are_errors: false
 
+# This library is required for installing the `rgl` pkg dependency
+addons:
+  apt:
+    packages:
+    - libglu1-mesa-dev
+
 r:
   - oldrel
   - release

--- a/R/tab_footnote.R
+++ b/R/tab_footnote.R
@@ -161,7 +161,17 @@ set_footnote.cells_column_labels <- function(loc, data, footnote) {
 
 set_footnote.cells_group <- function(loc, data, footnote) {
 
-  groups <- (loc$groups %>% as.character())[-1]
+  row_groups <- attr(data, "arrange_groups")$groups
+
+  # Resolve row groups
+  resolved_row_groups_idx <-
+    resolve_data_vals_idx(
+      var_expr = !!loc$groups,
+      data = NULL,
+      vals = row_groups
+    )
+
+  groups <- row_groups[resolved_row_groups_idx]
 
   attr(data, "footnotes_df") <-
     add_location_row_footnotes(

--- a/R/tab_style.R
+++ b/R/tab_style.R
@@ -245,7 +245,17 @@ set_style.cells_column_labels <- function(loc, data, style) {
 
 set_style.cells_group <- function(loc, data, style) {
 
-  groups <- (loc$groups %>% as.character())[-1]
+  row_groups <- attr(data, "arrange_groups")$groups
+
+  # Resolve row groups
+  resolved_row_groups_idx <-
+    resolve_data_vals_idx(
+      var_expr = !!loc$groups,
+      data = NULL,
+      vals = row_groups
+    )
+
+  groups <- row_groups[resolved_row_groups_idx]
 
   attr(data, "styles_df") <-
     add_location_row_styles(


### PR DESCRIPTION
This change uses the resolving function `resolve_data_vals_idx()` to correctly resolve the row group names from various types of inputs provided to `groups` in `cells_groups()`.

Fixes https://github.com/rstudio/gt/issues/308.