### PR TITLE
Perform input validation and check for types when formatting

### DIFF
--- a/R/data_color.R
+++ b/R/data_color.R
@@ -133,6 +133,10 @@ data_color <- function(data,
                        apply_to = "fill",
                        autocolor_text = TRUE) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
+  # Get the internal data table
   data_tbl <- dt_data_get(data = data)
 
   # Collect the column names from `data_tbl`

--- a/R/export.R
+++ b/R/export.R
@@ -88,8 +88,8 @@ gtsave <- function(data,
                    path = NULL,
                    ...) {
 
-  # Input object validation
-  stop_if_not_gt(data)
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Get the lowercased file extension
   file_ext <- gtsave_file_ext(filename)
@@ -297,6 +297,9 @@ gtsave_filename <- function(path, filename) {
 as_raw_html <- function(data,
                         inline_css = TRUE) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Generation of the HTML table
   html_table <- render_as_html(data = data)
 
@@ -352,6 +355,9 @@ as_raw_html <- function(data,
 #'
 #' @export
 as_latex <- function(data) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Build all table data objects through a common pipeline
   data <- data %>% build_data(context = "latex")
@@ -434,6 +440,9 @@ as_latex <- function(data) {
 #'
 #' @export
 as_rtf <- function(data) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Build all table data objects through a common pipeline
   data <- data %>% build_data(context = "rtf")
@@ -547,6 +556,9 @@ as_rtf <- function(data) {
 #'
 #' @export
 extract_summary <- function(data) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Stop function if there are no
   # directives to create summary rows

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -142,6 +142,9 @@ fmt_number <- function(data,
                        dec_mark = ".",
                        locale = NULL) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Use locale-based marks if a locale ID is provided
   sep_mark <- get_locale_sep_mark(locale, sep_mark, use_seps)
   dec_mark <- get_locale_dec_mark(locale, dec_mark)
@@ -251,6 +254,9 @@ fmt_scientific <- function(data,
                            sep_mark = ",",
                            dec_mark = ".",
                            locale = NULL) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Set default values
   suffixing <- FALSE
@@ -513,6 +519,9 @@ fmt_percent <- function(data,
                         placement = "right",
                         locale = NULL) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Capture expression in `rows` and `columns`
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
@@ -665,6 +674,9 @@ fmt_currency <- function(data,
                          incl_space = FALSE,
                          locale = NULL) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Capture expression in `rows` and `columns`
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
@@ -794,6 +806,9 @@ fmt_date <- function(data,
                      rows = NULL,
                      date_style = 2) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Transform `date_style` to `date_format_str`
   date_format_str <- get_date_format(date_style = date_style)
 
@@ -917,6 +932,9 @@ fmt_time <- function(data,
                      rows = NULL,
                      time_style = 2) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Transform `time_style` to `time_format_str`
   time_format_str <- get_time_format(time_style = time_style)
 
@@ -1030,6 +1048,9 @@ fmt_datetime <- function(data,
                          rows = NULL,
                          date_style = 2,
                          time_style = 2) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Transform `date_style` to `date_format`
   date_format_str <- get_date_format(date_style = date_style)
@@ -1166,6 +1187,9 @@ fmt_markdown <- function(data,
                          columns,
                          rows = NULL) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Capture expression in `rows`
   columns <- rlang::enquo(columns)
   rows <- rlang::enquo(rows)
@@ -1246,6 +1270,9 @@ fmt_passthrough <- function(data,
                             rows = NULL,
                             escape = TRUE,
                             pattern = "{x}") {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Capture expression in `rows` and `columns`
   rows <- rlang::enquo(rows)
@@ -1362,6 +1389,9 @@ fmt_missing <- function(data,
                         rows = NULL,
                         missing_text = "---") {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Capture expression in `rows` and `columns`
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
@@ -1460,6 +1490,9 @@ fmt <- function(data,
                 columns = NULL,
                 rows = NULL,
                 fns) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Get the `stub_df` data frame from `data`
   stub_df <- dt_stub_df_get(data = data)

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -161,7 +161,7 @@ fmt_number <- function(data,
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
-  if (!column_classes_are_valid(data, columns, valid_classes = c("numeric", "integer"))) {
+  if (!column_classes_are_valid(data, !!columns, valid_classes = c("numeric", "integer"))) {
     stop("The `fmt_number()` function can only be used on `columns` with numeric data",
          call. = FALSE)
   }
@@ -285,7 +285,7 @@ fmt_scientific <- function(data,
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
-  if (!column_classes_are_valid(data, columns, valid_classes = c("numeric", "integer"))) {
+  if (!column_classes_are_valid(data, !!columns, valid_classes = c("numeric", "integer"))) {
     stop("The `fmt_scientific()` function can only be used on `columns` with numeric data",
          call. = FALSE)
   }
@@ -541,7 +541,7 @@ fmt_percent <- function(data,
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
-  if (!column_classes_are_valid(data, columns, valid_classes = c("numeric", "integer"))) {
+  if (!column_classes_are_valid(data, !!columns, valid_classes = c("numeric", "integer"))) {
     stop("The `fmt_percent()` function can only be used on `columns` with numeric data",
          call. = FALSE)
   }
@@ -703,7 +703,7 @@ fmt_currency <- function(data,
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
-  if (!column_classes_are_valid(data, columns, valid_classes = c("numeric", "integer"))) {
+  if (!column_classes_are_valid(data, !!columns, valid_classes = c("numeric", "integer"))) {
     stop("The `fmt_currency()` function can only be used on `columns` with numeric data",
          call. = FALSE)
   }
@@ -845,7 +845,7 @@ fmt_date <- function(data,
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
-  if (!column_classes_are_valid(data, columns, valid_classes = c("Date", "character"))) {
+  if (!column_classes_are_valid(data, !!columns, valid_classes = c("Date", "character"))) {
     stop("The `fmt_date()` function can only be used on `columns` with `character` or `Date` values",
          call. = FALSE)
   }
@@ -978,7 +978,7 @@ fmt_time <- function(data,
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
-  if (!column_classes_are_valid(data, columns, valid_classes = "character")) {
+  if (!column_classes_are_valid(data, !!columns, valid_classes = "character")) {
     stop("The `fmt_date()` function can only be used on `columns` with `character` values",
          call. = FALSE)
   }
@@ -1105,7 +1105,7 @@ fmt_datetime <- function(data,
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
-  if (!column_classes_are_valid(data, columns, valid_classes = "character")) {
+  if (!column_classes_are_valid(data, !!columns, valid_classes = "character")) {
     stop("The `fmt_datetime()` function can only be used on `columns` with `character` values",
          call. = FALSE)
   }

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -102,8 +102,7 @@
 #' # large-number suffixing
 #' tab_2 <-
 #'   countrypops %>%
-#'   dplyr::select(
-#'     country_code_3, year, population) %>%
+#'   dplyr::select(country_code_3, year, population) %>%
 #'   dplyr::filter(
 #'     country_code_3 %in% c(
 #'       "CHN", "IND", "USA", "PAK", "IDN")
@@ -113,7 +112,7 @@
 #'   dplyr::arrange(desc(`2015`)) %>%
 #'   gt(rowname_col = "country_code_3") %>%
 #'   fmt_number(
-#'     columns = TRUE,
+#'     columns = 2:9,
 #'     decimals = 2,
 #'     suffixing = TRUE
 #'   )
@@ -159,6 +158,13 @@ fmt_number <- function(data,
   # Capture expression in `rows` and `columns`
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
+
+  # Stop function if any columns have data that is incompatible
+  # with this formatter
+  if (!column_classes_are_valid(data, columns, valid_classes = c("numeric", "integer"))) {
+    stop("The `fmt_number()` function can only be used on `columns` with numeric data",
+         call. = FALSE)
+  }
 
   # Pass `data`, `columns`, `rows`, and the formatting
   # functions as a function list to `fmt()`
@@ -276,6 +282,13 @@ fmt_scientific <- function(data,
   # Capture expression in `rows` and `columns`
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
+
+  # Stop function if any columns have data that is incompatible
+  # with this formatter
+  if (!column_classes_are_valid(data, columns, valid_classes = c("numeric", "integer"))) {
+    stop("The `fmt_scientific()` function can only be used on `columns` with numeric data",
+         call. = FALSE)
+  }
 
   # Pass `data`, `columns`, `rows`, and the formatting
   # functions as a function list to `fmt()`
@@ -526,6 +539,13 @@ fmt_percent <- function(data,
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
 
+  # Stop function if any columns have data that is incompatible
+  # with this formatter
+  if (!column_classes_are_valid(data, columns, valid_classes = c("numeric", "integer"))) {
+    stop("The `fmt_percent()` function can only be used on `columns` with numeric data",
+         call. = FALSE)
+  }
+
   fmt_symbol(
     data = data,
     columns = !!columns,
@@ -681,6 +701,13 @@ fmt_currency <- function(data,
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
 
+  # Stop function if any columns have data that is incompatible
+  # with this formatter
+  if (!column_classes_are_valid(data, columns, valid_classes = c("numeric", "integer"))) {
+    stop("The `fmt_currency()` function can only be used on `columns` with numeric data",
+         call. = FALSE)
+  }
+
   # Stop function if `currency` does not have a valid value
   validate_currency(currency = currency)
 
@@ -816,6 +843,13 @@ fmt_date <- function(data,
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
 
+  # Stop function if any columns have data that is incompatible
+  # with this formatter
+  if (!column_classes_are_valid(data, columns, valid_classes = c("Date", "character"))) {
+    stop("The `fmt_date()` function can only be used on `columns` with `character` or `Date` values",
+         call. = FALSE)
+  }
+
   # Pass `data`, `columns`, `rows`, and the formatting
   # functions as a function list to `fmt()`
   fmt(
@@ -942,6 +976,13 @@ fmt_time <- function(data,
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
 
+  # Stop function if any columns have data that is incompatible
+  # with this formatter
+  if (!column_classes_are_valid(data, columns, valid_classes = "character")) {
+    stop("The `fmt_date()` function can only be used on `columns` with `character` values",
+         call. = FALSE)
+  }
+
   # Pass `data`, `columns`, `rows`, and the formatting
   # functions as a function list to `fmt()`
   fmt(
@@ -1058,12 +1099,16 @@ fmt_datetime <- function(data,
   # Transform `time_style` to `time_format`
   time_format_str <- get_time_format(time_style = time_style)
 
-  # Combine into a single datetime format string
-  # date_time_format_str <- paste0(date_format, " ", time_format)
-
   # Capture expression in `rows` and `columns`
   rows <- rlang::enquo(rows)
   columns <- rlang::enquo(columns)
+
+  # Stop function if any columns have data that is incompatible
+  # with this formatter
+  if (!column_classes_are_valid(data, columns, valid_classes = "character")) {
+    stop("The `fmt_datetime()` function can only be used on `columns` with `character` values",
+         call. = FALSE)
+  }
 
   # Pass `data`, `columns`, `rows`, and the formatting
   # functions as a function list to `fmt()`

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -98,8 +98,8 @@
 #'   )
 #'
 #' # Use `countrypops` to create a gt
-#' # table; format all columns to use
-#' # large-number suffixing
+#' # table; format all numeric columns
+#' # to use large-number suffixing
 #' tab_2 <-
 #'   countrypops %>%
 #'   dplyr::select(country_code_3, year, population) %>%

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -51,6 +51,10 @@ cols_align <- function(data,
                        align = c("auto", "left", "center", "right"),
                        columns = TRUE) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
+  # Get the internal data table
   data_tbl <- dt_data_get(data = data)
 
   # Get the `align` value, this stops the function if there is no match
@@ -160,6 +164,9 @@ cols_align <- function(data,
 cols_width <- function(data,
                        ...,
                        .list = list2(...)) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Collect a named list of column widths
   widths_list <- .list
@@ -312,6 +319,9 @@ cols_label <- function(data,
                        ...,
                        .list = list2(...)) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Collect a named list of column labels
   labels_list <- .list
 
@@ -422,6 +432,9 @@ cols_label <- function(data,
 cols_move_to_start <- function(data,
                                columns) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   columns <- enquo(columns)
 
   vars <- dt_boxhead_get_vars(data = data)
@@ -512,6 +525,9 @@ cols_move_to_start <- function(data,
 cols_move_to_end <- function(data,
                              columns) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   columns <- enquo(columns)
 
   vars <- dt_boxhead_get_vars(data = data)
@@ -593,6 +609,9 @@ cols_move_to_end <- function(data,
 cols_move <- function(data,
                       columns,
                       after) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   columns <- enquo(columns)
   after <- enquo(after)
@@ -714,6 +733,9 @@ cols_move <- function(data,
 cols_hide <- function(data,
                       columns) {
 
+  # Perform input object validation
+  # stop_if_not_gt(data = data)
+
   columns <- enquo(columns)
 
   # Get the columns supplied in `columns` as a character vector
@@ -822,6 +844,9 @@ cols_merge_uncert <- function(data,
                               col_uncert,
                               autohide = TRUE) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Use a predefined separator
   sep <- " \u00B1 "
 
@@ -910,6 +935,9 @@ cols_merge_range <- function(data,
                              col_end,
                              sep = "--",
                              autohide = TRUE) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Set the formatting pattern
   pattern <- "{1}{sep}{2}"
@@ -1015,6 +1043,9 @@ cols_merge <- function(data,
                        columns,
                        hide_columns = columns[-1],
                        pattern = paste0("{", seq_along(columns), "}", collapse = " ")) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   columns <- enquo(columns)
 

--- a/R/modify_rows.R
+++ b/R/modify_rows.R
@@ -46,6 +46,9 @@
 row_group_order <- function(data,
                             groups) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Stop function if `groups` is not a `character` or
   #   `numeric` object
   if (!inherits(groups, c("character", "numeric"))) {

--- a/R/summary_rows.R
+++ b/R/summary_rows.R
@@ -89,6 +89,9 @@ summary_rows <- function(data,
                          formatter = fmt_number,
                          ...) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Collect all provided formatter options in a list
   formatter_options <- list(...)
 
@@ -211,6 +214,9 @@ grand_summary_rows <- function(data,
                                missing_text = "---",
                                formatter = fmt_number,
                                ...) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   summary_rows(
     data,

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -40,6 +40,9 @@ tab_header <- function(data,
                        title,
                        subtitle = NULL) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   data %>% dt_heading_title_subtitle(title = title, subtitle = subtitle)
 }
 
@@ -90,6 +93,9 @@ tab_spanner <- function(data,
                         label,
                         columns,
                         gather = TRUE) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   checkmate::assert_character(
     label, len = 1, any.missing = FALSE, null.ok = FALSE)
@@ -175,6 +181,9 @@ tab_spanner_delim <- function(data,
                               delim,
                               columns = NULL,
                               gather = TRUE) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   columns <- enquo(columns)
 
@@ -311,6 +320,9 @@ tab_row_group <- function(data,
                           rows = NULL,
                           others = NULL) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   arrange_groups_vars <- dt_row_groups_get(data = data)
 
   # Capture the `rows` expression
@@ -414,6 +426,9 @@ tab_row_group <- function(data,
 tab_stubhead <- function(data,
                          label) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   data %>% dt_stubhead_label(label = label)
 }
 
@@ -497,6 +512,9 @@ tab_stubhead <- function(data,
 tab_footnote <- function(data,
                          footnote,
                          locations) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Resolve into a list of locations
   locations <- as_locations(locations)
@@ -734,6 +752,9 @@ set_footnote.cells_grand_summary <- function(loc, data, footnote) {
 tab_source_note <- function(data,
                             source_note) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   data %>% dt_source_notes_add(source_note = source_note)
 }
 
@@ -849,6 +870,9 @@ tab_source_note <- function(data,
 tab_style <- function(data,
                       style,
                       locations) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Resolve into a list of locations
   locations <- as_locations(locations)
@@ -1460,6 +1484,9 @@ tab_options <- function(data,
   # TODO: add helper functions to divide the options into those by location
   # TODO: add helper functions to divide the options into those by parameter
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Extract the options table from `data`
   opts_df <- dt_options_get(data = data)
 
@@ -1585,6 +1612,9 @@ tab_options <- function(data,
 #' @export
 opt_footnote_marks <- function(data,
                                marks = NULL) {
+
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   if (!is.null(marks)) {
     data <- data %>% tab_options(footnotes.marks = marks)

--- a/R/text_transform.R
+++ b/R/text_transform.R
@@ -49,6 +49,9 @@ text_transform <- function(data,
                            locations,
                            fn) {
 
+  # Perform input object validation
+  stop_if_not_gt(data = data)
+
   # Resolve into a list of locations
   locations <- as_locations(locations = locations)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -970,12 +970,13 @@ validate_length_one <- function(x, name) {
 
 column_classes_are_valid <- function(data, columns, valid_classes) {
 
-  col_classes <-
-    dt_data_get(data = data) %>%
+  dt_data_get(data = data) %>%
     dplyr::select(resolve_vars(var_expr = !!columns, data = data)) %>%
-    vapply(class, FUN.VALUE = character(1), USE.NAMES = FALSE)
-
-  all(col_classes %in% valid_classes)
+    vapply(
+      FUN.VALUE = logical(1), USE.NAMES = FALSE,
+      FUN = function(x) any(class(x) %in% valid_classes)
+    ) %>%
+    all()
 }
 
 # print8 <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -968,6 +968,16 @@ validate_length_one <- function(x, name) {
   }
 }
 
+column_classes_are_valid <- function(data, columns, valid_classes) {
+
+  col_classes <-
+    dt_data_get(data = data) %>%
+    dplyr::select(resolve_vars(var_expr = !!columns, data = data)) %>%
+    vapply(class, FUN.VALUE = character(1), USE.NAMES = FALSE)
+
+  all(col_classes %in% valid_classes)
+}
+
 # print8 <- function(x) {
 #   force(x)
 #

--- a/R/utils.R
+++ b/R/utils.R
@@ -971,7 +971,7 @@ validate_length_one <- function(x, name) {
 column_classes_are_valid <- function(data, columns, valid_classes) {
 
   dt_data_get(data = data) %>%
-    dplyr::select(resolve_vars(var_expr = !!columns, data = data)) %>%
+    dplyr::select(resolve_vars(var_expr = {{columns}}, data = data)) %>%
     vapply(
       FUN.VALUE = logical(1), USE.NAMES = FALSE,
       FUN = function(x) any(class(x) %in% valid_classes)

--- a/R/utils.R
+++ b/R/utils.R
@@ -879,7 +879,8 @@ is_gt <- function(data) {
 
 #' Stop any function if object is not a `gt_tbl` object
 #'
-#' @param data A table object that is created using the [gt()] function.
+#' @param data The input `data` object that is to be validated.
+#'
 #' @noRd
 stop_if_not_gt <- function(data) {
 

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -146,8 +146,7 @@ tab_1 <-
 # large-number suffixing
 tab_2 <-
   countrypops \%>\%
-  dplyr::select(
-    country_code_3, year, population) \%>\%
+  dplyr::select(country_code_3, year, population) \%>\%
   dplyr::filter(
     country_code_3 \%in\% c(
       "CHN", "IND", "USA", "PAK", "IDN")
@@ -157,7 +156,7 @@ tab_2 <-
   dplyr::arrange(desc(`2015`)) \%>\%
   gt(rowname_col = "country_code_3") \%>\%
   fmt_number(
-    columns = TRUE,
+    columns = 2:9,
     decimals = 2,
     suffixing = TRUE
   )

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -142,8 +142,8 @@ tab_1 <-
   )
 
 # Use `countrypops` to create a gt
-# table; format all columns to use
-# large-number suffixing
+# table; format all numeric columns
+# to use large-number suffixing
 tab_2 <-
   countrypops \%>\%
   dplyr::select(country_code_3, year, population) \%>\%

--- a/tests/testthat/test-input_data_validation.R
+++ b/tests/testthat/test-input_data_validation.R
@@ -1,0 +1,50 @@
+context("Ensuring that the incoming `data` object is of class `gt_tbl`")
+
+test_that("all exported functions validate the incoming `data` object", {
+
+  regexp_stop <- "The object to `data` is not a `gt_tbl` object"
+
+  # Test the `exibble` tibble with all exported functions;
+  # don't provide values for any arguments and ensure that
+  # the function stop message pertains to the input data
+  # validation
+  expect_error(exibble %>% tab_header(), regexp = regexp_stop)
+  expect_error(exibble %>% tab_spanner(), regexp = regexp_stop)
+  expect_error(exibble %>% tab_spanner_delim(), regexp = regexp_stop)
+  expect_error(exibble %>% tab_row_group(), regexp = regexp_stop)
+  expect_error(exibble %>% tab_stubhead(), regexp = regexp_stop)
+  expect_error(exibble %>% tab_footnote(), regexp = regexp_stop)
+  expect_error(exibble %>% tab_source_note(), regexp = regexp_stop)
+  expect_error(exibble %>% tab_style(), regexp = regexp_stop)
+  expect_error(exibble %>% tab_options(), regexp = regexp_stop)
+  expect_error(exibble %>% opt_footnote_marks(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_number(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_scientific(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_percent(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_currency(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_date(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_time(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_datetime(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_markdown(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_passthrough(), regexp = regexp_stop)
+  expect_error(exibble %>% fmt_missing(), regexp = regexp_stop)
+  expect_error(exibble %>% text_transform(), regexp = regexp_stop)
+  expect_error(exibble %>% data_color(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_align(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_width(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_label(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_move_to_start(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_move_to_end(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_move(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_merge_uncert(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_merge_range(), regexp = regexp_stop)
+  expect_error(exibble %>% cols_merge(), regexp = regexp_stop)
+  expect_error(exibble %>% row_group_order(), regexp = regexp_stop)
+  expect_error(exibble %>% summary_rows(), regexp = regexp_stop)
+  expect_error(exibble %>% grand_summary_rows(), regexp = regexp_stop)
+  expect_error(exibble %>% gtsave(), regexp = regexp_stop)
+  expect_error(exibble %>% as_raw_html(), regexp = regexp_stop)
+  expect_error(exibble %>% as_latex(), regexp = regexp_stop)
+  expect_error(exibble %>% as_rtf(), regexp = regexp_stop)
+  expect_error(exibble %>% extract_summary(), regexp = regexp_stop)
+})

--- a/tests/testthat/test-input_data_validation.R
+++ b/tests/testthat/test-input_data_validation.R
@@ -48,3 +48,51 @@ test_that("all exported functions validate the incoming `data` object", {
   expect_error(exibble %>% as_rtf(), regexp = regexp_stop)
   expect_error(exibble %>% extract_summary(), regexp = regexp_stop)
 })
+
+test_that("certain `fmt_*()` functions stop if given incompatible column data", {
+
+  gt_tbl <- exibble %>% gt()
+
+  # Tests with `fmt_number()`
+  gt_tbl %>% fmt_number(columns = vars(num)) %>% expect_is("gt_tbl")
+  gt_tbl %>% fmt_number(columns = vars()) %>% expect_is("gt_tbl")
+  gt_tbl %>% fmt_number(columns = vars(currency)) %>% expect_is("gt_tbl")
+  expect_error(gt_tbl %>% fmt_number(columns = vars(num, fctr)))
+  expect_error(gt_tbl %>% fmt_number(columns = vars(char)))
+
+  # Tests with `fmt_scientific()`
+  gt_tbl %>% fmt_scientific(columns = vars(num)) %>% expect_is("gt_tbl")
+  gt_tbl %>% fmt_scientific(columns = vars()) %>% expect_is("gt_tbl")
+  expect_error(gt_tbl %>% fmt_scientific(columns = vars(num, fctr)))
+  expect_error(gt_tbl %>% fmt_scientific(columns = vars(char)))
+
+  # Tests with `fmt_percent()`
+  gt_tbl %>% fmt_percent(columns = vars(num)) %>% expect_is("gt_tbl")
+  gt_tbl %>% fmt_percent(columns = vars()) %>% expect_is("gt_tbl")
+  expect_error(gt_tbl %>% fmt_percent(columns = vars(num, fctr)))
+  expect_error(gt_tbl %>% fmt_percent(columns = vars(char)))
+
+  # Tests with `fmt_currency()`
+  gt_tbl %>% fmt_currency(columns = vars(num)) %>% expect_is("gt_tbl")
+  gt_tbl %>% fmt_currency(columns = vars()) %>% expect_is("gt_tbl")
+  expect_error(gt_tbl %>% fmt_currency(columns = vars(num, fctr)))
+  expect_error(gt_tbl %>% fmt_currency(columns = vars(char)))
+
+  # Tests with `fmt_date()`
+  gt_tbl %>% fmt_date(columns = vars(date)) %>% expect_is("gt_tbl")
+  gt_tbl %>% fmt_date(columns = vars()) %>% expect_is("gt_tbl")
+  expect_error(gt_tbl %>% fmt_date(columns = vars(date, num)))
+  expect_error(gt_tbl %>% fmt_date(columns = vars(fctr)))
+
+  # Tests with `fmt_time()`
+  gt_tbl %>% fmt_time(columns = vars(time)) %>% expect_is("gt_tbl")
+  gt_tbl %>% fmt_time(columns = vars()) %>% expect_is("gt_tbl")
+  expect_error(gt_tbl %>% fmt_time(columns = vars(time, num)))
+  expect_error(gt_tbl %>% fmt_time(columns = vars(fctr)))
+
+  # Tests with `fmt_datetime()`
+  gt_tbl %>% fmt_datetime(columns = vars(datetime)) %>% expect_is("gt_tbl")
+  gt_tbl %>% fmt_datetime(columns = vars()) %>% expect_is("gt_tbl")
+  expect_error(gt_tbl %>% fmt_datetime(columns = vars(datetime, num)))
+  expect_error(gt_tbl %>% fmt_datetime(columns = vars(fctr)))
+})


### PR DESCRIPTION
This PR checks that the incoming data is a `gt_tbl` object (i.e., created by the `gt()` function). Column types are also checked in `fmt_*()` functions and `stop()`s are put into place for column types that won't be evaluated correctly.

Fixes: https://github.com/rstudio/gt/issues/444
Fixes: https://github.com/rstudio/gt/issues/449
Fixes: https://github.com/rstudio/gt/issues/385
Fixes: https://github.com/rstudio/gt/issues/205