### PR TITLE
Fix testthat tests

### DIFF
--- a/tests/testthat/test-gtsave.R
+++ b/tests/testthat/test-gtsave.R
@@ -24,16 +24,12 @@ test_that("the `gtsave()` function creates an HTML file based on the extension",
   # Expect that the content of the file is HTML
   (path_1 %>%
       readLines()) %>% paste(collapse = "\n") %>%
-    expect_match(
-      "<!DOCTYPE html>",
-      fixed = TRUE)
+    tidy_grepl("<!DOCTYPE html>")
 
   # Expect that CSS styles are not inlined
   (path_1 %>%
       readLines()) %>% paste(collapse = "\n") %>%
-    expect_match(
-      "<style>html {",
-      fixed = TRUE)
+    expect_match("<style>html \\{")
 
   # Create a filename with path, having the
   # .htm extension
@@ -55,18 +51,16 @@ test_that("the `gtsave()` function creates an HTML file based on the extension",
   expect_true(file.exists(path_2))
 
   # Expect that the content of the file is HTML
-  (path_2 %>%
-      readLines())[1] %>%
-    expect_match(
-      "<!DOCTYPE html>",
-      fixed = TRUE)
+  (path_1 %>%
+      readLines()) %>% paste(collapse = "\n") %>%
+    tidy_grepl("<!DOCTYPE html>") %>%
+    expect_true()
 
   # Expect that CSS styles are not inlined
-  (path_2 %>%
-      readLines())[9] %>%
-    expect_match(
-      "<style>html {",
-      fixed = TRUE)
+  (path_1 %>%
+      readLines()) %>% paste(collapse = "\n") %>%
+    tidy_grepl("<style>html \\{") %>%
+    expect_true()
 
   # Create a filename with path, having the
   # .html extension
@@ -85,17 +79,16 @@ test_that("the `gtsave()` function creates an HTML file based on the extension",
     gtsave(filename = path_3, inline_css = TRUE)
 
   # Expect that the content of the file is HTML
-  (path_3 %>%
-      readLines())[1] %>%
-    expect_match(
-      "<!DOCTYPE html>",
-      fixed = TRUE)
+  (path_1 %>%
+      readLines()) %>% paste(collapse = "\n") %>%
+    tidy_grepl("<!DOCTYPE html>") %>%
+    expect_true()
 
-  # Expect that CSS styles are indeed inlined
-  (path_3 %>%
-      readLines())[9] %>%
-    expect_match(
-      "<table style.*")
+  # Expect that CSS styles are not inlined
+  (path_1 %>%
+      readLines()) %>% paste(collapse = "\n") %>%
+    tidy_grepl("<style>html \\{") %>%
+    expect_true()
 })
 
 # test_that("the `gtsave()` function creates a LaTeX file based on the extension", {

--- a/tests/testthat/test-gtsave.R
+++ b/tests/testthat/test-gtsave.R
@@ -24,12 +24,14 @@ test_that("the `gtsave()` function creates an HTML file based on the extension",
   # Expect that the content of the file is HTML
   (path_1 %>%
       readLines()) %>% paste(collapse = "\n") %>%
-    tidy_grepl("<!DOCTYPE html>")
+    tidy_grepl("<!DOCTYPE html>") %>%
+    expect_true()
 
   # Expect that CSS styles are not inlined
   (path_1 %>%
       readLines()) %>% paste(collapse = "\n") %>%
-    expect_match("<style>html \\{")
+    tidy_grepl("<style>html \\{") %>%
+    expect_true()
 
   # Create a filename with path, having the
   # .htm extension


### PR DESCRIPTION
With an update in testthat, these tests worked fine locally but failed on Travis. I modified the approach to use `... %>% tidy_grepl() %>% expect_true()` instead of `expect_match()`. With this change, tests now pass on Travis (and locally, as before). 