### PR TITLE
Enable option to set row group padding in `tab_options()`

### DIFF
--- a/R/gt_options_default.R
+++ b/R/gt_options_default.R
@@ -35,7 +35,7 @@ gt_options_default <- function() {
     "columns_border_bottom_style",        TRUE,  "columns",          "value",   "solid",
     "columns_border_bottom_width",        TRUE,  "columns",          "px",      "2px",
     "columns_border_bottom_color",        TRUE,  "columns",          "value",   "#A8A8A8",
-    "summary_row_padding",                TRUE,  "row_group",        "px",      "8px",
+    "row_group_padding",                  TRUE,  "row_group",        "px",      "8px",
     "row_group_background_color",         TRUE,  "row_group",        "value",   NA_character_,
     "row_group_font_size",                TRUE,  "row_group",        "px",      "16px",
     "row_group_font_weight",              TRUE,  "row_group",        "value",   "initial",

--- a/R/gt_options_default.R
+++ b/R/gt_options_default.R
@@ -35,6 +35,7 @@ gt_options_default <- function() {
     "columns_border_bottom_style",        TRUE,  "columns",          "value",   "solid",
     "columns_border_bottom_width",        TRUE,  "columns",          "px",      "2px",
     "columns_border_bottom_color",        TRUE,  "columns",          "value",   "#A8A8A8",
+    "summary_row_padding",                TRUE,  "row_group",        "px",      "8px",
     "row_group_background_color",         TRUE,  "row_group",        "value",   NA_character_,
     "row_group_font_size",                TRUE,  "row_group",        "px",      "16px",
     "row_group_font_weight",              TRUE,  "row_group",        "value",   "initial",

--- a/R/tab_options.R
+++ b/R/tab_options.R
@@ -42,12 +42,12 @@
 #'   the value is given in units of pixels. The [px()] and [pct()] helper
 #'   functions can also be used to pass in numeric values and obtain values as
 #'   pixel or percent units.
-#' @param column_labels.font.weight,row_group.font.weight the font weight of
+#' @param column_labels.font.weight,row_group.font.weight The font weight of
 #'   the `columns` and `row_group` text element.
-#' @param summary_row.text_transform,grand_summary_row.text_transform an option
+#' @param summary_row.text_transform,grand_summary_row.text_transform An option
 #'   to apply text transformations to the label text in each summary row.
 #' @param table.background.color,heading.background.color,column_labels.background.color,row_group.background.color,summary_row.background.color,grand_summary_row.background.color
-#'   background colors for the parent element `table` and the following child
+#'   Background colors for the parent element `table` and the following child
 #'   elements: `heading`, `columns`, `row_group`, `summary_row`, and
 #'   `table_body`. A color name or a hexadecimal color code should be provided.
 #' @param table.border.top.style,table.border.top.width,table.border.top.color
@@ -61,10 +61,10 @@
 #' @param table_body.border.top.style,table_body.border.top.width,table_body.border.top.color
 #'   The style, width, and color of the table body's top border.
 #' @param table_body.border.bottom.style,table_body.border.bottom.width,table_body.border.bottom.color
-#'   the style, width, and color of the table body's bottom border.
-#' @param row.padding,summary_row.padding,grand_summary_row.padding the amount
-#'   of padding in each row and in each type of summary row.
-#' @param footnote.sep the separating characters between adjacent footnotes in
+#'   The style, width, and color of the table body's bottom border.
+#' @param row.padding,row_group.padding,summary_row.padding,grand_summary_row.padding
+#'   The amount of padding in each type of row.
+#' @param footnote.sep The separating characters between adjacent footnotes in
 #'   the footnotes section. The default value produces a linebreak.
 #' @param footnote.marks The set of sequential marks used to reference and
 #'   identify each of the footnotes (same input as the [opt_footnote_marks()]
@@ -203,6 +203,7 @@ tab_options <- function(data,
                         column_labels.font.size = NULL,
                         column_labels.font.weight = NULL,
                         column_labels.hidden = NULL,
+                        row_group.padding = NULL,
                         row_group.background.color = NULL,
                         row_group.font.size = NULL,
                         row_group.font.weight = NULL,

--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -82,7 +82,7 @@
   }
 
   .gt_group_heading {
-    padding: 8px;
+    padding: $row_group_padding; /* row_group.padding */
     color: font-color($row_group_background_color);
     background-color: $row_group_background_color; /* row_group.background.color */
     font-size: $row_group_font_size; /* row_group.font.size */

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -17,10 +17,10 @@ tab_options(data, container.width = NULL, container.height = NULL,
   heading.border.bottom.color = NULL,
   column_labels.background.color = NULL,
   column_labels.font.size = NULL, column_labels.font.weight = NULL,
-  column_labels.hidden = NULL, row_group.background.color = NULL,
-  row_group.font.size = NULL, row_group.font.weight = NULL,
-  row_group.border.top.style = NULL, row_group.border.top.width = NULL,
-  row_group.border.top.color = NULL,
+  column_labels.hidden = NULL, row_group.padding = NULL,
+  row_group.background.color = NULL, row_group.font.size = NULL,
+  row_group.font.weight = NULL, row_group.border.top.style = NULL,
+  row_group.border.top.width = NULL, row_group.border.top.color = NULL,
   row_group.border.bottom.style = NULL,
   row_group.border.bottom.width = NULL,
   row_group.border.bottom.color = NULL,
@@ -87,7 +87,7 @@ the value is given in units of pixels. The \code{\link[=px]{px()}} and \code{\li
 functions can also be used to pass in numeric values and obtain values as
 pixel or percent units.}
 
-\item{table.background.color, heading.background.color, column_labels.background.color, row_group.background.color, summary_row.background.color, grand_summary_row.background.color}{background colors for the parent element \code{table} and the following child
+\item{table.background.color, heading.background.color, column_labels.background.color, row_group.background.color, summary_row.background.color, grand_summary_row.background.color}{Background colors for the parent element \code{table} and the following child
 elements: \code{heading}, \code{columns}, \code{row_group}, \code{summary_row}, and
 \code{table_body}. A color name or a hexadecimal color code should be provided.}
 
@@ -95,7 +95,7 @@ elements: \code{heading}, \code{columns}, \code{row_group}, \code{summary_row}, 
 
 \item{heading.border.bottom.style, heading.border.bottom.width, heading.border.bottom.color}{The style, width, and color of the heading's bottom border.}
 
-\item{column_labels.font.weight, row_group.font.weight}{the font weight of
+\item{column_labels.font.weight, row_group.font.weight}{The font weight of
 the \code{columns} and \code{row_group} text element.}
 
 \item{column_labels.hidden}{An option to hide the column labels.}
@@ -106,15 +106,14 @@ the \code{columns} and \code{row_group} text element.}
 
 \item{table_body.border.top.style, table_body.border.top.width, table_body.border.top.color}{The style, width, and color of the table body's top border.}
 
-\item{table_body.border.bottom.style, table_body.border.bottom.width, table_body.border.bottom.color}{the style, width, and color of the table body's bottom border.}
+\item{table_body.border.bottom.style, table_body.border.bottom.width, table_body.border.bottom.color}{The style, width, and color of the table body's bottom border.}
 
-\item{row.padding, summary_row.padding, grand_summary_row.padding}{the amount
-of padding in each row and in each type of summary row.}
+\item{row.padding, row_group.padding, summary_row.padding, grand_summary_row.padding}{The amount of padding in each type of row.}
 
-\item{summary_row.text_transform, grand_summary_row.text_transform}{an option
+\item{summary_row.text_transform, grand_summary_row.text_transform}{An option
 to apply text transformations to the label text in each summary row.}
 
-\item{footnote.sep}{the separating characters between adjacent footnotes in
+\item{footnote.sep}{The separating characters between adjacent footnotes in
 the footnotes section. The default value produces a linebreak.}
 
 \item{footnote.marks}{The set of sequential marks used to reference and


### PR DESCRIPTION
This PR allows us to use the `row_group.padding` option in `tab_options()` to specify a common padding value for row groups in a **gt** table (instead of the `8px` default). 

Here is an example:

```r
exibble %>%
  gt(rowname_col = "row", groupname_col = "group") %>%
  tab_options(row_group.padding = px(24))
```

<img width="924" alt="row_group_padding" src="https://user-images.githubusercontent.com/5612024/62496071-cee34b00-b7a5-11e9-8d40-f263f83fbc8a.png">

Fixes: https://github.com/rstudio/gt/issues/327.