### PR TITLE
Fix for invisible top borders in rendered HTML tables

### DIFF
--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -126,9 +126,9 @@
   .gt_row {
     padding: $row_padding; /* row.padding */
     margin: 10px;
-    border-bottom-style: solid;
-    border-bottom-width: thin;
-    border-bottom-color: #D3D3D3;
+    border-top-style: solid;
+    border-top-width: 1px;
+    border-top-color: #D3D3D3;
     vertical-align: middle;
     overflow-x: hidden;
   }

--- a/tests/testthat/test-util_functions.R
+++ b/tests/testthat/test-util_functions.R
@@ -431,8 +431,8 @@ test_that("the `inline_html_styles()` function works correctly", {
   expect_true(
     grepl(
       paste0(
-        "style=\"padding: 8px; margin: 10px; border-bottom-style: solid; ",
-        "border-bottom-width: thin; border-bottom-color: #D3D3D3; ",
+        "style=\"padding: 8px; margin: 10px; border-top-style: solid; ",
+        "border-top-width: 1px; border-top-color: #D3D3D3; ",
         "vertical-align: middle; overflow-x: hidden; text-align: right; ",
         "font-variant-numeric: tabular-nums; font-size: 10px;\""
       ),


### PR DESCRIPTION
This PR addresses the problem whereby gt tables, when rendered as HTML, have invisible top lines of cell borders (not visible unless `2px` or larger).

The problem is isolated to the CSS rules of the `gt_row` class:

```scss
  .gt_row {
    padding: $row_padding; /* row.padding */
    margin: 10px;
    border-bottom-style: solid;
    border-bottom-width: thin;
    border-bottom-color: #D3D3D3;
    vertical-align: middle;
    overflow-x: hidden;
  }
```

Substituting all `border-bottom-*` rules for `border-top-*` avoids the line-drawing conflict between row lines and border lines. That is the only change in this PR and, through several visual tests, the changes made here fix the display issue.

Fixes: https://github.com/rstudio/gt/issues/358.