### PR TITLE
Fix error with `fmt_number()` on an NA-only column

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ BugReports: https://github.com/rstudio/gt/issues
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 Depends:
     R (>= 3.2.0)
 Imports: 

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -162,11 +162,6 @@ fmt_number <- function(data,
       pattern = pattern,
       format_fn = function(x, context) {
 
-        # Return `x` if the length of it is zero
-        if (length(x) == 0) {
-          return(x)
-        }
-
         # Create the `suffix_df` object
         suffix_df <- create_suffix_df(x, decimals, suffix_labels, scale_by)
 

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -162,7 +162,10 @@ fmt_number <- function(data,
       pattern = pattern,
       format_fn = function(x, context) {
 
-        x_str <- character(length(x))
+        # Return `x` if the length of it is zero
+        if (length(x) == 0) {
+          return(x)
+        }
 
         # Create the `suffix_df` object
         suffix_df <- create_suffix_df(x, decimals, suffix_labels, scale_by)

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -645,6 +645,10 @@ num_fmt_factory <- function(context,
     # Create a possibly shorter vector of non-NA `x` values
     x_vals <- x[non_na_x]
 
+    if (length(x_vals) == 0) {
+      return(character(0))
+    }
+
     # Apply a series of transformations to `x_str_vals`
     x_str_vals <-
       x_vals %>%

--- a/tests/testthat/test-fmt_number.R
+++ b/tests/testthat/test-fmt_number.R
@@ -21,15 +21,6 @@ test_that("the `fmt_number()` function works correctly", {
   # Expect that the object has the correct classes
   expect_is(tab, c("gt_tbl", "data.frame"))
 
-  # Expect certain named attributes
-  # expect_true(
-  #   all(
-  #     names(attributes(tab)) %in%
-  #       c("names", "class", "row.names",
-  #         "boxh_df", "stub_df", "footnotes_df", "styles_df",
-  #         "rows_df", "cols_df", "col_labels", "grp_labels",
-  #         "arrange_groups", "data_df", "opts_df", "formats", "transforms")))
-
   # Extract vectors from the table object for comparison
   # to the original dataset
   char_1 <- (tab %>% dt_data_get())[["char_1"]]
@@ -184,6 +175,38 @@ test_that("the `fmt_number()` function works correctly", {
        fmt_number(columns = "num_1", decimals = 2, locale = "gl_ES") %>%
        render_formats_test("html"))[["num_1"]],
     c("1.836,23", "2.763,39", "937,29", "643,00", "212,23", "0,00", "&minus;23,24"))
+
+  # Expect that a column with NAs will work fine with `fmt_number()`,
+  # it'll just produce NA values
+  na_col_tbl <- dplyr::tibble(a = rep(NA_real_, 10)) %>% gt()
+
+  # Expect a returned object of class `gt_tbl` with various
+  # uses of `fmt_number()`
+  expect_s3_class(
+    na_col_tbl %>%
+      fmt_number(columns = vars(a)),
+    "gt_tbl"
+  )
+  expect_s3_class(
+    na_col_tbl %>%
+      fmt_number(columns = vars(a), rows = 1:5),
+    "gt_tbl"
+  )
+  expect_s3_class(
+    na_col_tbl %>%
+      fmt_number(columns = vars(a), scale_by = 100),
+    "gt_tbl"
+  )
+  expect_s3_class(
+    na_col_tbl %>%
+      fmt_number(columns = vars(a), suffixing = TRUE),
+    "gt_tbl"
+  )
+  expect_s3_class(
+    na_col_tbl %>%
+      fmt_number(columns = vars(a), pattern = "a{x}b"),
+    "gt_tbl"
+  )
 })
 
 test_that("the `fmt_number()` function can scale/suffix larger numbers", {

--- a/tests/testthat/test-fmt_number.R
+++ b/tests/testthat/test-fmt_number.R
@@ -178,34 +178,37 @@ test_that("the `fmt_number()` function works correctly", {
 
   # Expect that a column with NAs will work fine with `fmt_number()`,
   # it'll just produce NA values
-  na_col_tbl <- dplyr::tibble(a = rep(NA_real_, 10)) %>% gt()
+  na_col_tbl <- dplyr::tibble(a = rep(NA_real_, 10), b = 1:10) %>% gt()
 
   # Expect a returned object of class `gt_tbl` with various
   # uses of `fmt_number()`
-  expect_s3_class(
-    na_col_tbl %>%
-      fmt_number(columns = vars(a)),
-    "gt_tbl"
+  expect_error(
+    na_col_tbl %>% fmt_number(columns = vars(a)) %>% as_raw_html(), NA
   )
-  expect_s3_class(
+  expect_error(
     na_col_tbl %>%
-      fmt_number(columns = vars(a), rows = 1:5),
-    "gt_tbl"
+      fmt_number(columns = vars(a), rows = 1:5) %>% as_raw_html(), NA
   )
-  expect_s3_class(
+  expect_error(
     na_col_tbl %>%
-      fmt_number(columns = vars(a), scale_by = 100),
-    "gt_tbl"
+      fmt_number(columns = vars(a), scale_by = 100) %>% as_raw_html(), NA
   )
-  expect_s3_class(
+  expect_error(
     na_col_tbl %>%
-      fmt_number(columns = vars(a), suffixing = TRUE),
-    "gt_tbl"
+      fmt_number(columns = vars(a), suffixing = TRUE) %>% as_raw_html(), NA
   )
-  expect_s3_class(
+  expect_error(
     na_col_tbl %>%
-      fmt_number(columns = vars(a), pattern = "a{x}b"),
-    "gt_tbl"
+      fmt_number(columns = vars(a), pattern = "a{x}b") %>% as_raw_html(), NA
+  )
+
+  # Expect that two columns being formatted (one entirely NA) will work
+  expect_equal(
+    (na_col_tbl %>%
+       fmt_number(columns = vars(a)) %>%
+       fmt_number(columns = vars(b)) %>% render_formats_test("html"))[["b"]],
+    c("1.00", "2.00", "3.00", "4.00", "5.00", "6.00", "7.00", "8.00",
+      "9.00", "10.00")
   )
 })
 


### PR DESCRIPTION
Critical test is:

```r
library(gt)
library(tidyverse)

tbl <- 
  dplyr::tibble(
    groups = c(rep("one", 5), rep("two", 5)),
    rows = 1:10,
    a = NA_real_
  )

tbl %>%
  gt() %>%
  fmt_number(columns = vars(a))
```

Which shouldn't fail any more, but result in a column of unchanged NAs.


Fixes: https://github.com/rstudio/gt/issues/408