### PR TITLE
Modify default CSS option for column `font-weight`

### DIFF
--- a/R/dt_options.R
+++ b/R/dt_options.R
@@ -48,7 +48,7 @@ dt_options_init <- function(data) {
     "heading_border_lr_color",            TRUE,  "heading",          "value",   "#D3D3D3",
     "column_labels_background_color",     TRUE,  "column_labels",    "value",   NA_character_,
     "column_labels_font_size",            TRUE,  "column_labels",    "px",      "100%",
-    "column_labels_font_weight",          TRUE,  "column_labels",    "value",   "initial",
+    "column_labels_font_weight",          TRUE,  "column_labels",    "value",   "normal",
     "column_labels_text_transform",       TRUE,  "column_labels",    "value",   "inherit",
     "column_labels_border_top_style",     TRUE,  "column_labels",    "value",   "solid",
     "column_labels_border_top_width",     TRUE,  "column_labels",    "px",      "2px",

--- a/tests/testthat/test-tab_options.R
+++ b/tests/testthat/test-tab_options.R
@@ -428,7 +428,7 @@ test_that("the internal `opts_df` table can be correctly modified", {
   c(dt_options_get_value(data = data, option = "column_labels_font_weight"),
     dt_options_get_value(data = tbl_html, option = "column_labels_font_weight")
   ) %>%
-    expect_equal(c("initial", "bold"))
+    expect_equal(c("normal", "bold"))
 
   # Modify the `column_labels.text_transform`
   tbl_html <- data %>% tab_options(column_labels.text_transform = "uppercase")


### PR DESCRIPTION
This change ensures that IE11 won't automatically bold the column labels. The `font-weight` property has been changed from `initial` to `normal`. Performed a manual test in my Windows 10 VM to make sure this change worked.

Fixes https://github.com/rstudio/gt/issues/430.