### PR TITLE
Implement fix for UTF-8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ BugReports: https://github.com/rstudio/gt/issues
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 Depends:
     R (>= 3.2.0)
 Imports: 

--- a/R/utils.R
+++ b/R/utils.R
@@ -968,6 +968,7 @@ validate_length_one <- function(x, name) {
 }
 
 # print8 <- function(x) {
+#   force(x)
 #
 #   old_ctype <- Sys.getlocale("LC_CTYPE")
 #   Sys.setlocale("LC_CTYPE", "en_CA.UTF-8")

--- a/R/utils.R
+++ b/R/utils.R
@@ -966,3 +966,12 @@ validate_length_one <- function(x, name) {
          call. = FALSE)
   }
 }
+
+# print8 <- function(x) {
+#
+#   old_ctype <- Sys.getlocale("LC_CTYPE")
+#   Sys.setlocale("LC_CTYPE", "en_CA.UTF-8")
+#   on.exit(Sys.setlocale("LC_CTYPE", old_ctype), add = TRUE)
+#
+#   print(x)
+# }

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -113,12 +113,12 @@ migrate_unformatted_to_output <- function(data,
         lapply(
           data_tbl[[colname]][row_index],
           function(x) {
+
+            if (is.numeric(x)) {
+              x <- format(x, drop0trailing = FALSE, trim = TRUE, justify = "none")
+            }
+
             x %>%
-              format(
-                drop0trailing = FALSE,
-                trim = TRUE,
-                justify = "none"
-              ) %>%
               tidy_gsub("\\s+$", "") %>%
               process_text(context) %>%
               paste(collapse = ", ")
@@ -128,14 +128,13 @@ migrate_unformatted_to_output <- function(data,
     } else {
 
       # No `lapply()` used: all values will be treated cohesively
-      body[[colname]][row_index] <-
-        format(
-          data_tbl[[colname]][row_index],
-          drop0trailing = FALSE,
-          trim = TRUE,
-          justify = "none"
-        ) %>%
-        process_text(context)
+      vals <- data_tbl[[colname]][row_index]
+
+      if (is.numeric(vals)) {
+        vals <- format(vals, drop0trailing = FALSE, trim = TRUE, justify = "none")
+      }
+
+      body[[colname]][row_index] <- vals %>% process_text(context)
     }
   }
 

--- a/tests/testthat/test-gt_object.R
+++ b/tests/testthat/test-gt_object.R
@@ -1,5 +1,19 @@
 context("Ensuring that the `gt()` function works as expected")
 
+# Function to skip tests if Suggested packages not available on system
+check_suggests <- function() {
+  skip_if_not_installed("rvest")
+  skip_if_not_installed("xml2")
+}
+
+# Gets the inner HTML text from a single value
+selection_text <- function(html, selection) {
+
+  html %>%
+    rvest::html_nodes(selection) %>%
+    rvest::html_text()
+}
+
 test_that("a gt table object contains the correct components", {
 
   # Create a `gt_tbl` object with `gt()`
@@ -141,4 +155,82 @@ test_that("a gt table can be made from a table with no rows", {
   # usual components and that they have all of the
   # expected dimensions and features
   expect_tab(tab = tab, df = data_e %>% dplyr::group_by(group))
+})
+
+test_that("a gt table can use UTF-8 chars in any system locale", {
+
+  # Check that specific suggested packages are available
+  check_suggests()
+
+  # Skip these tests if the platform is Windows or Solaris
+  skip_on_os(os = c("windows", "solaris"))
+
+  system_locales <-
+    c("nl_NL.UTF-8", "pt_BR.UTF-8", "cs_CZ.UTF-8", "zh_CN.UTF-8",
+      "en_US.UTF-8", "sk_SK.UTF-8", "de_DE.UTF-8", "am_ET.UTF-8", "be_BY.UTF-8",
+      "af_ZA.UTF-8", "ro_RO.UTF-8", "en_NZ.UTF-8", "fi_FI.UTF-8", "hr_HR.UTF-8",
+      "da_DK.UTF-8", "de_AT.UTF-8", "en_AU.UTF-8", "hu_HU.UTF-8", "et_EE.UTF-8",
+      "he_IL.UTF-8", "fr_BE.UTF-8", "fr_CH.UTF-8", "sl_SI.UTF-8", "pl_PL.UTF-8",
+      "sv_SE.UTF-8", "sr_YU.UTF-8", "de_CH.UTF-8", "pt_PT.UTF-8", "ca_ES.UTF-8",
+      "en_GB.UTF-8", "ru_RU.UTF-8", "eu_ES.UTF-8", "it_CH.UTF-8", "nl_BE.UTF-8",
+      "lt_LT.UTF-8", "is_IS.UTF-8", "zh_TW.UTF-8", "el_GR.UTF-8", "it_IT.UTF-8",
+      "en_CA.UTF-8", "uk_UA.UTF-8", "zh_HK.UTF-8", "bg_BG.UTF-8", "ja_JP.UTF-8",
+      "fr_FR.UTF-8", "ko_KR.UTF-8", "kk_KZ.UTF-8", "en_IE.UTF-8", "fr_CA.UTF-8",
+      "hy_AM.UTF-8", "no_NO.UTF-8", "es_ES.UTF-8", "tr_TR.UTF-8",
+      "en_NZ", "af_ZA", "bg_BG", "fi_FI", "eu_ES", "nl_BE", "fr_BE", "sk_SK",
+      "de_CH", "zh_HK", "uk_UA", "en_US", "am_ET", "sv_SE", "be_BY", "kk_KZ",
+      "it_CH", "pt_BR", "ko_KR", "it_IT", "zh_TW", "en_CA", "pt_PT", "hr_HR",
+      "cs_CZ", "fr_CH", "he_IL", "fr_CA", "sl_SI", "ro_RO", "ja_JP", "zh_CN",
+      "nl_NL", "hy_AM", "hu_HU", "en_AU", "en_GB", "et_EE", "ca_ES", "sr_YU",
+      "ru_RU", "is_IS", "es_ES", "el_GR", "da_DK", "no_NO", "en_IE", "pl_PL",
+      "fr_FR", "de_AT", "de_DE", "lt_LT", "tr_TR",
+      "C", "POSIX"
+    )
+
+  names_df <-
+    data.frame(
+      first = c("\u6625", "Fred"),
+      last = c("\u9ad8","B\u00e4ckhed"),
+      stringsAsFactors = FALSE
+    )
+
+  # Function to check for identical vectors in a df processed by
+  # gt and an expectation vector
+  test_df_output_with_sys_locale <- function(df, locale, expected_vec) {
+
+    old_ctype <- Sys.getlocale("LC_CTYPE")
+    Sys.setlocale("LC_CTYPE", locale = locale)
+    on.exit(Sys.setlocale("LC_CTYPE", old_ctype), add = TRUE)
+
+    # Expect that UTF-8 characters are retained in the
+    # gt object after rendering
+    expect_identical(
+      expected_vec %>% sort(),
+      (df %>% gt() %>% render_formats_test("html")) %>%
+        unlist() %>% unname() %>% sort()
+    )
+
+    # Expect that UTF-8 characters are retained in the
+    # rendered HTML table
+    expect_identical(
+      expected_vec %>% sort(),
+      df %>%
+        gt() %>%
+        tab_options(row.striping.include_table_body = FALSE) %>%
+        render_as_html() %>%
+        xml2::read_html() %>%
+        selection_text("[class='gt_row gt_left']") %>%
+        sort()
+    )
+  }
+
+  # Run tests with `test_df_output_with_sys_locale()` for all locales
+  # in the `system_locales` vector
+  for (locale in system_locales) {
+    test_df_output_with_sys_locale(
+      df = names_df,
+      locale = locale,
+      expected_vec = c("B\u00e4ckhed", "Fred", "\u6625", "\u9ad8")
+    )
+  }
 })


### PR DESCRIPTION
This change ensures that UTF-8 encoded characters don't get flattened to text during the building of table data. Change is focused on only the `migrate_unformatted_to_output()` internal function, where character values were passed through `format()` (now, only `numeric` vectors are).

Fixes: https://github.com/rstudio/gt/issues/419