### PR TITLE
Fix for `cells_stub()` stylizing helper function

### DIFF
--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -707,7 +707,7 @@ create_body_component_h <- function(output_df,
 
         styles_resolved_row <-
           styles_resolved %>%
-          dplyr::filter(rownum == i, locname == "data")
+          dplyr::filter(rownum == i, locname %in% c("stub", "data"))
 
         row_styles <-
           build_row_styles(


### PR DESCRIPTION
This is a simple fix to a `filter()` statement within `create_body_component_h()` that restores the ability to style stub cells. Here's a sample table after the fix is applied:

```r
sza %>%
  dplyr::filter(
    latitude == 20 & tst <= "1000") %>%
  dplyr::select(-latitude) %>%
  dplyr::filter(!is.na(sza)) %>%
  tidyr::spread(key = "tst", value = sza) %>%
  gt(rowname_col = "month") %>%
  fmt_missing(
    columns = TRUE,
    missing_text = ""
  ) %>%
  tab_style(
    style = list(
      cell_fill(color = "darkblue"),
      cell_text(color = "white")
    ),
    locations = cells_stub(rows = TRUE)
  ) %>%
  tab_style(
    style = list(
      cell_fill(color = "lightblue"),
      cell_text(color = "black")
    ),
    locations = cells_data(rows = TRUE)
  )
```

<img width="742" alt="cells_stub_fix" src="https://user-images.githubusercontent.com/5612024/62416055-3eb8d080-b602-11e9-86ae-383114006b9b.png">

Fixes: https://github.com/rstudio/gt/issues/339.