### PR TITLE
add a summary_vars argument to create_summary_rows

### DIFF
--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -413,6 +413,8 @@ create_summary_rows <- function(n_rows,
       list_of_summaries$summary_df_display_list[[group]] %>%
       as.data.frame(stringsAsFactors = FALSE)
 
+    if (!"rowname" %in% summary_vars) summary_vars <- c("rowname", summary_vars)
+
     summary_df <-
       summary_df[, summary_vars]
 

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -389,6 +389,7 @@ create_summary_rows <- function(n_rows,
                                 groups_rows_df,
                                 stub_available,
                                 summaries_present,
+                                summary_vars,
                                 context = "latex") {
 
   lapply(seq(n_rows), function(x) {
@@ -411,6 +412,9 @@ create_summary_rows <- function(n_rows,
     summary_df <-
       list_of_summaries$summary_df_display_list[[group]] %>%
       as.data.frame(stringsAsFactors = FALSE)
+
+    summary_df <-
+      summary_df[, summary_vars]
 
     body_content_summary <-
       as.vector(t(summary_df))

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -238,6 +238,8 @@ create_body_component_l <- function(data) {
       dplyr::select(rowname) %>%
       dplyr::rename(`::rowname` = rowname) %>%
       cbind(body)
+  } else {
+    body_vars <- default_vars
   }
 
 

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -231,7 +231,7 @@ create_body_component_l <- function(data) {
   group_rows <- create_group_rows(n_rows, groups_rows_df, context = "latex")
 
   if (stub_available) {
-    default_vars <- c("::rowname", default_vars)
+    body_vars <- c("::rowname", default_vars)
 
     body <-
       dt_stub_df_get(data = data) %>%
@@ -242,7 +242,7 @@ create_body_component_l <- function(data) {
 
 
   # Split `body_content` by slices of rows and create data rows
-  body_content <- as.vector(t(body[, default_vars]))
+  body_content <- as.vector(t(body[, body_vars]))
   row_splits <- split(body_content, ceiling(seq_along(body_content) / n_cols))
   data_rows <- create_data_rows(n_rows, row_splits, context = "latex")
 
@@ -254,6 +254,7 @@ create_body_component_l <- function(data) {
       groups_rows_df = groups_rows_df,
       stub_available = stub_available,
       summaries_present = summaries_present,
+      summary_vars = default_vars,
       context = "latex"
     )
 


### PR DESCRIPTION
This PR would fix https://github.com/rstudio/gt/issues/465. 

Basically the underlying issue was the the `create_summary_rows` function was including the grouping and rowname columns in its creation of the latex summary row lines. This resulted in two extra columns being added somewhere in each summary row (one for group column and one for rowname column). 

The changes I made add an additional argument to `create_summary_rows` named `summary_vars` which is meant to be all of the column names in the table. To accomplish this in `create_body_component_l` I just used the `default_vars` variable before `::rowname` was added to it. I also renamed the `default_vars`-post `::rowname` addition to `body_vars` since it is being used for the body portion of the table. 

In the `create_summary_rows` function, I added a line that will only select for the column names that are passed into the `summary_vars` function. 

Using these changed functions, the example shown in the above example works as expected. 

Let me know if there is anything else I need to do to get this PR merged!

Thanks!