### PR TITLE
Remove use of emo package from example script

### DIFF
--- a/tests/gt-examples/02-html-rmd/html-01-iris.Rmd
+++ b/tests/gt-examples/02-html-rmd/html-01-iris.Rmd
@@ -26,4 +26,5 @@ gt(data = iris) %>%
   ) %>%
   tab_source_note(
     source_note = md("The data were collected by *Anderson* (1935).")
+  )
 ```

--- a/tests/gt-examples/05-html-email/emailing_table.R
+++ b/tests/gt-examples/05-html-email/emailing_table.R
@@ -3,7 +3,6 @@ library(blastula)
 library(tidyverse)
 library(glue)
 library(scales)
-library(emo)
 
 # Create short labels for months (displays
 # better for small plots in email messages)
@@ -124,7 +123,7 @@ pizza_tab_email <-
     income = "Income"
   ) %>%
   tab_header(
-    title = paste0("My ", emo::ji("pizza"), " sales in 2015"),
+    title = paste0("My pizza sales in 2015"),
     subtitle = "Split by the type of pizza and the size"
   ) %>%
   as_raw_html()


### PR DESCRIPTION
This removes all use of the **emo** package from an example script that creates a table for a **blastula** email.