### PR TITLE
Add vertical align option in `cell_text()`

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -695,6 +695,8 @@ cells_styles <- function(bkgd_color = NULL,
 #'   numeric mapping of weight.
 #' @param align The text alignment. Can be one of either `"center"`, `"left"`,
 #'   `"right"`, or `"justify"`.
+#' @param v_align The vertical alignment of the text in the cell. Options are
+#'   `"center"`, `"top"`, or `"bottom"`.
 #' @param stretch Allows for text to either be condensed or expanded. We can use
 #'   one of the following text-based keywords to describe the degree of
 #'   condensation/expansion: `"ultra-condensed"`, `"extra-condensed"`,
@@ -714,6 +716,7 @@ cell_text <- function(color = NULL,
                       font = NULL,
                       size = NULL,
                       align = NULL,
+                      v_align = NULL,
                       style = NULL,
                       weight = NULL,
                       stretch = NULL,
@@ -740,6 +743,11 @@ cell_text <- function(color = NULL,
   validate_style_in(
     style_vals, style_names, "align",
     c("center", "left", "right", "justify")
+  )
+
+  validate_style_in(
+    style_vals, style_names, "v_align",
+    c("center", "top", "bottom")
   )
 
   validate_style_in(
@@ -781,6 +789,7 @@ cell_style_to_html.cell_text <- function(style) {
       font = "font-family",
       size = "font-size",
       align = "text-align",
+      v_align = "vertical-align",
       style = "font-style",
       weight = "font-weight",
       stretch = "font-stretch",

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -696,7 +696,7 @@ cells_styles <- function(bkgd_color = NULL,
 #' @param align The text alignment. Can be one of either `"center"`, `"left"`,
 #'   `"right"`, or `"justify"`.
 #' @param v_align The vertical alignment of the text in the cell. Options are
-#'   `"center"`, `"top"`, or `"bottom"`.
+#'   `"middle"`, `"top"`, or `"bottom"`.
 #' @param stretch Allows for text to either be condensed or expanded. We can use
 #'   one of the following text-based keywords to describe the degree of
 #'   condensation/expansion: `"ultra-condensed"`, `"extra-condensed"`,
@@ -747,7 +747,7 @@ cell_text <- function(color = NULL,
 
   validate_style_in(
     style_vals, style_names, "v_align",
-    c("center", "top", "bottom")
+    c("middle", "top", "bottom")
   )
 
   validate_style_in(

--- a/man/cell_text.Rd
+++ b/man/cell_text.Rd
@@ -24,7 +24,7 @@ or \code{"xx-large"}.}
 \code{"right"}, or \code{"justify"}.}
 
 \item{v_align}{The vertical alignment of the text in the cell. Options are
-\code{"center"}, \code{"top"}, or \code{"bottom"}.}
+\code{"middle"}, \code{"top"}, or \code{"bottom"}.}
 
 \item{style}{The text style. Can be one of either \code{"center"}, \code{"normal"},
 \code{"italic"}, or \code{"oblique"}.}

--- a/man/cell_text.Rd
+++ b/man/cell_text.Rd
@@ -5,8 +5,8 @@
 \title{Helper for defining custom text styles for table cells}
 \usage{
 cell_text(color = NULL, font = NULL, size = NULL, align = NULL,
-  style = NULL, weight = NULL, stretch = NULL, indent = NULL,
-  decorate = NULL, transform = NULL)
+  v_align = NULL, style = NULL, weight = NULL, stretch = NULL,
+  indent = NULL, decorate = NULL, transform = NULL)
 }
 \arguments{
 \item{color}{The text color.}
@@ -22,6 +22,9 @@ or \code{"xx-large"}.}
 
 \item{align}{The text alignment. Can be one of either \code{"center"}, \code{"left"},
 \code{"right"}, or \code{"justify"}.}
+
+\item{v_align}{The vertical alignment of the text in the cell. Options are
+\code{"center"}, \code{"top"}, or \code{"bottom"}.}
 
 \item{style}{The text style. Can be one of either \code{"center"}, \code{"normal"},
 \code{"italic"}, or \code{"oblique"}.}


### PR DESCRIPTION
This allows for selected cells to have their contents vertically aligned (`top`, `center`, and `bottom`). Currently, the vertical alignment of all cell content is `center`; there's no easy way to change this.

This option is useful for tables with large chunks of text, where the less verbose columns end up way down the page. 

Here is an example where the option is used effectively:

```r
library(gt)
library(stringi)

long_text <- 
  stri_rand_lipsum(3) %>%
  str_c(., collapse = "\n")


data.frame(
  index = c("I want this", "at the top", "of each cell"),
  text = long_text
)  %>% 
  gt() %>%
  tab_style(
    style = cell_text(v_align = "top"),
    locations = cells_data()
  )
```

<img width="967" alt="vertical_align_cells" src="https://user-images.githubusercontent.com/5612024/69105325-ed114600-0a38-11ea-803f-098c0c7e765f.png">

All CI tests pass with this fairly minimal change.

Fixes https://github.com/rstudio/gt/issues/380