### PR TITLE
Allow use of integers in `pct()`/`px()`

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1003,7 +1003,7 @@ cell_style_structure <- function(name, obj, subclass = name) {
 #' @export
 pct <- function(x) {
 
-  if (!inherits(x, "numeric") && !inherits(x, "integer")) {
+  if (mode(x) != "numeric") {
     stop("The supplied value must be numeric", call. = FALSE)
   }
 
@@ -1018,7 +1018,7 @@ pct <- function(x) {
 #' @export
 px <- function(x) {
 
-  if (!inherits(x, "numeric") && !inherits(x, "integer")) {
+  if (mode(x) != "numeric") {
     stop("The supplied value must be numeric", call. = FALSE)
   }
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1003,7 +1003,7 @@ cell_style_structure <- function(name, obj, subclass = name) {
 #' @export
 pct <- function(x) {
 
-  if (!inherits(x, "numeric")) {
+  if (!inherits(x, "numeric") && !inherits(x, "integer")) {
     stop("The supplied value must be numeric", call. = FALSE)
   }
 
@@ -1018,7 +1018,7 @@ pct <- function(x) {
 #' @export
 px <- function(x) {
 
-  if (!inherits(x, "numeric")) {
+  if (!inherits(x, "numeric") && !inherits(x, "integer")) {
     stop("The supplied value must be numeric", call. = FALSE)
   }
 


### PR DESCRIPTION
Both the `pct()` and `px()` don't allow `integer`-class values as input (only `numeric`). This PR allows the use of integers, so, this will now work:

```r
sp500 %>%
  head() %>%
  gt() %>%
  tab_header(
    title = "S&P 500",
    subtitle = "5 rows"
  ) %>%
  tab_spanner(
    label = "prices",
    columns = vars(open, high, low, close)
  ) %>%
  fmt_date(
    columns = vars(date),
    date_style = 2
  ) %>%
  fmt_currency(
    columns = vars(open, high, low, close),
    currency = "USD"
  ) %>%
  fmt_number(
    columns = vars(volume),
    suffixing = TRUE
  ) %>%
  tab_options(
    table.font.size = px(10L)
  )
```

Fixes: https://github.com/rstudio/gt/issues/307.