### PR TITLE
Expand documentation such that all functions get at least one self-contained example

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,10 +1,15 @@
 #' Interpret input text as Markdown-formatted text
 #'
-#' @param text The text that is understood to contain Markdown formatting.
-#' @return A character object that is tagged for a Markdown-to-HTML
-#'   transformation.
+#' Markdown! It's a wonderful thing. We can use it in certain places (e.g.,
+#' footnotes, source notes, the table title, etc.) and expect it to render to
+#' HTML as Markdown does. There is the [html()] helper that allows you to ferry
+#' in HTML but this function `md()`... it's almost like a two-for-one deal (you
+#' get to use Markdown plus any HTML fragments *at the same time*).
 #'
-#' @return A character object of class `from_markdown`.
+#' @param text The text that is understood to contain Markdown formatting.
+#'
+#' @return A character object of class `from_markdown`. It's tagged as being
+#'   Markdown text and it will undergo conversion to HTML.
 #'
 #' @examples
 #' # Use `exibble` to create a gt table;
@@ -38,12 +43,17 @@ md <- function(text) {
 
 #' Interpret input text as HTML-formatted text
 #'
+#' For certain pieces of text (like in column labels or table headings) we may
+#' want to express them as raw HTML. In fact, with HTML, anything goes so it can
+#' be much more than just text. The `html()` function will guard the input HTML
+#' against escaping, so, your HTML tags will come through as HTML when
+#' rendered... to HTML.
+#'
 #' @param text,... The text that is understood to be HTML text, which is to be
 #'   preserved.
-#' @return A character object that is tagged as an HTML fragment that is not to
-#'   be sanitized.
 #'
-#' @return A character object of class `html`.
+#' @return A character object of class `html`. It's tagged as an HTML fragment
+#'   that is not to be sanitized.
 #'
 #' @examples
 #' # Use `exibble` to create a gt table;
@@ -77,6 +87,12 @@ is_html <- function(x) {
 }
 
 #' Helper for providing a numeric value as pixels value
+#'
+#' For certain parameters, a length value is required. Examples include the
+#' setting of font sizes (e.g., in [cell_text()]) and thicknesses of lines
+#' (e.g., in [cell_borders()]). Setting a length in pixels with `px()` allows
+#' for an absolute definition of size as opposed to the analogous helper
+#' function [pct()].
 #'
 #' @param x the numeric value to format as a string (e.g., `"12px"`) for
 #'   some [tab_options()] arguments that can take values as units of
@@ -114,6 +130,15 @@ px <- function(x) {
 }
 
 #' Helper for providing a numeric value as percentage
+#'
+#' A percentage value acts as a length value that is relative to an initial
+#' state. For instance an 80 percent value for something will size the target
+#' to 80 percent the size of its 'previous' value. This type of sizing is
+#' useful for sizing up or down a length value with an intuitive measure. This
+#' helper function can be used for the setting of font sizes (e.g., in
+#' [cell_text()]) and altering the thicknesses of lines (e.g., in
+#' [cell_borders()]). Should a more exact definition of size be required, the
+#' analogous helper function [pct()] will be more useful.
 #'
 #' @param x the numeric value to format as a string percentage for some
 #'   [tab_options()] arguments that can take percentage values

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -82,6 +82,23 @@ is_html <- function(x) {
 #'   some [tab_options()] arguments that can take values as units of
 #'   pixels (e.g., `table.font.size`).
 #'
+#' @return A character vector with a single value in pixel units.
+#'
+#' @examples
+#' # Use `exibble` to create a gt table;
+#' # use the `px()` helper to define the
+#' # font size for the column labels
+#' tab_1 <-
+#'   exibble %>%
+#'   gt() %>%
+#'   tab_style(
+#'     style = cell_text(size = px(20)),
+#'     locations = cells_column_labels(columns = TRUE)
+#'   )
+#'
+#' @section Figures:
+#' \if{html}{\figure{man_px_1.svg}{options: width=100\%}}
+#'
 #' @family Helper Functions
 #' @section Function ID:
 #' 7-3
@@ -101,6 +118,23 @@ px <- function(x) {
 #' @param x the numeric value to format as a string percentage for some
 #'   [tab_options()] arguments that can take percentage values
 #'   (e.g., `table.width`).
+#'
+#' @return A character vector with a single value in percentage units.
+#'
+#' @examples
+#' # Use `exibble` to create a gt table;
+#' # use the `pct()` helper to define the
+#' # font size for the column labels
+#' tab_1 <-
+#'   exibble %>%
+#'   gt() %>%
+#'   tab_style(
+#'     style = cell_text(size = pct(75)),
+#'     locations = cells_column_labels(columns = TRUE)
+#'   )
+#'
+#' @section Figures:
+#' \if{html}{\figure{man_pct_1.svg}{options: width=100\%}}
 #'
 #' @family Helper Functions
 #' @section Function ID:
@@ -1007,6 +1041,9 @@ cells_grand_summary <- function(columns = TRUE,
 #'     decimals = 2
 #'   )
 #'
+#' @section Figures:
+#' \if{html}{\figure{man_currency_1.svg}{options: width=100\%}}
+#'
 #' @family Helper Functions
 #' @section Function ID:
 #' 7-14
@@ -1083,11 +1120,45 @@ currency <- function(...,
 #'   `"expanded"`, `"extra-expanded"`, or `"ultra-expanded"`. Alternatively, we
 #'   can supply percentage values from `0\%` to `200\%`, inclusive. Negative
 #'   percentage values are not allowed.
-#' @param indent The indentation of the text.
+#' @param indent The indentation of the text. Can be provided as a number that
+#'   is assumed to represent `px` values (or could be wrapped in the [px()])
+#'   helper function. Alternatively, this can be given as a percentage (easily
+#'   constructed with [pct()]).
 #' @param decorate allows for text decoration effect to be applied. Here, we can
 #'   use `"overline"`, `"line-through"`, or `"underline"`.
 #' @param transform Allows for the transformation of text. Options are
 #'   `"uppercase"`, `"lowercase"`, or `"capitalize"`.
+#'
+#' @return A list object of class `cell_styles`.
+#'
+#' @examples
+#' # Use `exibble` to create a gt table;
+#' # add styles with `tab_style()` and
+#' # the `cell_text()` helper function
+#' tab_1 <-
+#'   exibble %>%
+#'   dplyr::select(num, currency) %>%
+#'   gt() %>%
+#'   fmt_number(
+#'     columns = vars(num, currency),
+#'     decimals = 1
+#'   ) %>%
+#'   tab_style(
+#'     style = cell_text(weight = "bold"),
+#'     locations = cells_body(
+#'       columns = vars(num),
+#'       rows = num >= 5000)
+#'   ) %>%
+#'   tab_style(
+#'     style = cell_text(style = "italic"),
+#'     locations = cells_body(
+#'       columns = vars(currency),
+#'       rows = currency < 100
+#'     )
+#'   )
+#'
+#' @section Figures:
+#' \if{html}{\figure{man_cell_text_1.svg}{options: width=100\%}}
 #'
 #' @family Helper Functions
 #' @section Function ID:
@@ -1200,6 +1271,37 @@ cell_style_to_html.cell_text <- function(style) {
 #'   provided the fill color will either be fully opaque or use alpha
 #'   information from the color value if it is supplied in the #RRGGBBAA format.
 #'
+#' @return A list object of class `cell_styles`.
+#'
+#' @examples
+#' # Use `exibble` to create a gt table;
+#' # add styles with `tab_style()` and
+#' # the `cell_fill()` helper function
+#' tab_1 <-
+#'   exibble %>%
+#'   dplyr::select(num, currency) %>%
+#'   gt() %>%
+#'   fmt_number(
+#'     columns = vars(num, currency),
+#'     decimals = 1
+#'   ) %>%
+#'   tab_style(
+#'     style = cell_fill(color = "lightblue"),
+#'     locations = cells_body(
+#'       columns = vars(num),
+#'       rows = num >= 5000)
+#'   ) %>%
+#'   tab_style(
+#'     style = cell_fill(color = "gray85"),
+#'     locations = cells_body(
+#'       columns = vars(currency),
+#'       rows = currency < 100
+#'     )
+#'   )
+#'
+#' @section Figures:
+#' \if{html}{\figure{man_cell_fill_1.svg}{options: width=100\%}}
+#'
 #' @family Helper Functions
 #' @section Function ID:
 #' 7-16
@@ -1255,6 +1357,8 @@ cell_style_to_html.cell_fill <- function(style) {
 #'   any defined `sides` can be removed by supplying `NULL` to any of `color`,
 #'   `style`, or `weight`.
 #'
+#' @return A list object of class `cell_styles`.
+#'
 #' @examples
 #' # Add horizontal border lines for
 #' # all table body rows in `exibble`
@@ -1265,7 +1369,9 @@ cell_style_to_html.cell_fill <- function(style) {
 #'     tab_style(
 #'       style = cell_borders(
 #'         sides = c("top", "bottom"),
-#'         color = "gray", weight = px(0.5), style = "solid"
+#'         color = "#BBBBBB",
+#'         weight = px(1.5),
+#'         style = "solid"
 #'       ),
 #'       locations = cells_body(
 #'         columns = everything(),
@@ -1284,12 +1390,12 @@ cell_style_to_html.cell_fill <- function(style) {
 #'       style = list(
 #'         cell_borders(
 #'           sides = c("top", "bottom"),
-#'           color = "red",
+#'           color = "#FF0000",
 #'           weight = px(2)
 #'         ),
 #'         cell_borders(
 #'           sides = c("left", "right"),
-#'           color = "blue",
+#'           color = "#0000FF",
 #'           weight = px(2)
 #'         )
 #'       ),
@@ -1304,6 +1410,11 @@ cell_style_to_html.cell_fill <- function(style) {
 #'         )
 #'       )
 #'     )
+#'
+#' @section Figures:
+#' \if{html}{\figure{man_cell_borders_1.svg}{options: width=100\%}}
+#'
+#' \if{html}{\figure{man_cell_borders_2.svg}{options: width=100\%}}
 #'
 #' @family Helper Functions
 #' @section Function ID:
@@ -1525,6 +1636,8 @@ adjust_luminance <- function(colors,
 #'
 #' @param n The number of lowercase letters to use for the random ID.
 #'
+#' @return A character vector containing a single, random ID.
+#'
 #' @family Helper Functions
 #' @section Function ID:
 #' 7-19
@@ -1543,6 +1656,8 @@ random_id <- function(n = 10) {
 #'
 #' @param text a character vector containing the text that is to be
 #'   LaTeX-escaped.
+#'
+#' @return A character vector.
 #'
 #' @family Helper Functions
 #' @section Function ID:
@@ -1593,6 +1708,8 @@ escape_latex <- function(text) {
 #'
 #' \end{document}
 #' }
+#'
+#' @return An object of class `knit_asis`.
 #'
 #' @family Helper Functions
 #' @section Function ID:

--- a/man/cell_borders.Rd
+++ b/man/cell_borders.Rd
@@ -20,6 +20,9 @@ is useful for this. The default value for \code{weight} is \code{"1px"}. Borders
 any defined \code{sides} can be removed by supplying \code{NULL} to any of \code{color},
 \code{style}, or \code{weight}.}
 }
+\value{
+A list object of class \code{cell_styles}.
+}
 \description{
 The \code{cell_borders()} helper function is to be used with the \code{\link[=tab_style]{tab_style()}}
 function, which itself allows for the setting of custom styles to one or more
@@ -29,6 +32,13 @@ define which borders should be modified (e.g., \code{"left"}, \code{"right"}, et
 With that selection, the \code{color}, \code{style}, and \code{weight} of the selected
 borders can then be modified.
 }
+\section{Figures}{
+
+\if{html}{\figure{man_cell_borders_1.svg}{options: width=100\%}}
+
+\if{html}{\figure{man_cell_borders_2.svg}{options: width=100\%}}
+}
+
 \section{Function ID}{
 
 7-17
@@ -44,7 +54,9 @@ tab_1 <-
     tab_style(
       style = cell_borders(
         sides = c("top", "bottom"),
-        color = "gray", weight = px(0.5), style = "solid"
+        color = "#BBBBBB",
+        weight = px(1.5),
+        style = "solid"
       ),
       locations = cells_body(
         columns = everything(),
@@ -63,12 +75,12 @@ tab_2 <-
       style = list(
         cell_borders(
           sides = c("top", "bottom"),
-          color = "red",
+          color = "#FF0000",
           weight = px(2)
         ),
         cell_borders(
           sides = c("left", "right"),
-          color = "blue",
+          color = "#0000FF",
           weight = px(2)
         )
       ),

--- a/man/cell_fill.Rd
+++ b/man/cell_fill.Rd
@@ -15,17 +15,52 @@ value in the range of \code{0} (fully transparent) to \code{1} (fully opaque). I
 provided the fill color will either be fully opaque or use alpha
 information from the color value if it is supplied in the #RRGGBBAA format.}
 }
+\value{
+A list object of class \code{cell_styles}.
+}
 \description{
 The \code{cell_fill()} helper function is to be used with the \code{\link[=tab_style]{tab_style()}}
 function, which itself allows for the setting of custom styles to one or more
 cells. Specifically, the call to \code{cell_fill()} should be bound to the
 \code{styles} argument of \code{\link[=tab_style]{tab_style()}}.
 }
+\section{Figures}{
+
+\if{html}{\figure{man_cell_fill_1.svg}{options: width=100\%}}
+}
+
 \section{Function ID}{
 
 7-16
 }
 
+\examples{
+# Use `exibble` to create a gt table;
+# add styles with `tab_style()` and
+# the `cell_fill()` helper function
+tab_1 <-
+  exibble \%>\%
+  dplyr::select(num, currency) \%>\%
+  gt() \%>\%
+  fmt_number(
+    columns = vars(num, currency),
+    decimals = 1
+  ) \%>\%
+  tab_style(
+    style = cell_fill(color = "lightblue"),
+    locations = cells_body(
+      columns = vars(num),
+      rows = num >= 5000)
+  ) \%>\%
+  tab_style(
+    style = cell_fill(color = "gray85"),
+    locations = cells_body(
+      columns = vars(currency),
+      rows = currency < 100
+    )
+  )
+
+}
 \seealso{
 Other Helper Functions: 
 \code{\link{adjust_luminance}()},

--- a/man/cell_text.Rd
+++ b/man/cell_text.Rd
@@ -52,7 +52,10 @@ condensation/expansion: \code{"ultra-condensed"}, \code{"extra-condensed"},
 can supply percentage values from \verb{0\\\%} to \verb{200\\\%}, inclusive. Negative
 percentage values are not allowed.}
 
-\item{indent}{The indentation of the text.}
+\item{indent}{The indentation of the text. Can be provided as a number that
+is assumed to represent \code{px} values (or could be wrapped in the \code{\link[=px]{px()}})
+helper function. Alternatively, this can be given as a percentage (easily
+constructed with \code{\link[=pct]{pct()}}).}
 
 \item{decorate}{allows for text decoration effect to be applied. Here, we can
 use \code{"overline"}, \code{"line-through"}, or \code{"underline"}.}
@@ -60,17 +63,52 @@ use \code{"overline"}, \code{"line-through"}, or \code{"underline"}.}
 \item{transform}{Allows for the transformation of text. Options are
 \code{"uppercase"}, \code{"lowercase"}, or \code{"capitalize"}.}
 }
+\value{
+A list object of class \code{cell_styles}.
+}
 \description{
 This helper function is to be used with the \code{\link[=tab_style]{tab_style()}} function, which
 itself allows for the setting of custom styles to one or more cells. We can
 also define several styles within a single call of \code{cell_text()} and
 \code{\link[=tab_style]{tab_style()}} will reliably apply those styles to the targeted element.
 }
+\section{Figures}{
+
+\if{html}{\figure{man_cell_text_1.svg}{options: width=100\%}}
+}
+
 \section{Function ID}{
 
 7-15
 }
 
+\examples{
+# Use `exibble` to create a gt table;
+# add styles with `tab_style()` and
+# the `cell_text()` helper function
+tab_1 <-
+  exibble \%>\%
+  dplyr::select(num, currency) \%>\%
+  gt() \%>\%
+  fmt_number(
+    columns = vars(num, currency),
+    decimals = 1
+  ) \%>\%
+  tab_style(
+    style = cell_text(weight = "bold"),
+    locations = cells_body(
+      columns = vars(num),
+      rows = num >= 5000)
+  ) \%>\%
+  tab_style(
+    style = cell_text(style = "italic"),
+    locations = cells_body(
+      columns = vars(currency),
+      rows = currency < 100
+    )
+  )
+
+}
 \seealso{
 Other Helper Functions: 
 \code{\link{adjust_luminance}()},

--- a/man/currency.Rd
+++ b/man/currency.Rd
@@ -36,6 +36,11 @@ string without a name, it will be taken as the \code{default} (i.e.,
 we were to specify currency strings for multiple output contexts, names are
 required each and every context.
 }
+\section{Figures}{
+
+\if{html}{\figure{man_currency_1.svg}{options: width=100\%}}
+}
+
 \section{Function ID}{
 
 7-14

--- a/man/escape_latex.Rd
+++ b/man/escape_latex.Rd
@@ -10,6 +10,9 @@ escape_latex(text)
 \item{text}{a character vector containing the text that is to be
 LaTeX-escaped.}
 }
+\value{
+A character vector.
+}
 \description{
 Text may contain several characters with special meanings in LaTeX. This
 function will transform a character vector so that it is safe to use within

--- a/man/figures/man_cell_borders_1.svg
+++ b/man/figures/man_cell_borders_1.svg
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="361.244mm" height="116.064mm"
+ viewBox="0 0 1024 329"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,8 L858,8 L858,321 L166,321 L166,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,9 L252,9 L252,39 L166,39 L166,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,9 L336,9 L336,39 L252,39 L252,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,9 L389,9 L389,39 L336,39 L336,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,9 L481,9 L481,39 L389,39 L389,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,9 L531,9 L531,39 L481,39 L481,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,9 L667,9 L667,39 L531,39 L531,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,9 L753,9 L753,39 L667,39 L667,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,9 L807,9 L807,39 L753,39 L753,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,9 L858,9 L858,39 L807,39 L807,9"/>
+</g>
+
+<g fill="#bbbbbb" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,74 L252,74 L252,75 L166,75 L166,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,74 L336,74 L336,75 L252,75 L252,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,74 L389,74 L389,75 L336,75 L336,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,74 L481,74 L481,75 L389,75 L389,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,74 L531,74 L531,75 L481,75 L481,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,74 L667,74 L667,75 L531,75 L531,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,74 L753,74 L753,75 L667,75 L667,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,74 L807,74 L807,75 L753,75 L753,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,74 L858,74 L858,75 L807,75 L807,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,74 L252,74 L252,75 L166,75 L166,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,109 L252,109 L252,110 L166,110 L166,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,74 L336,74 L336,75 L252,75 L252,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,109 L336,109 L336,110 L252,110 L252,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,74 L389,74 L389,75 L336,75 L336,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,109 L389,109 L389,110 L336,110 L336,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,74 L481,74 L481,75 L389,75 L389,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,109 L481,109 L481,110 L389,110 L389,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,74 L531,74 L531,75 L481,75 L481,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,109 L531,109 L531,110 L481,110 L481,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,74 L667,74 L667,75 L531,75 L531,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,109 L667,109 L667,110 L531,110 L531,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,74 L753,74 L753,75 L667,75 L667,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,109 L753,109 L753,110 L667,110 L667,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,74 L807,74 L807,75 L753,75 L753,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,109 L807,109 L807,110 L753,110 L753,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,74 L858,74 L858,75 L807,75 L807,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,109 L858,109 L858,110 L807,110 L807,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,109 L252,109 L252,110 L166,110 L166,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,144 L252,144 L252,145 L166,145 L166,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,109 L336,109 L336,110 L252,110 L252,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,144 L336,144 L336,145 L252,145 L252,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,109 L389,109 L389,110 L336,110 L336,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,144 L389,144 L389,145 L336,145 L336,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,109 L481,109 L481,110 L389,110 L389,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,144 L481,144 L481,145 L389,145 L389,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,109 L531,109 L531,110 L481,110 L481,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,144 L531,144 L531,145 L481,145 L481,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,109 L667,109 L667,110 L531,110 L531,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,144 L667,144 L667,145 L531,145 L531,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,109 L753,109 L753,110 L667,110 L667,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,144 L753,144 L753,145 L667,145 L667,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,109 L807,109 L807,110 L753,110 L753,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,144 L807,144 L807,145 L753,145 L753,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,109 L858,109 L858,110 L807,110 L807,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,144 L858,144 L858,145 L807,145 L807,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,144 L252,144 L252,145 L166,145 L166,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,179 L252,179 L252,180 L166,180 L166,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,144 L336,144 L336,145 L252,145 L252,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,179 L336,179 L336,180 L252,180 L252,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,144 L389,144 L389,145 L336,145 L336,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,179 L389,179 L389,180 L336,180 L336,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,144 L481,144 L481,145 L389,145 L389,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,179 L481,179 L481,180 L389,180 L389,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,144 L531,144 L531,145 L481,145 L481,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,179 L531,179 L531,180 L481,180 L481,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,144 L667,144 L667,145 L531,145 L531,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,179 L667,179 L667,180 L531,180 L531,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,144 L753,144 L753,145 L667,145 L667,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,179 L753,179 L753,180 L667,180 L667,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,144 L807,144 L807,145 L753,145 L753,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,179 L807,179 L807,180 L753,180 L753,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,144 L858,144 L858,145 L807,145 L807,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,179 L858,179 L858,180 L807,180 L807,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,179 L252,179 L252,180 L166,180 L166,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,214 L252,214 L252,215 L166,215 L166,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,179 L336,179 L336,180 L252,180 L252,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,214 L336,214 L336,215 L252,215 L252,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,179 L389,179 L389,180 L336,180 L336,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,214 L389,214 L389,215 L336,215 L336,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,179 L481,179 L481,180 L389,180 L389,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,214 L481,214 L481,215 L389,215 L389,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,179 L531,179 L531,180 L481,180 L481,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,214 L531,214 L531,215 L481,215 L481,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,179 L667,179 L667,180 L531,180 L531,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,214 L667,214 L667,215 L531,215 L531,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,179 L753,179 L753,180 L667,180 L667,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,214 L753,214 L753,215 L667,215 L667,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,179 L807,179 L807,180 L753,180 L753,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,214 L807,214 L807,215 L753,215 L753,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,179 L858,179 L858,180 L807,180 L807,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,214 L858,214 L858,215 L807,215 L807,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,214 L252,214 L252,215 L166,215 L166,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,249 L252,249 L252,250 L166,250 L166,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,214 L336,214 L336,215 L252,215 L252,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,249 L336,249 L336,250 L252,250 L252,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,214 L389,214 L389,215 L336,215 L336,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,249 L389,249 L389,250 L336,250 L336,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,214 L481,214 L481,215 L389,215 L389,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,249 L481,249 L481,250 L389,250 L389,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,214 L531,214 L531,215 L481,215 L481,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,249 L531,249 L531,250 L481,250 L481,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,214 L667,214 L667,215 L531,215 L531,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,249 L667,249 L667,250 L531,250 L531,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,214 L753,214 L753,215 L667,215 L667,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,249 L753,249 L753,250 L667,250 L667,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,214 L807,214 L807,215 L753,215 L753,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,249 L807,249 L807,250 L753,250 L753,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,214 L858,214 L858,215 L807,215 L807,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,249 L858,249 L858,250 L807,250 L807,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,249 L252,249 L252,250 L166,250 L166,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,284 L252,284 L252,285 L166,285 L166,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,249 L336,249 L336,250 L252,250 L252,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,284 L336,284 L336,285 L252,285 L252,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,249 L389,249 L389,250 L336,250 L336,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,284 L389,284 L389,285 L336,285 L336,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,249 L481,249 L481,250 L389,250 L389,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,284 L481,284 L481,285 L389,285 L389,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,249 L531,249 L531,250 L481,250 L481,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,284 L531,284 L531,285 L481,285 L481,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,249 L667,249 L667,250 L531,250 L531,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,284 L667,284 L667,285 L531,285 L531,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,249 L753,249 L753,250 L667,250 L667,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,284 L753,284 L753,285 L667,285 L667,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,249 L807,249 L807,250 L753,250 L753,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,284 L807,284 L807,285 L753,285 L753,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,249 L858,249 L858,250 L807,250 L807,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,284 L858,284 L858,285 L807,285 L807,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,284 L252,284 L252,285 L166,285 L166,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,284 L336,284 L336,285 L252,285 L252,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,284 L389,284 L389,285 L336,285 L336,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,284 L481,284 L481,285 L389,285 L389,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,284 L531,284 L531,285 L481,285 L481,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,284 L667,284 L667,285 L531,285 L531,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,284 L753,284 L753,285 L667,285 L667,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,284 L807,284 L807,285 L753,285 L753,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,284 L858,284 L858,285 L807,285 L807,284"/>
+</g>
+
+<g fill="#d3d3d3" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,8 L252,8 L252,10 L166,10 L166,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,38 L252,38 L252,40 L166,40 L166,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,8 L336,8 L336,10 L252,10 L252,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,38 L336,38 L336,40 L252,40 L252,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,8 L389,8 L389,10 L336,10 L336,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,38 L389,38 L389,40 L336,40 L336,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,8 L481,8 L481,10 L389,10 L389,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,38 L481,38 L481,40 L389,40 L389,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,8 L531,8 L531,10 L481,10 L481,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,38 L531,38 L531,40 L481,40 L481,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,8 L667,8 L667,10 L531,10 L531,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,38 L667,38 L667,40 L531,40 L531,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,8 L753,8 L753,10 L667,10 L667,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,38 L753,38 L753,40 L667,40 L667,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,8 L807,8 L807,10 L753,10 L753,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,38 L807,38 L807,40 L753,40 L753,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,8 L858,8 L858,10 L807,10 L807,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,38 L858,38 L858,40 L807,40 L807,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,38 L252,38 L252,40 L166,40 L166,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,38 L336,38 L336,40 L252,40 L252,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,38 L389,38 L389,40 L336,40 L336,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,38 L481,38 L481,40 L389,40 L389,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,38 L531,38 L531,40 L481,40 L481,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,38 L667,38 L667,40 L531,40 L531,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,38 L753,38 L753,40 L667,40 L667,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,38 L807,38 L807,40 L753,40 L753,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,38 L858,38 L858,40 L807,40 L807,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,319 L252,319 L252,321 L166,321 L166,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,319 L336,319 L336,321 L252,321 L252,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,319 L389,319 L389,321 L336,321 L336,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,319 L481,319 L481,321 L389,321 L389,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,319 L531,319 L531,321 L481,321 L481,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,319 L667,319 L667,321 L531,321 L531,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,319 L753,319 L753,321 L667,321 L667,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,319 L807,319 L807,321 L753,321 L753,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,319 L858,319 L858,321 L807,321 L807,319"/>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="216" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >num</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >char</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="352" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >fctr</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >date</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >time</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >datetime</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="687" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >currency</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >group</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="175" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.111e-01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >apricot</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="349" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >one</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-01-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13:35</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-01-01 02:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >49.950</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_1</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2.222e+00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >banana</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="350" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >two</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-02-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >14:40</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-02-02 14:33</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17.950</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_2</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >3.333e+01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >coconut</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="344.5" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >three</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-03-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >15:45</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-03-03 03:44</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="708" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.390</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_3</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >4.444e+02</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >durian</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="349" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >four</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-04-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >16:50</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-04-04 15:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="672" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >65100.000</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_4</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >5.550e+03</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="350" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >five</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-05-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-05-05 04:00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="681" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1325.810</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_5</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="224" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >fig</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="352.5" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >six</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-06-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-06-06 16:11</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13.255</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_6</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >7.770e+05</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grapefruit</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="341" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >seven</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >19:10</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-07-07 05:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="725" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_7</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >8.880e+06</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >honeydew</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="345" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >eight</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-08-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >20:20</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="708" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >0.440</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_8</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+</g>
+</g>
+</svg>

--- a/man/figures/man_cell_borders_2.svg
+++ b/man/figures/man_cell_borders_2.svg
@@ -1,0 +1,421 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="361.244mm" height="117.122mm"
+ viewBox="0 0 1024 332"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,332 L0,332 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,332 L0,332 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,332 L0,332 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,8 L859,8 L859,324 L165,324 L165,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,9 L251,9 L251,39 L165,39 L165,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,9 L335,9 L335,39 L251,39 L251,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,9 L388,9 L388,39 L335,39 L335,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,9 L480,9 L480,39 L388,39 L388,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,9 L530,9 L530,39 L480,39 L480,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,9 L667,9 L667,39 L530,39 L530,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,9 L753,9 L753,39 L667,39 L667,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,9 L808,9 L808,39 L753,39 L753,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,9 L859,9 L859,39 L808,39 L808,9"/>
+</g>
+
+<g fill="#808080" fill-opacity="0.0470588" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,74 L251,74 L251,109 L165,109 L165,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,74 L335,74 L335,109 L251,109 L251,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,74 L388,74 L388,109 L335,109 L335,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,74 L480,74 L480,109 L388,109 L388,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,74 L530,74 L530,109 L480,109 L480,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,74 L667,74 L667,109 L530,109 L530,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,74 L753,74 L753,109 L667,109 L667,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,74 L808,74 L808,109 L753,109 L753,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,74 L859,74 L859,109 L808,109 L808,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,144 L251,144 L251,179 L165,179 L165,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,144 L335,144 L335,179 L251,179 L251,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,144 L388,144 L388,179 L335,179 L335,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,144 L480,144 L480,179 L388,179 L388,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,144 L530,144 L530,179 L480,179 L480,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,144 L667,144 L667,179 L530,179 L530,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,144 L753,144 L753,179 L667,179 L667,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,144 L808,144 L808,179 L753,179 L753,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,144 L859,144 L859,179 L808,179 L808,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,215 L251,215 L251,251 L165,251 L165,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,215 L335,215 L335,251 L251,251 L251,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,215 L388,215 L388,251 L335,251 L335,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,215 L480,215 L480,251 L388,251 L388,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,215 L530,215 L530,251 L480,251 L480,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,215 L667,215 L667,251 L530,251 L530,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,215 L753,215 L753,251 L667,251 L667,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,215 L808,215 L808,251 L753,251 L753,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,215 L859,215 L859,251 L808,251 L808,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,287 L251,287 L251,323 L165,323 L165,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,287 L335,287 L335,323 L251,323 L251,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,287 L388,287 L388,323 L335,323 L335,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,287 L480,287 L480,323 L388,323 L388,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,287 L530,287 L530,323 L480,323 L480,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,287 L667,287 L667,323 L530,323 L530,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,287 L753,287 L753,323 L667,323 L667,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,287 L808,287 L808,323 L753,323 L753,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,287 L859,287 L859,323 L808,323 L808,287"/>
+</g>
+
+<g fill="#d3d3d3" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,74 L251,74 L251,75 L165,75 L165,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,74 L335,74 L335,75 L251,75 L251,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,74 L388,74 L388,75 L335,75 L335,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,74 L480,74 L480,75 L388,75 L388,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,74 L530,74 L530,75 L480,75 L480,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,74 L667,74 L667,75 L530,75 L530,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,74 L753,74 L753,75 L667,75 L667,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,74 L808,74 L808,75 L753,75 L753,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,74 L859,74 L859,75 L808,75 L808,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,74 L251,74 L251,75 L165,75 L165,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,109 L251,109 L251,110 L165,110 L165,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,74 L335,74 L335,75 L251,75 L251,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,109 L335,109 L335,110 L251,110 L251,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,74 L388,74 L388,75 L335,75 L335,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,109 L388,109 L388,110 L335,110 L335,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,74 L480,74 L480,75 L388,75 L388,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,109 L480,109 L480,110 L388,110 L388,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,74 L530,74 L530,75 L480,75 L480,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,109 L530,109 L530,110 L480,110 L480,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,74 L667,74 L667,75 L530,75 L530,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,109 L667,109 L667,110 L530,110 L530,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,74 L753,74 L753,75 L667,75 L667,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,109 L753,109 L753,110 L667,110 L667,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,74 L808,74 L808,75 L753,75 L753,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,109 L808,109 L808,110 L753,110 L753,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,74 L859,74 L859,75 L808,75 L808,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,109 L859,109 L859,110 L808,110 L808,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,109 L251,109 L251,110 L165,110 L165,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,144 L251,144 L251,145 L165,145 L165,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,109 L335,109 L335,110 L251,110 L251,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,144 L335,144 L335,145 L251,145 L251,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,109 L388,109 L388,110 L335,110 L335,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,144 L388,144 L388,145 L335,145 L335,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,109 L480,109 L480,110 L388,110 L388,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,144 L480,144 L480,145 L388,145 L388,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,109 L530,109 L530,110 L480,110 L480,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,144 L530,144 L530,145 L480,145 L480,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,109 L667,109 L667,110 L530,110 L530,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,144 L667,144 L667,145 L530,145 L530,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,109 L753,109 L753,110 L667,110 L667,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,144 L753,144 L753,145 L667,145 L667,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,109 L808,109 L808,110 L753,110 L753,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,144 L808,144 L808,145 L753,145 L753,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,109 L859,109 L859,110 L808,110 L808,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,144 L859,144 L859,145 L808,145 L808,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,144 L251,144 L251,145 L165,145 L165,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,179 L251,179 L251,180 L165,180 L165,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,144 L335,144 L335,145 L251,145 L251,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,179 L335,179 L335,180 L251,180 L251,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,144 L388,144 L388,145 L335,145 L335,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,179 L388,179 L388,180 L335,180 L335,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,144 L480,144 L480,145 L388,145 L388,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,179 L480,179 L480,180 L388,180 L388,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,144 L530,144 L530,145 L480,145 L480,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,179 L530,179 L530,180 L480,180 L480,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,144 L667,144 L667,145 L530,145 L530,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,179 L667,179 L667,180 L530,180 L530,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,144 L753,144 L753,145 L667,145 L667,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,179 L753,179 L753,180 L667,180 L667,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,144 L808,144 L808,145 L753,145 L753,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,179 L808,179 L808,180 L753,180 L753,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,144 L859,144 L859,145 L808,145 L808,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,179 L859,179 L859,180 L808,180 L808,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,179 L251,179 L251,180 L165,180 L165,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,179 L335,179 L335,180 L251,180 L251,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,215 L335,215 L335,216 L251,216 L251,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,179 L388,179 L388,180 L335,180 L335,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,215 L388,215 L388,216 L335,216 L335,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,179 L480,179 L480,180 L388,180 L388,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,215 L480,215 L480,216 L388,216 L388,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,179 L530,179 L530,180 L480,180 L480,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,215 L530,215 L530,216 L480,216 L480,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,179 L667,179 L667,180 L530,180 L530,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,215 L667,215 L667,216 L530,216 L530,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,179 L753,179 L753,180 L667,180 L667,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,215 L753,215 L753,216 L667,216 L667,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,179 L808,179 L808,180 L753,180 L753,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,215 L808,215 L808,216 L753,216 L753,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,179 L859,179 L859,180 L808,180 L808,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,215 L859,215 L859,216 L808,216 L808,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,215 L335,215 L335,216 L250,216 L250,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,251 L335,251 L335,252 L250,252 L250,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,215 L388,215 L388,216 L335,216 L335,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,251 L388,251 L388,252 L335,252 L335,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,215 L480,215 L480,216 L388,216 L388,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,251 L480,251 L480,252 L388,252 L388,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,215 L530,215 L530,216 L480,216 L480,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,251 L530,251 L530,252 L480,252 L480,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,215 L667,215 L667,216 L530,216 L530,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,251 L667,251 L667,252 L530,252 L530,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,215 L753,215 L753,216 L667,216 L667,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,215 L808,215 L808,216 L753,216 L753,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,251 L808,251 L808,252 L753,252 L753,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,215 L859,215 L859,216 L808,216 L808,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,251 L859,251 L859,252 L808,252 L808,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,287 L251,287 L251,288 L165,288 L165,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,251 L335,251 L335,252 L251,252 L251,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,287 L335,287 L335,288 L251,288 L251,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,251 L388,251 L388,252 L335,252 L335,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,287 L388,287 L388,288 L335,288 L335,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,251 L480,251 L480,252 L388,252 L388,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,287 L480,287 L480,288 L388,288 L388,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,251 L530,251 L530,252 L480,252 L480,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,287 L530,287 L530,288 L480,288 L480,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,251 L668,251 L668,252 L530,252 L530,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,287 L668,287 L668,288 L530,288 L530,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M752,251 L808,251 L808,252 L752,252 L752,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M752,287 L808,287 L808,288 L752,288 L752,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,251 L859,251 L859,252 L808,252 L808,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,287 L859,287 L859,288 L808,288 L808,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,287 L251,287 L251,288 L165,288 L165,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,287 L335,287 L335,288 L251,288 L251,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,287 L388,287 L388,288 L335,288 L335,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,287 L480,287 L480,288 L388,288 L388,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,287 L530,287 L530,288 L480,288 L480,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,287 L667,287 L667,288 L530,288 L530,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,287 L808,287 L808,288 L753,288 L753,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,287 L859,287 L859,288 L808,288 L808,287"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,8 L251,8 L251,10 L165,10 L165,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,38 L251,38 L251,40 L165,40 L165,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,8 L335,8 L335,10 L251,10 L251,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,38 L335,38 L335,40 L251,40 L251,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,8 L388,8 L388,10 L335,10 L335,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,38 L388,38 L388,40 L335,40 L335,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,8 L480,8 L480,10 L388,10 L388,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,38 L480,38 L480,40 L388,40 L388,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,8 L530,8 L530,10 L480,10 L480,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,38 L530,38 L530,40 L480,40 L480,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,8 L667,8 L667,10 L530,10 L530,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,38 L667,38 L667,40 L530,40 L530,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,8 L753,8 L753,10 L667,10 L667,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,38 L753,38 L753,40 L667,40 L667,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,8 L808,8 L808,10 L753,10 L753,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,38 L808,38 L808,40 L753,40 L753,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,8 L859,8 L859,10 L808,10 L808,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,38 L859,38 L859,40 L808,40 L808,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,38 L251,38 L251,40 L165,40 L165,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,38 L335,38 L335,40 L251,40 L251,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,38 L388,38 L388,40 L335,40 L335,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,38 L480,38 L480,40 L388,40 L388,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,38 L530,38 L530,40 L480,40 L480,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,38 L667,38 L667,40 L530,40 L530,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,38 L753,38 L753,40 L667,40 L667,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,38 L808,38 L808,40 L753,40 L753,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,38 L859,38 L859,40 L808,40 L808,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,322 L251,322 L251,324 L165,324 L165,322"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M251,322 L335,322 L335,324 L251,324 L251,322"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M335,322 L388,322 L388,324 L335,324 L335,322"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M388,322 L480,322 L480,324 L388,324 L388,322"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M480,322 L530,322 L530,324 L480,324 L480,322"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M530,322 L667,322 L667,324 L530,324 L530,322"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,322 L753,322 L753,324 L667,324 L667,322"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,322 L808,322 L808,324 L753,324 L753,322"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M808,322 L859,322 L859,324 L808,324 L808,322"/>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,214 L251,214 L251,216 L165,216 L165,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,214 L252,214 L252,216 L164,216 L164,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,250 L252,250 L252,252 L164,252 L164,250"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,250 L753,250 L753,252 L667,252 L667,250"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M165,250 L251,250 L251,252 L165,252 L165,250"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M666,250 L754,250 L754,252 L666,252 L666,250"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M666,286 L754,286 L754,288 L666,288 L666,286"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,286 L753,286 L753,288 L667,288 L667,286"/>
+</g>
+
+<g fill="#0000ff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,214 L166,214 L166,252 L164,252 L164,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,214 L252,214 L252,252 L250,252 L250,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,215 L252,215 L252,252 L250,252 L250,215"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M666,251 L668,251 L668,288 L666,288 L666,251"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M666,250 L668,250 L668,288 L666,288 L666,250"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M752,250 L754,250 L754,288 L752,288 L752,250"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M752,251 L754,251 L754,288 L752,288 L752,251"/>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="215" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >num</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="256" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >char</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="351" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >fctr</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >date</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >time</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >datetime</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="687" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >currency</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >group</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="174" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.111e-01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="256" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >apricot</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="348" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >one</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-01-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13:35</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-01-01 02:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >49.950</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_1</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="170" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2.222e+00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="256" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >banana</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="349" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >two</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-02-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >14:40</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-02-02 14:33</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17.950</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_2</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="170" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >3.333e+01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="256" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >coconut</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="343.5" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >three</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-03-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >15:45</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-03-03 03:44</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="708" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.390</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_3</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="170" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >4.444e+02</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="256" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >durian</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="348" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >four</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-04-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >16:50</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-04-04 15:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="672" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >65100.000</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_4</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="170" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >5.550e+03</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="256" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="349" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >five</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-05-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-05-05 04:00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="681" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1325.810</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_5</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="222" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >fig</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="351.5" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >six</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-06-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-06-06 16:11</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13.255</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_6</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="238" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="170" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >7.770e+05</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="256" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grapefruit</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="340" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >seven</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >19:10</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-07-07 05:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="724" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="759" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_7</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="274" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="170" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >8.880e+06</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="256" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >honeydew</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="344" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >eight</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="393" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-08-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="485" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >20:20</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="535" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="708" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >0.440</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_8</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="813" y="310" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+</g>
+</g>
+</svg>

--- a/man/figures/man_cell_fill_1.svg
+++ b/man/figures/man_cell_fill_1.svg
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="361.244mm" height="116.064mm"
+ viewBox="0 0 1024 329"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,8 L595,8 L595,321 L429,321 L429,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,9 L523,9 L523,39 L429,39 L429,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,9 L595,9 L595,39 L523,39 L523,9"/>
+</g>
+
+<g fill="#d9d9d9" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,39 L595,39 L595,74 L523,74 L523,39"/>
+</g>
+
+<g fill="#808080" fill-opacity="0.0470588" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,74 L523,74 L523,109 L429,109 L429,74"/>
+</g>
+
+<g fill="#d9d9d9" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,74 L595,74 L595,109 L523,109 L523,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,109 L595,109 L595,144 L523,144 L523,109"/>
+</g>
+
+<g fill="#808080" fill-opacity="0.0470588" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,144 L523,144 L523,179 L429,179 L429,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,144 L595,144 L595,179 L523,179 L523,144"/>
+</g>
+
+<g fill="#add8e6" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,179 L523,179 L523,214 L429,214 L429,179"/>
+</g>
+
+<g fill="#808080" fill-opacity="0.0470588" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,214 L523,214 L523,249 L429,249 L429,214"/>
+</g>
+
+<g fill="#d9d9d9" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,214 L595,214 L595,249 L523,249 L523,214"/>
+</g>
+
+<g fill="#add8e6" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,249 L523,249 L523,284 L429,284 L429,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,284 L523,284 L523,320 L429,320 L429,284"/>
+</g>
+
+<g fill="#d9d9d9" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,284 L595,284 L595,320 L523,320 L523,284"/>
+</g>
+
+<g fill="#d3d3d3" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,74 L523,74 L523,75 L429,75 L429,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,74 L595,74 L595,75 L523,75 L523,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,74 L523,74 L523,75 L429,75 L429,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,109 L523,109 L523,110 L429,110 L429,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,74 L595,74 L595,75 L523,75 L523,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,109 L595,109 L595,110 L523,110 L523,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,109 L523,109 L523,110 L429,110 L429,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,144 L523,144 L523,145 L429,145 L429,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,109 L595,109 L595,110 L523,110 L523,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,144 L595,144 L595,145 L523,145 L523,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,144 L523,144 L523,145 L429,145 L429,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,179 L523,179 L523,180 L429,180 L429,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,144 L595,144 L595,145 L523,145 L523,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,179 L595,179 L595,180 L523,180 L523,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,179 L523,179 L523,180 L429,180 L429,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,214 L523,214 L523,215 L429,215 L429,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,179 L595,179 L595,180 L523,180 L523,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,214 L595,214 L595,215 L523,215 L523,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,214 L523,214 L523,215 L429,215 L429,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,249 L523,249 L523,250 L429,250 L429,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,214 L595,214 L595,215 L523,215 L523,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,249 L595,249 L595,250 L523,250 L523,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,249 L523,249 L523,250 L429,250 L429,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,284 L523,284 L523,285 L429,285 L429,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,249 L595,249 L595,250 L523,250 L523,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,284 L595,284 L595,285 L523,285 L523,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,284 L523,284 L523,285 L429,285 L429,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,284 L595,284 L595,285 L523,285 L523,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,8 L523,8 L523,10 L429,10 L429,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,38 L523,38 L523,40 L429,40 L429,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,8 L595,8 L595,10 L523,10 L523,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,38 L595,38 L595,40 L523,40 L523,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,38 L523,38 L523,40 L429,40 L429,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,38 L595,38 L595,40 L523,40 L523,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,319 L523,319 L523,321 L429,321 L429,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,319 L595,319 L595,321 L523,321 L523,319"/>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="487" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >num</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="529" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >currency</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="496" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >0.1</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="559" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >50.0</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="496" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2.2</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="559" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17.9</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="487" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >33.3</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="568" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.4</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="478" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >444.4</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="528" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >65,100.0</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="465" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >5,550.0</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="537" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1,325.8</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="495" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="559" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13.3</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="447" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >777,000.0</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="567" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="434" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >8,880,000.0</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="568" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >0.4</text>
+</g>
+</g>
+</svg>

--- a/man/figures/man_cell_text_1.svg
+++ b/man/figures/man_cell_text_1.svg
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="361.244mm" height="116.064mm"
+ viewBox="0 0 1024 329"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,8 L595,8 L595,321 L429,321 L429,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,9 L523,9 L523,39 L429,39 L429,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,9 L595,9 L595,39 L523,39 L523,9"/>
+</g>
+
+<g fill="#808080" fill-opacity="0.0470588" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,74 L523,74 L523,109 L429,109 L429,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,74 L595,74 L595,109 L523,109 L523,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,144 L523,144 L523,179 L429,179 L429,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,144 L595,144 L595,179 L523,179 L523,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,214 L523,214 L523,249 L429,249 L429,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,214 L595,214 L595,249 L523,249 L523,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,284 L523,284 L523,320 L429,320 L429,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,284 L595,284 L595,320 L523,320 L523,284"/>
+</g>
+
+<g fill="#d3d3d3" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,74 L523,74 L523,75 L429,75 L429,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,74 L595,74 L595,75 L523,75 L523,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,74 L523,74 L523,75 L429,75 L429,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,109 L523,109 L523,110 L429,110 L429,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,74 L595,74 L595,75 L523,75 L523,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,109 L595,109 L595,110 L523,110 L523,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,109 L523,109 L523,110 L429,110 L429,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,144 L523,144 L523,145 L429,145 L429,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,109 L595,109 L595,110 L523,110 L523,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,144 L595,144 L595,145 L523,145 L523,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,144 L523,144 L523,145 L429,145 L429,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,179 L523,179 L523,180 L429,180 L429,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,144 L595,144 L595,145 L523,145 L523,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,179 L595,179 L595,180 L523,180 L523,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,179 L523,179 L523,180 L429,180 L429,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,214 L523,214 L523,215 L429,215 L429,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,179 L595,179 L595,180 L523,180 L523,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,214 L595,214 L595,215 L523,215 L523,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,214 L523,214 L523,215 L429,215 L429,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,249 L523,249 L523,250 L429,250 L429,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,214 L595,214 L595,215 L523,215 L523,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,249 L595,249 L595,250 L523,250 L523,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,249 L523,249 L523,250 L429,250 L429,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,284 L523,284 L523,285 L429,285 L429,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,249 L595,249 L595,250 L523,250 L523,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,284 L595,284 L595,285 L523,285 L523,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,284 L523,284 L523,285 L429,285 L429,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,284 L595,284 L595,285 L523,285 L523,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,8 L523,8 L523,10 L429,10 L429,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,38 L523,38 L523,40 L429,40 L429,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,8 L595,8 L595,10 L523,10 L523,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,38 L595,38 L595,40 L523,40 L523,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,38 L523,38 L523,40 L429,40 L429,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,38 L595,38 L595,40 L523,40 L523,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M429,319 L523,319 L523,321 L429,321 L429,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M523,319 L595,319 L595,321 L523,321 L523,319"/>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="487" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >num</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="529" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >currency</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="496" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >0.1</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="559" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+ >50.0</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="496" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2.2</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="559" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+ >17.9</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="487" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >33.3</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="568" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+ >1.4</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="478" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >444.4</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="528" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >65,100.0</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="700" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="465" y="202" font-family="Arial" font-size="16" font-weight="700" font-style="normal" 
+ >5,550.0</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="537" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1,325.8</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="495" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="559" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+ >13.3</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="700" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="447" y="272" font-family="Arial" font-size="16" font-weight="700" font-style="normal" 
+ >777,000.0</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="567" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="700" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="434" y="307" font-family="Arial" font-size="16" font-weight="700" font-style="normal" 
+ >8,880,000.0</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="568" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="italic" 
+ >0.4</text>
+</g>
+</g>
+</svg>

--- a/man/figures/man_currency_1.svg
+++ b/man/figures/man_currency_1.svg
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="361.244mm" height="116.064mm"
+ viewBox="0 0 1024 329"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,329 L0,329 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,8 L860,8 L860,321 L164,321 L164,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,9 L250,9 L250,39 L164,39 L164,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,9 L334,9 L334,39 L250,39 L250,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,9 L387,9 L387,39 L334,39 L334,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,9 L479,9 L479,39 L387,39 L387,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,9 L529,9 L529,39 L479,39 L479,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,9 L665,9 L665,39 L529,39 L529,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,9 L755,9 L755,39 L665,39 L665,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,9 L809,9 L809,39 L755,39 L755,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,9 L860,9 L860,39 L809,39 L809,9"/>
+</g>
+
+<g fill="#808080" fill-opacity="0.0470588" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,74 L250,74 L250,109 L164,109 L164,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,74 L334,74 L334,109 L250,109 L250,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,74 L387,74 L387,109 L334,109 L334,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,74 L479,74 L479,109 L387,109 L387,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,74 L529,74 L529,109 L479,109 L479,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,74 L665,74 L665,109 L529,109 L529,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,74 L755,74 L755,109 L665,109 L665,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,74 L809,74 L809,109 L755,109 L755,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,74 L860,74 L860,109 L809,109 L809,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,144 L250,144 L250,179 L164,179 L164,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,144 L334,144 L334,179 L250,179 L250,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,144 L387,144 L387,179 L334,179 L334,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,144 L479,144 L479,179 L387,179 L387,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,144 L529,144 L529,179 L479,179 L479,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,144 L665,144 L665,179 L529,179 L529,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,144 L755,144 L755,179 L665,179 L665,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,144 L809,144 L809,179 L755,179 L755,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,144 L860,144 L860,179 L809,179 L809,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,214 L250,214 L250,249 L164,249 L164,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,214 L334,214 L334,249 L250,249 L250,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,214 L387,214 L387,249 L334,249 L334,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,214 L479,214 L479,249 L387,249 L387,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,214 L529,214 L529,249 L479,249 L479,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,214 L665,214 L665,249 L529,249 L529,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,214 L755,214 L755,249 L665,249 L665,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,214 L809,214 L809,249 L755,249 L755,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,214 L860,214 L860,249 L809,249 L809,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,284 L250,284 L250,320 L164,320 L164,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,284 L334,284 L334,320 L250,320 L250,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,284 L387,284 L387,320 L334,320 L334,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,284 L479,284 L479,320 L387,320 L387,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,284 L529,284 L529,320 L479,320 L479,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,284 L665,284 L665,320 L529,320 L529,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,284 L755,284 L755,320 L665,320 L665,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,284 L809,284 L809,320 L755,320 L755,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,284 L860,284 L860,320 L809,320 L809,284"/>
+</g>
+
+<g fill="#d3d3d3" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,74 L250,74 L250,75 L164,75 L164,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,74 L334,74 L334,75 L250,75 L250,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,74 L387,74 L387,75 L334,75 L334,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,74 L479,74 L479,75 L387,75 L387,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,74 L529,74 L529,75 L479,75 L479,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,74 L665,74 L665,75 L529,75 L529,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,74 L755,74 L755,75 L665,75 L665,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,74 L809,74 L809,75 L755,75 L755,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,74 L860,74 L860,75 L809,75 L809,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,74 L250,74 L250,75 L164,75 L164,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,109 L250,109 L250,110 L164,110 L164,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,74 L334,74 L334,75 L250,75 L250,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,109 L334,109 L334,110 L250,110 L250,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,74 L387,74 L387,75 L334,75 L334,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,109 L387,109 L387,110 L334,110 L334,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,74 L479,74 L479,75 L387,75 L387,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,109 L479,109 L479,110 L387,110 L387,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,74 L529,74 L529,75 L479,75 L479,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,109 L529,109 L529,110 L479,110 L479,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,74 L665,74 L665,75 L529,75 L529,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,109 L665,109 L665,110 L529,110 L529,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,74 L755,74 L755,75 L665,75 L665,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,109 L755,109 L755,110 L665,110 L665,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,74 L809,74 L809,75 L755,75 L755,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,109 L809,109 L809,110 L755,110 L755,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,74 L860,74 L860,75 L809,75 L809,74"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,109 L860,109 L860,110 L809,110 L809,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,109 L250,109 L250,110 L164,110 L164,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,144 L250,144 L250,145 L164,145 L164,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,109 L334,109 L334,110 L250,110 L250,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,144 L334,144 L334,145 L250,145 L250,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,109 L387,109 L387,110 L334,110 L334,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,144 L387,144 L387,145 L334,145 L334,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,109 L479,109 L479,110 L387,110 L387,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,144 L479,144 L479,145 L387,145 L387,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,109 L529,109 L529,110 L479,110 L479,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,144 L529,144 L529,145 L479,145 L479,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,109 L665,109 L665,110 L529,110 L529,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,144 L665,144 L665,145 L529,145 L529,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,109 L755,109 L755,110 L665,110 L665,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,144 L755,144 L755,145 L665,145 L665,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,109 L809,109 L809,110 L755,110 L755,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,144 L809,144 L809,145 L755,145 L755,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,109 L860,109 L860,110 L809,110 L809,109"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,144 L860,144 L860,145 L809,145 L809,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,144 L250,144 L250,145 L164,145 L164,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,179 L250,179 L250,180 L164,180 L164,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,144 L334,144 L334,145 L250,145 L250,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,179 L334,179 L334,180 L250,180 L250,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,144 L387,144 L387,145 L334,145 L334,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,179 L387,179 L387,180 L334,180 L334,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,144 L479,144 L479,145 L387,145 L387,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,179 L479,179 L479,180 L387,180 L387,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,144 L529,144 L529,145 L479,145 L479,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,179 L529,179 L529,180 L479,180 L479,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,144 L665,144 L665,145 L529,145 L529,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,179 L665,179 L665,180 L529,180 L529,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,144 L755,144 L755,145 L665,145 L665,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,179 L755,179 L755,180 L665,180 L665,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,144 L809,144 L809,145 L755,145 L755,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,179 L809,179 L809,180 L755,180 L755,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,144 L860,144 L860,145 L809,145 L809,144"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,179 L860,179 L860,180 L809,180 L809,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,179 L250,179 L250,180 L164,180 L164,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,214 L250,214 L250,215 L164,215 L164,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,179 L334,179 L334,180 L250,180 L250,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,214 L334,214 L334,215 L250,215 L250,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,179 L387,179 L387,180 L334,180 L334,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,214 L387,214 L387,215 L334,215 L334,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,179 L479,179 L479,180 L387,180 L387,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,214 L479,214 L479,215 L387,215 L387,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,179 L529,179 L529,180 L479,180 L479,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,214 L529,214 L529,215 L479,215 L479,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,179 L665,179 L665,180 L529,180 L529,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,214 L665,214 L665,215 L529,215 L529,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,179 L755,179 L755,180 L665,180 L665,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,214 L755,214 L755,215 L665,215 L665,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,179 L809,179 L809,180 L755,180 L755,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,214 L809,214 L809,215 L755,215 L755,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,179 L860,179 L860,180 L809,180 L809,179"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,214 L860,214 L860,215 L809,215 L809,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,214 L250,214 L250,215 L164,215 L164,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,249 L250,249 L250,250 L164,250 L164,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,214 L334,214 L334,215 L250,215 L250,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,249 L334,249 L334,250 L250,250 L250,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,214 L387,214 L387,215 L334,215 L334,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,249 L387,249 L387,250 L334,250 L334,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,214 L479,214 L479,215 L387,215 L387,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,249 L479,249 L479,250 L387,250 L387,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,214 L529,214 L529,215 L479,215 L479,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,249 L529,249 L529,250 L479,250 L479,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,214 L665,214 L665,215 L529,215 L529,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,249 L665,249 L665,250 L529,250 L529,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,214 L755,214 L755,215 L665,215 L665,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,249 L755,249 L755,250 L665,250 L665,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,214 L809,214 L809,215 L755,215 L755,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,249 L809,249 L809,250 L755,250 L755,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,214 L860,214 L860,215 L809,215 L809,214"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,249 L860,249 L860,250 L809,250 L809,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,249 L250,249 L250,250 L164,250 L164,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,284 L250,284 L250,285 L164,285 L164,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,249 L334,249 L334,250 L250,250 L250,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,284 L334,284 L334,285 L250,285 L250,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,249 L387,249 L387,250 L334,250 L334,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,284 L387,284 L387,285 L334,285 L334,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,249 L479,249 L479,250 L387,250 L387,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,284 L479,284 L479,285 L387,285 L387,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,249 L529,249 L529,250 L479,250 L479,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,284 L529,284 L529,285 L479,285 L479,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,249 L665,249 L665,250 L529,250 L529,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,284 L665,284 L665,285 L529,285 L529,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,249 L755,249 L755,250 L665,250 L665,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,284 L755,284 L755,285 L665,285 L665,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,249 L809,249 L809,250 L755,250 L755,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,284 L809,284 L809,285 L755,285 L755,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,249 L860,249 L860,250 L809,250 L809,249"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,284 L860,284 L860,285 L809,285 L809,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,284 L250,284 L250,285 L164,285 L164,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,284 L334,284 L334,285 L250,285 L250,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,284 L387,284 L387,285 L334,285 L334,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,284 L479,284 L479,285 L387,285 L387,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,284 L529,284 L529,285 L479,285 L479,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,284 L665,284 L665,285 L529,285 L529,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,284 L755,284 L755,285 L665,285 L665,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,284 L809,284 L809,285 L755,285 L755,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,284 L860,284 L860,285 L809,285 L809,284"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,8 L250,8 L250,10 L164,10 L164,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,38 L250,38 L250,40 L164,40 L164,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,8 L334,8 L334,10 L250,10 L250,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,38 L334,38 L334,40 L250,40 L250,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,8 L387,8 L387,10 L334,10 L334,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,38 L387,38 L387,40 L334,40 L334,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,8 L479,8 L479,10 L387,10 L387,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,38 L479,38 L479,40 L387,40 L387,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,8 L529,8 L529,10 L479,10 L479,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,38 L529,38 L529,40 L479,40 L479,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,8 L665,8 L665,10 L529,10 L529,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,38 L665,38 L665,40 L529,40 L529,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,8 L755,8 L755,10 L665,10 L665,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,38 L755,38 L755,40 L665,40 L665,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,8 L809,8 L809,10 L755,10 L755,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,38 L809,38 L809,40 L755,40 L755,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,8 L860,8 L860,10 L809,10 L809,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,38 L860,38 L860,40 L809,40 L809,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,38 L250,38 L250,40 L164,40 L164,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,38 L334,38 L334,40 L250,40 L250,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,38 L387,38 L387,40 L334,40 L334,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,38 L479,38 L479,40 L387,40 L387,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,38 L529,38 L529,40 L479,40 L479,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,38 L665,38 L665,40 L529,40 L529,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,38 L755,38 L755,40 L665,40 L665,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,38 L809,38 L809,40 L755,40 L755,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,38 L860,38 L860,40 L809,40 L809,38"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M164,319 L250,319 L250,321 L164,321 L164,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M250,319 L334,319 L334,321 L250,321 L250,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M334,319 L387,319 L387,321 L334,321 L334,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M387,319 L479,319 L479,321 L387,321 L387,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M479,319 L529,319 L529,321 L479,321 L479,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M529,319 L665,319 L665,321 L529,321 L529,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M665,319 L755,319 L755,321 L665,321 L665,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M755,319 L809,319 L809,321 L755,321 L755,319"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M809,319 L860,319 L860,321 L809,321 L809,319"/>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="214" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >num</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >char</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="350" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >fctr</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >date</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >time</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >datetime</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="689" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >currency</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="29" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >group</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="173" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.111e-01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >apricot</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="347" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >one</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-01-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13:35</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-01-01 02:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="701" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >ƒ49.95</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_1</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="62" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="169" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2.222e+00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >banana</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="348" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >two</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-02-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >14:40</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-02-02 14:33</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="701" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >ƒ17.95</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_2</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="97" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="169" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >3.333e+01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >coconut</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="342.5" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >three</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-03-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >15:45</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-03-03 03:44</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="710" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >ƒ1.39</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_3</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="132" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="169" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >4.444e+02</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >durian</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="347" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >four</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-04-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >16:50</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-04-04 15:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="670" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >ƒ65,100.00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_4</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="167" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="169" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >5.550e+03</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="348" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >five</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-05-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-05-05 04:00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="679" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >ƒ1,325.81</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_5</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="202" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="222" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >fig</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="350.5" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >six</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-06-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-06-06 16:11</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="701" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >ƒ13.26</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_6</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="237" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="169" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >7.770e+05</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grapefruit</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="339" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >seven</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >19:10</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-07-07 05:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="727" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_7</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="272" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="169" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >8.880e+06</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="255" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >honeydew</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="343" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >eight</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="392" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-08-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="484" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >20:20</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="534" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="710" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >ƒ0.44</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="760" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_8</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="814" y="307" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+</g>
+</g>
+</svg>

--- a/man/figures/man_pct_1.svg
+++ b/man/figures/man_pct_1.svg
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="361.244mm" height="114.653mm"
+ viewBox="0 0 1024 325"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,325 L0,325 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,325 L0,325 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,325 L0,325 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,8 L858,8 L858,317 L166,317 L166,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,9 L252,9 L252,35 L166,35 L166,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,9 L336,9 L336,35 L252,35 L252,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,9 L389,9 L389,35 L336,35 L336,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,9 L481,9 L481,35 L389,35 L389,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,9 L531,9 L531,35 L481,35 L481,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,9 L667,9 L667,35 L531,35 L531,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,9 L753,9 L753,35 L667,35 L667,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,9 L807,9 L807,35 L753,35 L753,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,9 L858,9 L858,35 L807,35 L807,9"/>
+</g>
+
+<g fill="#808080" fill-opacity="0.0470588" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,70 L252,70 L252,105 L166,105 L166,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,70 L336,70 L336,105 L252,105 L252,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,70 L389,70 L389,105 L336,105 L336,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,70 L481,70 L481,105 L389,105 L389,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,70 L531,70 L531,105 L481,105 L481,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,70 L667,70 L667,105 L531,105 L531,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,70 L753,70 L753,105 L667,105 L667,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,70 L807,70 L807,105 L753,105 L753,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,70 L858,70 L858,105 L807,105 L807,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,140 L252,140 L252,175 L166,175 L166,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,140 L336,140 L336,175 L252,175 L252,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,140 L389,140 L389,175 L336,175 L336,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,140 L481,140 L481,175 L389,175 L389,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,140 L531,140 L531,175 L481,175 L481,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,140 L667,140 L667,175 L531,175 L531,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,140 L753,140 L753,175 L667,175 L667,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,140 L807,140 L807,175 L753,175 L753,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,140 L858,140 L858,175 L807,175 L807,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,210 L252,210 L252,245 L166,245 L166,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,210 L336,210 L336,245 L252,245 L252,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,210 L389,210 L389,245 L336,245 L336,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,210 L481,210 L481,245 L389,245 L389,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,210 L531,210 L531,245 L481,245 L481,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,210 L667,210 L667,245 L531,245 L531,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,210 L753,210 L753,245 L667,245 L667,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,210 L807,210 L807,245 L753,245 L753,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,210 L858,210 L858,245 L807,245 L807,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,280 L252,280 L252,316 L166,316 L166,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,280 L336,280 L336,316 L252,316 L252,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,280 L389,280 L389,316 L336,316 L336,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,280 L481,280 L481,316 L389,316 L389,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,280 L531,280 L531,316 L481,316 L481,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,280 L667,280 L667,316 L531,316 L531,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,280 L753,280 L753,316 L667,316 L667,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,280 L807,280 L807,316 L753,316 L753,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,280 L858,280 L858,316 L807,316 L807,280"/>
+</g>
+
+<g fill="#d3d3d3" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,70 L252,70 L252,71 L166,71 L166,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,70 L336,70 L336,71 L252,71 L252,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,70 L389,70 L389,71 L336,71 L336,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,70 L481,70 L481,71 L389,71 L389,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,70 L531,70 L531,71 L481,71 L481,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,70 L667,70 L667,71 L531,71 L531,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,70 L753,70 L753,71 L667,71 L667,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,70 L807,70 L807,71 L753,71 L753,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,70 L858,70 L858,71 L807,71 L807,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,70 L252,70 L252,71 L166,71 L166,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,105 L252,105 L252,106 L166,106 L166,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,70 L336,70 L336,71 L252,71 L252,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,105 L336,105 L336,106 L252,106 L252,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,70 L389,70 L389,71 L336,71 L336,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,105 L389,105 L389,106 L336,106 L336,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,70 L481,70 L481,71 L389,71 L389,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,105 L481,105 L481,106 L389,106 L389,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,70 L531,70 L531,71 L481,71 L481,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,105 L531,105 L531,106 L481,106 L481,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,70 L667,70 L667,71 L531,71 L531,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,105 L667,105 L667,106 L531,106 L531,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,70 L753,70 L753,71 L667,71 L667,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,105 L753,105 L753,106 L667,106 L667,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,70 L807,70 L807,71 L753,71 L753,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,105 L807,105 L807,106 L753,106 L753,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,70 L858,70 L858,71 L807,71 L807,70"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,105 L858,105 L858,106 L807,106 L807,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,105 L252,105 L252,106 L166,106 L166,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,140 L252,140 L252,141 L166,141 L166,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,105 L336,105 L336,106 L252,106 L252,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,140 L336,140 L336,141 L252,141 L252,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,105 L389,105 L389,106 L336,106 L336,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,140 L389,140 L389,141 L336,141 L336,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,105 L481,105 L481,106 L389,106 L389,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,140 L481,140 L481,141 L389,141 L389,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,105 L531,105 L531,106 L481,106 L481,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,140 L531,140 L531,141 L481,141 L481,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,105 L667,105 L667,106 L531,106 L531,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,140 L667,140 L667,141 L531,141 L531,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,105 L753,105 L753,106 L667,106 L667,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,140 L753,140 L753,141 L667,141 L667,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,105 L807,105 L807,106 L753,106 L753,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,140 L807,140 L807,141 L753,141 L753,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,105 L858,105 L858,106 L807,106 L807,105"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,140 L858,140 L858,141 L807,141 L807,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,140 L252,140 L252,141 L166,141 L166,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,175 L252,175 L252,176 L166,176 L166,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,140 L336,140 L336,141 L252,141 L252,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,175 L336,175 L336,176 L252,176 L252,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,140 L389,140 L389,141 L336,141 L336,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,175 L389,175 L389,176 L336,176 L336,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,140 L481,140 L481,141 L389,141 L389,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,175 L481,175 L481,176 L389,176 L389,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,140 L531,140 L531,141 L481,141 L481,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,175 L531,175 L531,176 L481,176 L481,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,140 L667,140 L667,141 L531,141 L531,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,175 L667,175 L667,176 L531,176 L531,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,140 L753,140 L753,141 L667,141 L667,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,175 L753,175 L753,176 L667,176 L667,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,140 L807,140 L807,141 L753,141 L753,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,175 L807,175 L807,176 L753,176 L753,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,140 L858,140 L858,141 L807,141 L807,140"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,175 L858,175 L858,176 L807,176 L807,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,175 L252,175 L252,176 L166,176 L166,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,210 L252,210 L252,211 L166,211 L166,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,175 L336,175 L336,176 L252,176 L252,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,210 L336,210 L336,211 L252,211 L252,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,175 L389,175 L389,176 L336,176 L336,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,210 L389,210 L389,211 L336,211 L336,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,175 L481,175 L481,176 L389,176 L389,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,210 L481,210 L481,211 L389,211 L389,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,175 L531,175 L531,176 L481,176 L481,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,210 L531,210 L531,211 L481,211 L481,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,175 L667,175 L667,176 L531,176 L531,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,210 L667,210 L667,211 L531,211 L531,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,175 L753,175 L753,176 L667,176 L667,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,210 L753,210 L753,211 L667,211 L667,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,175 L807,175 L807,176 L753,176 L753,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,210 L807,210 L807,211 L753,211 L753,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,175 L858,175 L858,176 L807,176 L807,175"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,210 L858,210 L858,211 L807,211 L807,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,210 L252,210 L252,211 L166,211 L166,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,245 L252,245 L252,246 L166,246 L166,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,210 L336,210 L336,211 L252,211 L252,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,245 L336,245 L336,246 L252,246 L252,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,210 L389,210 L389,211 L336,211 L336,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,245 L389,245 L389,246 L336,246 L336,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,210 L481,210 L481,211 L389,211 L389,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,245 L481,245 L481,246 L389,246 L389,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,210 L531,210 L531,211 L481,211 L481,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,245 L531,245 L531,246 L481,246 L481,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,210 L667,210 L667,211 L531,211 L531,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,245 L667,245 L667,246 L531,246 L531,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,210 L753,210 L753,211 L667,211 L667,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,245 L753,245 L753,246 L667,246 L667,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,210 L807,210 L807,211 L753,211 L753,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,245 L807,245 L807,246 L753,246 L753,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,210 L858,210 L858,211 L807,211 L807,210"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,245 L858,245 L858,246 L807,246 L807,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,245 L252,245 L252,246 L166,246 L166,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,280 L252,280 L252,281 L166,281 L166,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,245 L336,245 L336,246 L252,246 L252,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,280 L336,280 L336,281 L252,281 L252,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,245 L389,245 L389,246 L336,246 L336,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,280 L389,280 L389,281 L336,281 L336,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,245 L481,245 L481,246 L389,246 L389,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,280 L481,280 L481,281 L389,281 L389,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,245 L531,245 L531,246 L481,246 L481,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,280 L531,280 L531,281 L481,281 L481,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,245 L667,245 L667,246 L531,246 L531,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,280 L667,280 L667,281 L531,281 L531,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,245 L753,245 L753,246 L667,246 L667,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,280 L753,280 L753,281 L667,281 L667,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,245 L807,245 L807,246 L753,246 L753,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,280 L807,280 L807,281 L753,281 L753,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,245 L858,245 L858,246 L807,246 L807,245"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,280 L858,280 L858,281 L807,281 L807,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,280 L252,280 L252,281 L166,281 L166,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,280 L336,280 L336,281 L252,281 L252,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,280 L389,280 L389,281 L336,281 L336,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,280 L481,280 L481,281 L389,281 L389,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,280 L531,280 L531,281 L481,281 L481,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,280 L667,280 L667,281 L531,281 L531,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,280 L753,280 L753,281 L667,281 L667,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,280 L807,280 L807,281 L753,281 L753,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,280 L858,280 L858,281 L807,281 L807,280"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,8 L252,8 L252,10 L166,10 L166,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,34 L252,34 L252,36 L166,36 L166,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,8 L336,8 L336,10 L252,10 L252,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,34 L336,34 L336,36 L252,36 L252,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,8 L389,8 L389,10 L336,10 L336,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,34 L389,34 L389,36 L336,36 L336,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,8 L481,8 L481,10 L389,10 L389,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,34 L481,34 L481,36 L389,36 L389,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,8 L531,8 L531,10 L481,10 L481,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,34 L531,34 L531,36 L481,36 L481,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,8 L667,8 L667,10 L531,10 L531,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,34 L667,34 L667,36 L531,36 L531,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,8 L753,8 L753,10 L667,10 L667,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,34 L753,34 L753,36 L667,36 L667,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,8 L807,8 L807,10 L753,10 L753,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,34 L807,34 L807,36 L753,36 L753,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,8 L858,8 L858,10 L807,10 L807,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,34 L858,34 L858,36 L807,36 L807,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,34 L252,34 L252,36 L166,36 L166,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,34 L336,34 L336,36 L252,36 L252,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,34 L389,34 L389,36 L336,36 L336,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,34 L481,34 L481,36 L389,36 L389,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,34 L531,34 L531,36 L481,36 L481,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,34 L667,34 L667,36 L531,36 L531,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,34 L753,34 L753,36 L667,36 L667,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,34 L807,34 L807,36 L753,36 L753,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,34 L858,34 L858,36 L807,36 L807,34"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M166,315 L252,315 L252,317 L166,317 L166,315"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M252,315 L336,315 L336,317 L252,317 L252,315"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M336,315 L389,315 L389,317 L336,317 L336,315"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M389,315 L481,315 L481,317 L389,317 L389,315"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M481,315 L531,315 L531,317 L481,317 L481,315"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M531,315 L667,315 L667,317 L531,317 L531,315"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M667,315 L753,315 L753,317 L667,317 L667,315"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M753,315 L807,315 L807,317 L753,317 L753,315"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M807,315 L858,315 L858,317 L807,317 L807,315"/>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="223" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >num</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >char</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="354.5" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >fctr</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >date</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >time</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >datetime</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="701" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >currency</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >row</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="26" font-family="Arial" font-size="12" font-weight="400" font-style="normal" 
+ >group</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="175" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.111e-01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >apricot</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="349" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >one</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-01-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13:35</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-01-01 02:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >49.950</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_1</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="58" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2.222e+00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >banana</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="350" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >two</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-02-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >14:40</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-02-02 14:33</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17.950</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_2</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="93" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >3.333e+01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >coconut</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="344.5" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >three</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-03-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >15:45</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-03-03 03:44</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="708" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.390</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_3</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="128" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >4.444e+02</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >durian</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="349" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >four</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-04-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >16:50</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-04-04 15:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="672" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >65100.000</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_4</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="163" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >5.550e+03</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="350" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >five</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-05-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-05-05 04:00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="681" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1325.810</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_5</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="198" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="224" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >fig</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="352.5" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >six</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-06-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-06-06 16:11</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="699" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13.255</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_6</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="233" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >7.770e+05</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grapefruit</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="341" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >seven</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >19:10</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-07-07 05:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="725" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_7</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="268" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="171" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >8.880e+06</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="257" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >honeydew</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="345" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >eight</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="394" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-08-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="486" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >20:20</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="536" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="708" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >0.440</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="758" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_8</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="812" y="303" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+</g>
+</g>
+</svg>

--- a/man/figures/man_px_1.svg
+++ b/man/figures/man_px_1.svg
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="361.244mm" height="117.828mm"
+ viewBox="0 0 1024 334"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,334 L0,334 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,334 L0,334 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,334 L0,334 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,8 L863,8 L863,326 L160,326 L160,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,9 L246,9 L246,44 L160,44 L160,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,9 L330,9 L330,44 L246,44 L246,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,9 L383,9 L383,44 L330,44 L330,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,9 L475,9 L475,44 L383,44 L383,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,9 L525,9 L525,44 L475,44 L475,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,9 L661,9 L661,44 L525,44 L525,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,9 L748,9 L748,44 L661,44 L661,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,9 L802,9 L802,44 L748,44 L748,9"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,9 L863,9 L863,44 L802,44 L802,9"/>
+</g>
+
+<g fill="#808080" fill-opacity="0.0470588" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,79 L246,79 L246,114 L160,114 L160,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,79 L330,79 L330,114 L246,114 L246,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,79 L383,79 L383,114 L330,114 L330,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,79 L475,79 L475,114 L383,114 L383,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,79 L525,79 L525,114 L475,114 L475,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,79 L661,79 L661,114 L525,114 L525,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,79 L748,79 L748,114 L661,114 L661,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,79 L802,79 L802,114 L748,114 L748,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,79 L863,79 L863,114 L802,114 L802,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,149 L246,149 L246,184 L160,184 L160,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,149 L330,149 L330,184 L246,184 L246,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,149 L383,149 L383,184 L330,184 L330,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,149 L475,149 L475,184 L383,184 L383,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,149 L525,149 L525,184 L475,184 L475,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,149 L661,149 L661,184 L525,184 L525,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,149 L748,149 L748,184 L661,184 L661,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,149 L802,149 L802,184 L748,184 L748,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,149 L863,149 L863,184 L802,184 L802,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,219 L246,219 L246,254 L160,254 L160,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,219 L330,219 L330,254 L246,254 L246,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,219 L383,219 L383,254 L330,254 L330,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,219 L475,219 L475,254 L383,254 L383,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,219 L525,219 L525,254 L475,254 L475,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,219 L661,219 L661,254 L525,254 L525,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,219 L748,219 L748,254 L661,254 L661,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,219 L802,219 L802,254 L748,254 L748,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,219 L863,219 L863,254 L802,254 L802,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,289 L246,289 L246,325 L160,325 L160,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,289 L330,289 L330,325 L246,325 L246,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,289 L383,289 L383,325 L330,325 L330,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,289 L475,289 L475,325 L383,325 L383,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,289 L525,289 L525,325 L475,325 L475,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,289 L661,289 L661,325 L525,325 L525,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,289 L748,289 L748,325 L661,325 L661,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,289 L802,289 L802,325 L748,325 L748,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,289 L863,289 L863,325 L802,325 L802,289"/>
+</g>
+
+<g fill="#d3d3d3" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,79 L246,79 L246,80 L160,80 L160,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,79 L330,79 L330,80 L246,80 L246,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,79 L383,79 L383,80 L330,80 L330,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,79 L475,79 L475,80 L383,80 L383,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,79 L525,79 L525,80 L475,80 L475,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,79 L661,79 L661,80 L525,80 L525,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,79 L748,79 L748,80 L661,80 L661,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,79 L802,79 L802,80 L748,80 L748,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,79 L863,79 L863,80 L802,80 L802,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,79 L246,79 L246,80 L160,80 L160,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,114 L246,114 L246,115 L160,115 L160,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,79 L330,79 L330,80 L246,80 L246,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,114 L330,114 L330,115 L246,115 L246,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,79 L383,79 L383,80 L330,80 L330,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,114 L383,114 L383,115 L330,115 L330,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,79 L475,79 L475,80 L383,80 L383,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,114 L475,114 L475,115 L383,115 L383,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,79 L525,79 L525,80 L475,80 L475,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,114 L525,114 L525,115 L475,115 L475,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,79 L661,79 L661,80 L525,80 L525,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,114 L661,114 L661,115 L525,115 L525,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,79 L748,79 L748,80 L661,80 L661,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,114 L748,114 L748,115 L661,115 L661,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,79 L802,79 L802,80 L748,80 L748,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,114 L802,114 L802,115 L748,115 L748,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,79 L863,79 L863,80 L802,80 L802,79"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,114 L863,114 L863,115 L802,115 L802,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,114 L246,114 L246,115 L160,115 L160,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,149 L246,149 L246,150 L160,150 L160,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,114 L330,114 L330,115 L246,115 L246,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,149 L330,149 L330,150 L246,150 L246,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,114 L383,114 L383,115 L330,115 L330,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,149 L383,149 L383,150 L330,150 L330,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,114 L475,114 L475,115 L383,115 L383,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,149 L475,149 L475,150 L383,150 L383,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,114 L525,114 L525,115 L475,115 L475,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,149 L525,149 L525,150 L475,150 L475,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,114 L661,114 L661,115 L525,115 L525,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,149 L661,149 L661,150 L525,150 L525,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,114 L748,114 L748,115 L661,115 L661,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,149 L748,149 L748,150 L661,150 L661,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,114 L802,114 L802,115 L748,115 L748,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,149 L802,149 L802,150 L748,150 L748,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,114 L863,114 L863,115 L802,115 L802,114"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,149 L863,149 L863,150 L802,150 L802,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,149 L246,149 L246,150 L160,150 L160,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,184 L246,184 L246,185 L160,185 L160,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,149 L330,149 L330,150 L246,150 L246,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,184 L330,184 L330,185 L246,185 L246,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,149 L383,149 L383,150 L330,150 L330,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,184 L383,184 L383,185 L330,185 L330,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,149 L475,149 L475,150 L383,150 L383,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,184 L475,184 L475,185 L383,185 L383,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,149 L525,149 L525,150 L475,150 L475,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,184 L525,184 L525,185 L475,185 L475,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,149 L661,149 L661,150 L525,150 L525,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,184 L661,184 L661,185 L525,185 L525,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,149 L748,149 L748,150 L661,150 L661,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,184 L748,184 L748,185 L661,185 L661,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,149 L802,149 L802,150 L748,150 L748,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,184 L802,184 L802,185 L748,185 L748,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,149 L863,149 L863,150 L802,150 L802,149"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,184 L863,184 L863,185 L802,185 L802,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,184 L246,184 L246,185 L160,185 L160,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,219 L246,219 L246,220 L160,220 L160,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,184 L330,184 L330,185 L246,185 L246,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,219 L330,219 L330,220 L246,220 L246,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,184 L383,184 L383,185 L330,185 L330,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,219 L383,219 L383,220 L330,220 L330,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,184 L475,184 L475,185 L383,185 L383,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,219 L475,219 L475,220 L383,220 L383,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,184 L525,184 L525,185 L475,185 L475,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,219 L525,219 L525,220 L475,220 L475,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,184 L661,184 L661,185 L525,185 L525,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,219 L661,219 L661,220 L525,220 L525,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,184 L748,184 L748,185 L661,185 L661,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,219 L748,219 L748,220 L661,220 L661,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,184 L802,184 L802,185 L748,185 L748,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,219 L802,219 L802,220 L748,220 L748,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,184 L863,184 L863,185 L802,185 L802,184"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,219 L863,219 L863,220 L802,220 L802,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,219 L246,219 L246,220 L160,220 L160,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,254 L246,254 L246,255 L160,255 L160,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,219 L330,219 L330,220 L246,220 L246,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,254 L330,254 L330,255 L246,255 L246,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,219 L383,219 L383,220 L330,220 L330,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,254 L383,254 L383,255 L330,255 L330,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,219 L475,219 L475,220 L383,220 L383,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,254 L475,254 L475,255 L383,255 L383,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,219 L525,219 L525,220 L475,220 L475,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,254 L525,254 L525,255 L475,255 L475,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,219 L661,219 L661,220 L525,220 L525,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,254 L661,254 L661,255 L525,255 L525,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,219 L748,219 L748,220 L661,220 L661,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,254 L748,254 L748,255 L661,255 L661,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,219 L802,219 L802,220 L748,220 L748,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,254 L802,254 L802,255 L748,255 L748,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,219 L863,219 L863,220 L802,220 L802,219"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,254 L863,254 L863,255 L802,255 L802,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,254 L246,254 L246,255 L160,255 L160,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,289 L246,289 L246,290 L160,290 L160,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,254 L330,254 L330,255 L246,255 L246,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,289 L330,289 L330,290 L246,290 L246,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,254 L383,254 L383,255 L330,255 L330,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,289 L383,289 L383,290 L330,290 L330,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,254 L475,254 L475,255 L383,255 L383,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,289 L475,289 L475,290 L383,290 L383,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,254 L525,254 L525,255 L475,255 L475,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,289 L525,289 L525,290 L475,290 L475,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,254 L661,254 L661,255 L525,255 L525,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,289 L661,289 L661,290 L525,290 L525,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,254 L748,254 L748,255 L661,255 L661,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,289 L748,289 L748,290 L661,290 L661,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,254 L802,254 L802,255 L748,255 L748,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,289 L802,289 L802,290 L748,290 L748,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,254 L863,254 L863,255 L802,255 L802,254"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,289 L863,289 L863,290 L802,290 L802,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,289 L246,289 L246,290 L160,290 L160,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,289 L330,289 L330,290 L246,290 L246,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,289 L383,289 L383,290 L330,290 L330,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,289 L475,289 L475,290 L383,290 L383,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,289 L525,289 L525,290 L475,290 L475,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,289 L661,289 L661,290 L525,290 L525,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,289 L748,289 L748,290 L661,290 L661,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,289 L802,289 L802,290 L748,290 L748,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,289 L863,289 L863,290 L802,290 L802,289"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,8 L246,8 L246,10 L160,10 L160,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,43 L246,43 L246,45 L160,45 L160,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,8 L330,8 L330,10 L246,10 L246,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,43 L330,43 L330,45 L246,45 L246,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,8 L383,8 L383,10 L330,10 L330,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,43 L383,43 L383,45 L330,45 L330,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,8 L475,8 L475,10 L383,10 L383,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,43 L475,43 L475,45 L383,45 L383,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,8 L525,8 L525,10 L475,10 L475,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,43 L525,43 L525,45 L475,45 L475,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,8 L661,8 L661,10 L525,10 L525,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,43 L661,43 L661,45 L525,45 L525,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,8 L748,8 L748,10 L661,10 L661,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,43 L748,43 L748,45 L661,45 L661,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,8 L802,8 L802,10 L748,10 L748,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,43 L802,43 L802,45 L748,45 L748,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,8 L863,8 L863,10 L802,10 L802,8"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,43 L863,43 L863,45 L802,45 L802,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,43 L246,43 L246,45 L160,45 L160,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,43 L330,43 L330,45 L246,45 L246,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,43 L383,43 L383,45 L330,45 L330,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,43 L475,43 L475,45 L383,45 L383,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,43 L525,43 L525,45 L475,45 L475,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,43 L661,43 L661,45 L525,45 L525,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,43 L748,43 L748,45 L661,45 L661,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,43 L802,43 L802,45 L748,45 L748,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,43 L863,43 L863,45 L802,45 L802,43"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M160,324 L246,324 L246,326 L160,326 L160,324"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M246,324 L330,324 L330,326 L246,326 L246,324"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M330,324 L383,324 L383,326 L330,326 L330,324"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M383,324 L475,324 L475,326 L383,326 L383,324"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M475,324 L525,324 L525,326 L475,326 L475,324"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M525,324 L661,324 L661,326 L525,326 L525,324"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M661,324 L748,324 L748,326 L661,326 L661,324"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M748,324 L802,324 L802,326 L748,326 L748,324"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M802,324 L863,324 L863,326 L802,326 L802,324"/>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="202" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >num</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >char</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="342" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >fctr</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >date</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >time</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >datetime</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="666" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >currency</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >row</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="33" font-family="Arial" font-size="20" font-weight="400" font-style="normal" 
+ >group</text>
+</g>
+
+<g fill="#333333" fill-opacity="1" stroke="#333333" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="169" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.111e-01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >apricot</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="343" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >one</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-01-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13:35</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-01-01 02:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="694" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >49.950</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_1</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="67" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="165" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2.222e+00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >banana</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="344" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >two</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-02-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >14:40</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-02-02 14:33</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="694" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17.950</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_2</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="102" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="165" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >3.333e+01</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >coconut</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="338.5" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >three</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-03-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >15:45</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-03-03 03:44</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="703" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1.390</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_3</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="137" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="165" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >4.444e+02</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >durian</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="343" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >four</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-04-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >16:50</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-04-04 15:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="667" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >65100.000</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_4</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="172" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_a</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="165" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >5.550e+03</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="344" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >five</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-05-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >17:55</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-05-05 04:00</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="676" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >1325.810</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_5</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="207" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="218" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >fig</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="346.5" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >six</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-06-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-06-06 16:11</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="694" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >13.255</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_6</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="242" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="165" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >7.770e+05</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grapefruit</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="335" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >seven</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >19:10</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2018-07-07 05:22</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="720" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_7</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="277" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="165" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >8.880e+06</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="251" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >honeydew</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="339" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >eight</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="388" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >2015-08-15</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="480" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >20:20</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="530" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >NA</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="703" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >0.440</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="753" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >row_8</text>
+<text fill="#333333" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="312" font-family="Arial" font-size="16" font-weight="400" font-style="normal" 
+ >grp_b</text>
+</g>
+</g>
+</svg>

--- a/man/gt_latex_dependencies.Rd
+++ b/man/gt_latex_dependencies.Rd
@@ -6,6 +6,9 @@
 \usage{
 gt_latex_dependencies()
 }
+\value{
+An object of class \code{knit_asis}.
+}
 \description{
 When working with Rnw (Sweave) files or otherwise writing LaTeX code,
 including a \strong{gt} table can be problematic if we don't have knowledge

--- a/man/html.Rd
+++ b/man/html.Rd
@@ -11,13 +11,15 @@ html(text, ...)
 preserved.}
 }
 \value{
-A character object that is tagged as an HTML fragment that is not to
-be sanitized.
-
-A character object of class \code{html}.
+A character object of class \code{html}. It's tagged as an HTML fragment
+that is not to be sanitized.
 }
 \description{
-Interpret input text as HTML-formatted text
+For certain pieces of text (like in column labels or table headings) we may
+want to express them as raw HTML. In fact, with HTML, anything goes so it can
+be much more than just text. The \code{html()} function will guard the input HTML
+against escaping, so, your HTML tags will come through as HTML when
+rendered... to HTML.
 }
 \section{Figures}{
 

--- a/man/md.Rd
+++ b/man/md.Rd
@@ -10,13 +10,15 @@ md(text)
 \item{text}{The text that is understood to contain Markdown formatting.}
 }
 \value{
-A character object that is tagged for a Markdown-to-HTML
-transformation.
-
-A character object of class \code{from_markdown}.
+A character object of class \code{from_markdown}. It's tagged as being
+Markdown text and it will undergo conversion to HTML.
 }
 \description{
-Interpret input text as Markdown-formatted text
+Markdown! It's a wonderful thing. We can use it in certain places (e.g.,
+footnotes, source notes, the table title, etc.) and expect it to render to
+HTML as Markdown does. There is the \code{\link[=html]{html()}} helper that allows you to ferry
+in HTML but this function \code{md()}... it's almost like a two-for-one deal (you
+get to use Markdown plus any HTML fragments \emph{at the same time}).
 }
 \section{Figures}{
 

--- a/man/pct.Rd
+++ b/man/pct.Rd
@@ -11,14 +11,35 @@ pct(x)
 \code{\link[=tab_options]{tab_options()}} arguments that can take percentage values
 (e.g., \code{table.width}).}
 }
+\value{
+A character vector with a single value in percentage units.
+}
 \description{
 Helper for providing a numeric value as percentage
 }
+\section{Figures}{
+
+\if{html}{\figure{man_pct_1.svg}{options: width=100\%}}
+}
+
 \section{Function ID}{
 
 7-4
 }
 
+\examples{
+# Use `exibble` to create a gt table;
+# use the `pct()` helper to define the
+# font size for the column labels
+tab_1 <-
+  exibble \%>\%
+  gt() \%>\%
+  tab_style(
+    style = cell_text(size = pct(75)),
+    locations = cells_column_labels(columns = TRUE)
+  )
+
+}
 \seealso{
 Other Helper Functions: 
 \code{\link{adjust_luminance}()},

--- a/man/pct.Rd
+++ b/man/pct.Rd
@@ -15,7 +15,14 @@ pct(x)
 A character vector with a single value in percentage units.
 }
 \description{
-Helper for providing a numeric value as percentage
+A percentage value acts as a length value that is relative to an initial
+state. For instance an 80 percent value for something will size the target
+to 80 percent the size of its 'previous' value. This type of sizing is
+useful for sizing up or down a length value with an intuitive measure. This
+helper function can be used for the setting of font sizes (e.g., in
+\code{\link[=cell_text]{cell_text()}}) and altering the thicknesses of lines (e.g., in
+\code{\link[=cell_borders]{cell_borders()}}). Should a more exact definition of size be required, the
+analogous helper function \code{\link[=pct]{pct()}} will be more useful.
 }
 \section{Figures}{
 

--- a/man/px.Rd
+++ b/man/px.Rd
@@ -11,14 +11,35 @@ px(x)
 some \code{\link[=tab_options]{tab_options()}} arguments that can take values as units of
 pixels (e.g., \code{table.font.size}).}
 }
+\value{
+A character vector with a single value in pixel units.
+}
 \description{
 Helper for providing a numeric value as pixels value
 }
+\section{Figures}{
+
+\if{html}{\figure{man_px_1.svg}{options: width=100\%}}
+}
+
 \section{Function ID}{
 
 7-3
 }
 
+\examples{
+# Use `exibble` to create a gt table;
+# use the `px()` helper to define the
+# font size for the column labels
+tab_1 <-
+  exibble \%>\%
+  gt() \%>\%
+  tab_style(
+    style = cell_text(size = px(20)),
+    locations = cells_column_labels(columns = TRUE)
+  )
+
+}
 \seealso{
 Other Helper Functions: 
 \code{\link{adjust_luminance}()},

--- a/man/px.Rd
+++ b/man/px.Rd
@@ -15,7 +15,11 @@ pixels (e.g., \code{table.font.size}).}
 A character vector with a single value in pixel units.
 }
 \description{
-Helper for providing a numeric value as pixels value
+For certain parameters, a length value is required. Examples include the
+setting of font sizes (e.g., in \code{\link[=cell_text]{cell_text()}}) and thicknesses of lines
+(e.g., in \code{\link[=cell_borders]{cell_borders()}}). Setting a length in pixels with \code{px()} allows
+for an absolute definition of size as opposed to the analogous helper
+function \code{\link[=pct]{pct()}}.
 }
 \section{Figures}{
 

--- a/man/random_id.Rd
+++ b/man/random_id.Rd
@@ -9,6 +9,9 @@ random_id(n = 10)
 \arguments{
 \item{n}{The number of lowercase letters to use for the random ID.}
 }
+\value{
+A character vector containing a single, random ID.
+}
 \description{
 This helper function is to be used with \code{id} argument of the \code{\link[=gt]{gt()}} function.
 The \code{id} option in \code{\link[=gt]{gt()}} uses \code{random_id()} by default however we can


### PR DESCRIPTION
This expands on the documentation already available. Includes examples, SVGs, `@return` values, and more, for those functions previously missing those documentation features.

Fixes: https://github.com/rstudio/gt/issues/446
Fixes: https://github.com/rstudio/gt/issues/422