### PR TITLE
Error with any common name supplied to `rowname_col` or `groupname_col`

### DIFF
--- a/R/dt_stub_df.R
+++ b/R/dt_stub_df.R
@@ -28,7 +28,7 @@ dt_stub_df_init <- function(data,
   # If `rowname` is a column available in `data`,
   # place that column's data into `stub_df` and
   # remove it from `data`
-  if (rowname_col %in% colnames(data_tbl)) {
+  if (!is.null(rowname_col) && rowname_col %in% colnames(data_tbl)) {
 
     data <- data %>% dt_boxhead_set_stub(var = rowname_col)
 

--- a/R/gt.R
+++ b/R/gt.R
@@ -95,6 +95,16 @@ gt <- function(data,
     groupname_col <- NULL
   }
 
+  # Stop function if `rowname_col` and `groupname_col`
+  # have the same string values
+  if (!is.null(rowname_col) &&
+      !is.null(groupname_col) &&
+      any(rowname_col %in% groupname_col)) {
+
+    stop("Any values provided to `rowname_col` and `groupname_col` cannot be shared.",
+         call. = FALSE)
+  }
+
   # Initialize the main objects
   data <-
     list() %>%

--- a/R/gt.R
+++ b/R/gt.R
@@ -101,7 +101,8 @@ gt <- function(data,
       !is.null(groupname_col) &&
       any(rowname_col %in% groupname_col)) {
 
-    stop("Any values provided to `rowname_col` and `groupname_col` cannot be shared.",
+    stop("The value \"", rowname_col, "\" appears in both `rowname_col` and ",
+         "`groupname_col`. These arguments must not have any values in common.",
          call. = FALSE)
   }
 

--- a/tests/testthat/test-gt_object.R
+++ b/tests/testthat/test-gt_object.R
@@ -623,3 +623,31 @@ test_that("The `rowname` column will be safely included when `rownames_to_stub =
       )
     )
 })
+
+test_that("Any shared names in `rowname_col` and `groupname_col` will be disallowed", {
+
+  # Expect an error if there are any shared names across `rowname_col`
+  # and `groupname_col`
+  expect_error(
+    exibble %>%
+      gt(rowname_col = "row", groupname_col = "row")
+  )
+  expect_error(
+    exibble %>%
+      gt(rowname_col = "group", groupname_col = "group")
+  )
+  expect_error(
+    exibble %>%
+      gt(rowname_col = "rowname", groupname_col = "rowname")
+  )
+  expect_error(
+    exibble %>%
+      dplyr::group_by(group) %>%
+      gt(rowname_col = "group")
+  )
+  expect_error(
+    exibble %>%
+      dplyr::group_by(date, row) %>%
+      gt(rowname_col = "row")
+  )
+})


### PR DESCRIPTION
This adds a `stop()` statement in the `gt()` function for the situation where any names supplied to `rowname_col` or `groupname_col` are shared amongst the two.

This will avoid any strange formatting of the table downstream. Furthermore, having columns specified in this way is probably not what the user wants anyhow (a clear error message provides the opportunity to correct the inputs for `gt()`).

Several **testthat** tests were added.

Fixes https://github.com/rstudio/gt/issues/474.