### PR TITLE
Place style block in <head>

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -311,7 +311,7 @@ as_raw_html <- function(data,
       inline_html_styles(css_tbl = get_css_tbl(data))
   }
 
-  html_table
+  htmltools::HTML(html_table)
 }
 
 #' Output a gt object as LaTeX

--- a/R/print.R
+++ b/R/print.R
@@ -81,7 +81,11 @@ as.tags.gt_tbl <- function(x, ...) {
   # Attach the dependency to the HTML table
   html_tbl <-
     htmltools::tagList(
-      htmltools::tags$style(htmltools::HTML(css)),
+      htmltools::tags$head(
+        htmltools::tags$style(
+          htmltools::HTML(css)
+        )
+      ),
       htmltools::tags$div(
         id = id,
         style = htmltools::css(


### PR DESCRIPTION
This change places the CSS styles inside of the `<head>`. This may be useful for ensuring that CSS styles are preserved in an email context. 