### PR TITLE
Add HTML dependency to the table

### DIFF
--- a/R/compile_scss.R
+++ b/R/compile_scss.R
@@ -1,5 +1,5 @@
 #' @noRd
-compile_scss <- function(data, id = NULL, output = NULL) {
+compile_scss <- function(data, id = NULL) {
 
   # Obtain the SCSS options table from `data`
   gt_options_tbl <-
@@ -28,7 +28,6 @@ compile_scss <- function(data, id = NULL, output = NULL) {
         @include gt_styles();
         <<ifelse(has_id, '}', '')>>
         ")
-    ),
-    output = output
+    )
   )
 }

--- a/R/compile_scss.R
+++ b/R/compile_scss.R
@@ -1,5 +1,5 @@
 #' @noRd
-compile_scss <- function(data, id = NULL) {
+compile_scss <- function(data, id = NULL, output = NULL) {
 
   # Obtain the SCSS options table from `data`
   gt_options_tbl <-
@@ -28,6 +28,7 @@ compile_scss <- function(data, id = NULL) {
         @include gt_styles();
         <<ifelse(has_id, '}', '')>>
         ")
-    )
+    ),
+    output = output
   )
 }

--- a/R/export.R
+++ b/R/export.R
@@ -263,7 +263,9 @@ gtsave_filename <- function(path, filename) {
 #'
 #' @param data A table object that is created using the [gt()] function.
 #' @param inline_css An option to supply styles to table elements as inlined CSS
-#'   styles.
+#'   styles. This is useful when including the table HTML as part of an HTML
+#'   email message body, since inlined styles are largely supported in email
+#'   clients over using CSS in a `<style>` block.
 #'
 #' @examples
 #' # Use `gtcars` to create a gt table;

--- a/R/print.R
+++ b/R/print.R
@@ -75,16 +75,20 @@ as.tags.gt_tbl <- function(x, ...) {
     id <- NULL
   }
 
+  temp <- tempfile(fileext = ".css")
+
   # Compile the SCSS as CSS
-  css <- compile_scss(data = x, id = id)
+  css <- compile_scss(data = x, id = id, output = temp)
 
   # Attach the dependency to the HTML table
   html_tbl <-
     htmltools::tagList(
-      htmltools::tags$head(
-        htmltools::tags$style(
-          htmltools::HTML(css)
-        )
+      htmltools::htmlDependency(
+        name = paste0("gt-", random_id()),
+        version = utils::packageVersion("gt"),
+        src = dirname(temp),
+        stylesheet = basename(temp),
+        all_files = FALSE
       ),
       htmltools::tags$div(
         id = id,

--- a/R/print.R
+++ b/R/print.R
@@ -75,21 +75,13 @@ as.tags.gt_tbl <- function(x, ...) {
     id <- NULL
   }
 
-  temp <- tempfile(fileext = ".css")
-
   # Compile the SCSS as CSS
-  css <- compile_scss(data = x, id = id, output = temp)
+  css <- compile_scss(data = x, id = id)
 
   # Attach the dependency to the HTML table
   html_tbl <-
     htmltools::tagList(
-      htmltools::htmlDependency(
-        name = paste0("gt-", random_id()),
-        version = utils::packageVersion("gt"),
-        src = dirname(temp),
-        stylesheet = basename(temp),
-        all_files = FALSE
-      ),
+      htmltools::tags$style(htmltools::HTML(css)),
       htmltools::tags$div(
         id = id,
         style = htmltools::css(
@@ -98,7 +90,8 @@ as.tags.gt_tbl <- function(x, ...) {
           width = container_width,
           height = container_height
         ),
-        htmltools::HTML(html_table))
+        htmltools::HTML(html_table)
+      )
     )
 
   html_tbl

--- a/man/as_raw_html.Rd
+++ b/man/as_raw_html.Rd
@@ -10,7 +10,9 @@ as_raw_html(data, inline_css = TRUE)
 \item{data}{A table object that is created using the \code{\link[=gt]{gt()}} function.}
 
 \item{inline_css}{An option to supply styles to table elements as inlined CSS
-styles.}
+styles. This is useful when including the table HTML as part of an HTML
+email message body, since inlined styles are largely supported in email
+clients over using CSS in a \verb{<style>} block.}
 }
 \description{
 Get the HTML content from a \code{gt_tbl} object as a single-element character

--- a/tests/gt-examples/05-html-email/connect-example-main.Rmd
+++ b/tests/gt-examples/05-html-email/connect-example-main.Rmd
@@ -25,10 +25,6 @@ diamonds %>%
   filter(cut != "Fair", carat < 3) %>%
   ggplot() +
   geom_point(aes(x = carat, y = mean_price)) +
-  stat_smooth(
-    aes(x = carat, y = mean_price),
-    method = "gam"
-  ) +
   facet_wrap(facets = vars(cut)) +
   labs(
     title = "Diamond Prices",
@@ -39,7 +35,7 @@ diamonds %>%
   scale_y_continuous(labels = scales::dollar)
 ```
 
-The above created a plot. Below is code that generates a **gt** table with the diamond data:
+The above created a plot. Below is code that generates a **gt** table with the diamond data. Note that we need to use the `as_raw_html()` on the **gt** object to ensure that styles are preserved when emailing.
 
 ```{r diamonds_table}
 
@@ -62,7 +58,8 @@ diamonds %>%
     columns = vars(price),
     currency = "USD",
     decimals = 0
-  )
+  ) %>%
+  as_raw_html()
 ```
 
 We can create an email using **RStudio Connect**, one that aligns with the content from this report. We do this with the `render_connect_email()` and `attach_connect_email()` functions from the **blastula** package. The email subdocument (`"connect-example-email.Rmd"`) is used to craft the contents of the email, drawing upon results available in this document.

--- a/tests/gt-examples/05-html-email/connect-example-main.Rmd
+++ b/tests/gt-examples/05-html-email/connect-example-main.Rmd
@@ -35,7 +35,7 @@ diamonds %>%
   scale_y_continuous(labels = scales::dollar)
 ```
 
-The above created a plot. Below is code that generates a **gt** table with the diamond data. Note that we need to use the `as_raw_html()` on the **gt** object to ensure that styles are preserved when emailing.
+The above created a plot. Below is code that generates a **gt** table with the diamond data. Note that we need to use the `as_raw_html()` function on the **gt** object to ensure that styles are preserved when emailing.
 
 ```{r diamonds_table}
 


### PR DESCRIPTION
This adds an HTML dependency to the table when `as.tags()` is called (occurs during `knit_print()`ing an HTML document and during the print method. 

Fixes: https://github.com/rstudio/gt/issues/459