### PR TITLE
Use alternate method to separate spanner lines

### DIFF
--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -535,7 +535,7 @@ create_columns_component_h <- function(data) {
           first_set[[length(first_set) + 1]] <-
             htmltools::tags$th(
               class = paste(
-                c("gt_center", "gt_columns_top_border"),
+                c("gt_center", "gt_columns_top_border", "gt_column_spanner_outer"),
                 collapse = " "
               ),
               rowspan = 1,

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -385,7 +385,7 @@ create_columns_component_h <- function(data) {
       table_col_headings[[length(table_col_headings) + 1]] <-
         htmltools::tags$th(
           class = paste(
-            c("gt_col_heading", "gt_columns_bottom_border", #"gt_columns_top_border",
+            c("gt_col_heading", "gt_columns_bottom_border",
               paste0("gt_", stubhead_label_alignment)),
             collapse = " "),
           rowspan = 1,
@@ -414,7 +414,7 @@ create_columns_component_h <- function(data) {
       table_col_headings[[length(table_col_headings) + 1]] <-
         htmltools::tags$th(
           class = paste(
-            c("gt_col_heading", "gt_columns_bottom_border", #"gt_columns_top_border",
+            c("gt_col_heading", "gt_columns_bottom_border",
               paste0("gt_", col_alignment[i])),
             collapse = " "),
           rowspan = 1,
@@ -447,7 +447,7 @@ create_columns_component_h <- function(data) {
       first_set[[length(first_set) + 1]] <-
         htmltools::tags$th(
           class = paste(
-            c("gt_col_heading", "gt_columns_bottom_border", #"gt_columns_top_border",
+            c("gt_col_heading", "gt_columns_bottom_border",
               paste0("gt_", stubhead_label_alignment)),
             collapse = " "),
           rowspan = 2,
@@ -513,18 +513,12 @@ create_columns_component_h <- function(data) {
           for (j in 1:length(spanners)) {
 
             if (is.na(spanners[i + j])) {
-              spanner_adjacent <- FALSE
               break
             } else if (duplicated(spanners)[i + j]) {
               colspan <- colspan + 1L
             } else {
-              spanner_adjacent <- ifelse(!is.na(spanners[i + j]), TRUE, FALSE)
               break
             }
-          }
-
-          if (spanner_adjacent) {
-            class <- paste0(class, " gt_sep_right")
           }
 
           styles_spanners <-
@@ -541,13 +535,16 @@ create_columns_component_h <- function(data) {
           first_set[[length(first_set) + 1]] <-
             htmltools::tags$th(
               class = paste(
-                c("gt_col_heading", "gt_center", "gt_columns_top_border", class),
+                c("gt_center", "gt_columns_top_border"),
                 collapse = " "
               ),
               rowspan = 1,
               colspan = colspan,
               style = spanner_style,
-              htmltools::HTML(spanners[i])
+              htmltools::tags$span(
+                class = "gt_column_spanner",
+                htmltools::HTML(spanners[i])
+              )
             )
         }
       }

--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -91,6 +91,14 @@
     text-transform: $column_labels_text_transform; // column_labels.text_transform
     padding-top: 0;
     padding-bottom: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+  .gt_column_spanner_outer:first-child {
+    padding-left: 0;
+  }
+  .gt_column_spanner_outer:last-child {
+    padding-right: 0;
   }
 
   .gt_column_spanner {
@@ -102,7 +110,7 @@
     padding-bottom: 6px;
     overflow-x: hidden;
     display: inline-block;
-    width: 97%;
+    width: 100%;
   }
 
   .gt_group_heading {

--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -3,78 +3,78 @@
   .gt_table {
     display: table;
     border-collapse: collapse;
-    margin-left: $table_margin_left; /* table.margin.left */
-    margin-right: $table_margin_right; /* table.margin.right */
+    margin-left: $table_margin_left; // table.margin.left
+    margin-right: $table_margin_right; // table.margin.right
     color: font-color($table_background_color);
-    font-size: $table_font_size; /* table.font.size */
-    background-color: $table_background_color; /* table.background.color */
-    width: $table_width; /* table.width */
-    border-top-style: $table_border_top_style; /* table.border.top.style */
-    border-top-width: $table_border_top_width; /* table.border.top.width */
-    border-top-color: $table_border_top_color; /* table.border.top.color */
-    border-bottom-style: $table_border_bottom_style; /* table.border.bottom.style */
-    border-bottom-width: $table_border_bottom_width; /* table.border.bottom.width */
-    border-bottom-color: $table_border_bottom_color; /* table.border.bottom.color */
+    font-size: $table_font_size; // table.font.size
+    background-color: $table_background_color; // table.background.color
+    width: $table_width; // table.width
+    border-top-style: $table_border_top_style; // table.border.top.style
+    border-top-width: $table_border_top_width; // table.border.top.width
+    border-top-color: $table_border_top_color; // table.border.top.color
+    border-bottom-style: $table_border_bottom_style; // table.border.bottom.style
+    border-bottom-width: $table_border_bottom_width; // table.border.bottom.width
+    border-bottom-color: $table_border_bottom_color; // table.border.bottom.color
   }
 
   .gt_heading {
-    background-color: $heading_background_color; /* heading.background.color */
-    border-bottom-color: $table_background_color; /* table.background.color */
-    border-left-style: $heading_border_lr_style; /* heading.border.lr.style */
-    border-left-width: $heading_border_lr_width; /* heading.border.lr.width */
-    border-left-color: $heading_border_lr_color; /* heading.border.lr.color */
-    border-right-style: $heading_border_lr_style; /* heading.border.lr.style */
-    border-right-width: $heading_border_lr_width; /* heading.border.lr.width */
-    border-right-color: $heading_border_lr_color; /* heading.border.lr.color */
+    background-color: $heading_background_color; // heading.background.color
+    border-bottom-color: $table_background_color; // table.background.color
+    border-left-style: $heading_border_lr_style; // heading.border.lr.style
+    border-left-width: $heading_border_lr_width; // heading.border.lr.width
+    border-left-color: $heading_border_lr_color; // heading.border.lr.color
+    border-right-style: $heading_border_lr_style; // heading.border.lr.style
+    border-right-width: $heading_border_lr_width; // heading.border.lr.width
+    border-right-color: $heading_border_lr_color; // heading.border.lr.color
   }
 
   .gt_title {
     color: font-color($heading_background_color);
-    font-size: $heading_title_font_size; /* heading.title.font.size */
-    font-weight: $heading_title_font_weight; /* heading.title.font.weight */
-    padding-top: 4px; /* heading.top.padding - not yet used */
+    font-size: $heading_title_font_size; // heading.title.font.size
+    font-weight: $heading_title_font_weight; // heading.title.font.weight
+    padding-top: 4px; // heading.top.padding - not yet used
     padding-bottom: 4px;
-    border-bottom-color: $table_background_color; /* table.background.color */
+    border-bottom-color: $table_background_color; // table.background.color
     border-bottom-width: 0;
   }
 
   .gt_subtitle {
     color: font-color($heading_background_color);
-    font-size: $heading_subtitle_font_size; /* heading.subtitle.font.size */
-    font-weight: $heading_subtitle_font_weight; /* heading.subtitle.font.weight */
+    font-size: $heading_subtitle_font_size; // heading.subtitle.font.size
+    font-weight: $heading_subtitle_font_weight; // heading.subtitle.font.weight
     padding-top: 0;
-    padding-bottom: 4px; /* heading.bottom.padding - not yet used */
-    border-top-color: $table_background_color; /* table.background.color */
+    padding-bottom: 4px; // heading.bottom.padding - not yet used
+    border-top-color: $table_background_color; // table.background.color
     border-top-width: 0;
   }
 
   .gt_bottom_border {
-    border-bottom-style: $heading_border_bottom_style; /* heading.border.bottom.style */
-    border-bottom-width: $heading_border_bottom_width; /* heading.border.bottom.width */
-    border-bottom-color: $heading_border_bottom_color; /* heading.border.bottom.color */
+    border-bottom-style: $heading_border_bottom_style; // heading.border.bottom.style
+    border-bottom-width: $heading_border_bottom_width; // heading.border.bottom.width
+    border-bottom-color: $heading_border_bottom_color; // heading.border.bottom.color
   }
 
   .gt_col_headings {
-    border-top-style: $column_labels_border_top_style; /* column_labels.border.top.style */
-    border-top-width: $column_labels_border_top_width; /* column_labels.border.top.width */
-    border-top-color: $column_labels_border_top_color; /* column_labels.border.top.color */
-    border-bottom-style: $column_labels_border_bottom_style; /* column_labels.border.bottom.style */
-    border-bottom-width: $column_labels_border_bottom_width; /* column_labels.border.bottom.width */
-    border-bottom-color: $column_labels_border_bottom_color; /* column_labels.border.bottom.color */
-    border-left-style: $column_labels_border_lr_style; /* column_labels.border.lr.style */
-    border-left-width: $column_labels_border_lr_width; /* column_labels.border.lr.width */
-    border-left-color: $column_labels_border_lr_color; /* column_labels.border.lr.color */
-    border-right-style: $column_labels_border_lr_style; /* column_labels.border.lr.style */
-    border-right-width: $column_labels_border_lr_width; /* column_labels.border.lr.width */
-    border-right-color: $column_labels_border_lr_color; /* column_labels.border.lr.color */
+    border-top-style: $column_labels_border_top_style; // column_labels.border.top.style
+    border-top-width: $column_labels_border_top_width; // column_labels.border.top.width
+    border-top-color: $column_labels_border_top_color; // column_labels.border.top.color
+    border-bottom-style: $column_labels_border_bottom_style; // column_labels.border.bottom.style
+    border-bottom-width: $column_labels_border_bottom_width; // column_labels.border.bottom.width
+    border-bottom-color: $column_labels_border_bottom_color; // column_labels.border.bottom.color
+    border-left-style: $column_labels_border_lr_style; // column_labels.border.lr.style
+    border-left-width: $column_labels_border_lr_width; // column_labels.border.lr.width
+    border-left-color: $column_labels_border_lr_color; // column_labels.border.lr.color
+    border-right-style: $column_labels_border_lr_style; // column_labels.border.lr.style
+    border-right-width: $column_labels_border_lr_width; // column_labels.border.lr.width
+    border-right-color: $column_labels_border_lr_color; // column_labels.border.lr.color
   }
 
   .gt_col_heading {
     color: font-color($column_labels_background_color);
-    background-color: $column_labels_background_color; /* column_labels.background.color */
-    font-size: $column_labels_font_size; /* column_labels.font.size */
-    font-weight: $column_labels_font_weight; /* column_labels.font.weight */
-    text-transform: $column_labels_text_transform; /* column_labels.text_transform */
+    background-color: $column_labels_background_color; // column_labels.background.color
+    font-size: $column_labels_font_size; // column_labels.font.size
+    font-weight: $column_labels_font_weight; // column_labels.font.weight
+    text-transform: $column_labels_text_transform; // column_labels.text_transform
     vertical-align: bottom;
     padding-top: 4px;
     padding-bottom: 4px;
@@ -85,14 +85,14 @@
 
   .gt_column_spanner {
     color: font-color($column_labels_background_color);
-    background-color: $column_labels_background_color; /* column_labels.background.color */
-    font-size: $column_labels_font_size; /* column_labels.font.size */
-    font-weight: $column_labels_font_weight; /* column_labels.font.weight */
-    text-transform: $column_labels_text_transform; /* column_labels.text_transform */
+    background-color: $column_labels_background_color; // column_labels.background.color
+    font-size: $column_labels_font_size; // column_labels.font.size
+    font-weight: $column_labels_font_weight; // column_labels.font.weight
+    text-transform: $column_labels_text_transform; // column_labels.text_transform
     vertical-align: bottom;
-    border-bottom-style: $column_labels_border_bottom_style; /* column_labels.border.bottom.style */
-    border-bottom-width: $column_labels_border_bottom_width; /* column_labels.border.bottom.width */
-    border-bottom-color: $column_labels_border_bottom_color; /* column_labels.border.bottom.color */
+    border-bottom-style: $column_labels_border_bottom_style; // column_labels.border.bottom.style
+    border-bottom-width: $column_labels_border_bottom_width; // column_labels.border.bottom.width
+    border-bottom-color: $column_labels_border_bottom_color; // column_labels.border.bottom.color
     padding-top: 4px;
     padding-bottom: 4px;
     overflow-x: hidden;
@@ -101,44 +101,44 @@
   }
 
   .gt_group_heading {
-    padding: $row_group_padding; /* row_group.padding */
+    padding: $row_group_padding; // row_group.padding
     color: font-color($row_group_background_color);
-    background-color: $row_group_background_color; /* row_group.background.color */
-    font-size: $row_group_font_size; /* row_group.font.size */
-    font-weight: $row_group_font_weight; /* row_group.font.weight */
-    text-transform: $row_group_text_transform; /* row_group.text_transform */
-    border-top-style: $row_group_border_top_style; /* row_group.border.top.style */
-    border-top-width: $row_group_border_top_width; /* row_group.border.top.width */
-    border-top-color: $row_group_border_top_color; /* row_group.border.top.color */
-    border-bottom-style: $row_group_border_bottom_style; /* row_group.border.bottom.style */
-    border-bottom-width: $row_group_border_bottom_width; /* row_group.border.bottom.width */
-    border-bottom-color: $row_group_border_bottom_color; /* row_group.border.bottom.color */
-    border-left-style: $row_group_border_left_style; /* row_group.border.left.style */
-    border-left-width: $row_group_border_left_width; /* row_group.border.left.width */
-    border-left-color: $row_group_border_left_color; /* row_group.border.left.color */
-    border-right-style: $row_group_border_right_style; /* row_group.border.right.style */
-    border-right-width: $row_group_border_right_width; /* row_group.border.right.width */
-    border-right-color: $row_group_border_right_color; /* row_group.border.right.color */
+    background-color: $row_group_background_color; // row_group.background.color
+    font-size: $row_group_font_size; // row_group.font.size
+    font-weight: $row_group_font_weight; // row_group.font.weight
+    text-transform: $row_group_text_transform; // row_group.text_transform
+    border-top-style: $row_group_border_top_style; // row_group.border.top.style
+    border-top-width: $row_group_border_top_width; // row_group.border.top.width
+    border-top-color: $row_group_border_top_color; // row_group.border.top.color
+    border-bottom-style: $row_group_border_bottom_style; // row_group.border.bottom.style
+    border-bottom-width: $row_group_border_bottom_width; // row_group.border.bottom.width
+    border-bottom-color: $row_group_border_bottom_color; // row_group.border.bottom.color
+    border-left-style: $row_group_border_left_style; // row_group.border.left.style
+    border-left-width: $row_group_border_left_width; // row_group.border.left.width
+    border-left-color: $row_group_border_left_color; // row_group.border.left.color
+    border-right-style: $row_group_border_right_style; // row_group.border.right.style
+    border-right-width: $row_group_border_right_width; // row_group.border.right.width
+    border-right-color: $row_group_border_right_color; // row_group.border.right.color
     vertical-align: middle;
   }
 
   .gt_empty_group_heading {
     padding: 0.5px;
     color: font-color($row_group_background_color);
-    background-color: $row_group_background_color; /* row_group.background.color */
-    font-size: $row_group_font_size; /* row_group.font.size */
-    font-weight: $row_group_font_weight; /* row_group.font.weight */
-    border-top-style: $row_group_border_top_style; /* row_group.border.top.style */
-    border-top-width: $row_group_border_top_width; /* row_group.border.top.width */
-    border-top-color: $row_group_border_top_color; /* row_group.border.top.color */
-    border-bottom-style: $row_group_border_bottom_style; /* row_group.border.bottom.style */
-    border-bottom-width: $row_group_border_bottom_width; /* row_group.border.bottom.width */
-    border-bottom-color: $row_group_border_bottom_color; /* row_group.border.bottom.color */
+    background-color: $row_group_background_color; // row_group.background.color
+    font-size: $row_group_font_size; // row_group.font.size
+    font-weight: $row_group_font_weight; // row_group.font.weight
+    border-top-style: $row_group_border_top_style; // row_group.border.top.style
+    border-top-width: $row_group_border_top_width; // row_group.border.top.width
+    border-top-color: $row_group_border_top_color; // row_group.border.top.color
+    border-bottom-style: $row_group_border_bottom_style; // row_group.border.bottom.style
+    border-bottom-width: $row_group_border_bottom_width; // row_group.border.bottom.width
+    border-bottom-color: $row_group_border_bottom_color; // row_group.border.bottom.color
     vertical-align: middle;
   }
 
   .gt_striped {
-     background-color: $row_striping_background_color; /* row.striping.background_color */
+     background-color: $row_striping_background_color; // row.striping.background_color
   }
 
   .gt_from_md > :first-child {
@@ -150,122 +150,122 @@
   }
 
   .gt_row {
-    padding-top: $data_row_padding; /* data_row.padding */
-    padding-bottom: $data_row_padding; /* data_row.padding */
+    padding-top: $data_row_padding; // data_row.padding
+    padding-bottom: $data_row_padding; // data_row.padding
     padding-left: 5px;
     padding-right: 5px;
     margin: 10px;
-    border-top-style: $table_body_hlines_style; /* table_body.hlines.style */
-    border-top-width: $table_body_hlines_width; /* table_body.hlines.width */
-    border-top-color: $table_body_hlines_color; /* table_body.hlines.color */
-    border-left-style: $table_body_vlines_style; /* table_body.vlines.style */
-    border-left-width: $table_body_vlines_width; /* table_body.vlines.width */
-    border-left-color: $table_body_vlines_color; /* table_body.vlines.color */
-    border-right-style: $table_body_vlines_style; /* table_body.vlines.style */
-    border-right-width: $table_body_vlines_width; /* table_body.vlines.width */
-    border-right-color: $table_body_vlines_color; /* table_body.vlines.color */
+    border-top-style: $table_body_hlines_style; // table_body.hlines.style
+    border-top-width: $table_body_hlines_width; // table_body.hlines.width
+    border-top-color: $table_body_hlines_color; // table_body.hlines.color
+    border-left-style: $table_body_vlines_style; // table_body.vlines.style
+    border-left-width: $table_body_vlines_width; // table_body.vlines.width
+    border-left-color: $table_body_vlines_color; // table_body.vlines.color
+    border-right-style: $table_body_vlines_style; // table_body.vlines.style
+    border-right-width: $table_body_vlines_width; // table_body.vlines.width
+    border-right-color: $table_body_vlines_color; // table_body.vlines.color
     vertical-align: middle;
     overflow-x: hidden;
   }
 
   .gt_stub {
     color: font-color($stub_background_color);
-    background-color: $stub_background_color; /* stub.background.color */
-    font-weight: $stub_font_weight; /* stub.font.weight */
-    text-transform: $stub_text_transform; /* stub.text_transform */
-    border-right-style: $stub_border_style; /* stub.border.style */
-    border-right-width: $stub_border_width; /* stub.border.width */
-    border-right-color: $stub_border_color; /* stub.border.color */
+    background-color: $stub_background_color; // stub.background.color
+    font-weight: $stub_font_weight; // stub.font.weight
+    text-transform: $stub_text_transform; // stub.text_transform
+    border-right-style: $stub_border_style; // stub.border.style
+    border-right-width: $stub_border_width; // stub.border.width
+    border-right-color: $stub_border_color; // stub.border.color
     padding-left: 12px;
   }
 
   .gt_summary_row {
     color: font-color($summary_row_background_color);
-    background-color: $summary_row_background_color; /* summary_row.background.color */
-    text-transform: $summary_row_text_transform; /* summary_row.text_transform */
-    padding-top: $summary_row_padding; /* summary_row.padding */
-    padding-bottom: $summary_row_padding; /* summary_row.padding */
+    background-color: $summary_row_background_color; // summary_row.background.color
+    text-transform: $summary_row_text_transform; // summary_row.text_transform
+    padding-top: $summary_row_padding; // summary_row.padding
+    padding-bottom: $summary_row_padding; // summary_row.padding
     padding-left: 5px;
     padding-right: 5px;
   }
 
   .gt_first_summary_row {
-    padding-top: $summary_row_padding; /* summary_row.padding */
-    padding-bottom: $summary_row_padding; /* summary_row.padding */
+    padding-top: $summary_row_padding; // summary_row.padding
+    padding-bottom: $summary_row_padding; // summary_row.padding
     padding-left: 5px;
     padding-right: 5px;
-    border-top-style: $summary_row_border_style; /* summary_row.border.style */
-    border-top-width: $summary_row_border_width; /* summary_row.border.width */
-    border-top-color: $summary_row_border_color; /* summary_row.border.color */
+    border-top-style: $summary_row_border_style; // summary_row.border.style
+    border-top-width: $summary_row_border_width; // summary_row.border.width
+    border-top-color: $summary_row_border_color; // summary_row.border.color
   }
 
   .gt_grand_summary_row {
     color: font-color($grand_summary_row_background_color);
-    background-color: $grand_summary_row_background_color; /* grand_summary_row.background.color */
-    text-transform: $grand_summary_row_text_transform; /* grand_summary_row.text_transform */
-    padding-top: $grand_summary_row_padding; /* grand_summary_row.padding */
-    padding-bottom: $grand_summary_row_padding; /* grand_summary_row.padding */
+    background-color: $grand_summary_row_background_color; // grand_summary_row.background.color
+    text-transform: $grand_summary_row_text_transform; // grand_summary_row.text_transform
+    padding-top: $grand_summary_row_padding; // grand_summary_row.padding
+    padding-bottom: $grand_summary_row_padding; // grand_summary_row.padding
     padding-left: 5px;
     padding-right: 5px;
   }
 
   .gt_first_grand_summary_row {
-    padding-top: $grand_summary_row_padding; /* grand_summary_row.padding */
-    padding-bottom: $grand_summary_row_padding; /* grand_summary_row.padding */
+    padding-top: $grand_summary_row_padding; // grand_summary_row.padding
+    padding-bottom: $grand_summary_row_padding; // grand_summary_row.padding
     padding-left: 5px;
     padding-right: 5px;
-    border-top-style: $grand_summary_row_border_style; /* grand_summary_row.border.style */
-    border-top-width: $grand_summary_row_border_width; /* grand_summary_row.border.width */
-    border-top-color: $grand_summary_row_border_color; /* grand_summary_row.border.color */
+    border-top-style: $grand_summary_row_border_style; // grand_summary_row.border.style
+    border-top-width: $grand_summary_row_border_width; // grand_summary_row.border.width
+    border-top-color: $grand_summary_row_border_color; // grand_summary_row.border.color
   }
 
   .gt_table_body {
-    border-top-style: $table_body_border_top_style; /* table_body.border.top.style */
-    border-top-width: $table_body_border_top_width; /* table_body.border.top.width */
-    border-top-color: $table_body_border_top_color; /* table_body.border.top.color */
-    border-bottom-style: $table_body_border_bottom_style; /* table_body.border.bottom.style */
-    border-bottom-width: $table_body_border_bottom_width; /* table_body.border.bottom.width */
-    border-bottom-color: $table_body_border_bottom_color; /* table_body.border.bottom.color */
+    border-top-style: $table_body_border_top_style; // table_body.border.top.style
+    border-top-width: $table_body_border_top_width; // table_body.border.top.width
+    border-top-color: $table_body_border_top_color; // table_body.border.top.color
+    border-bottom-style: $table_body_border_bottom_style; // table_body.border.bottom.style
+    border-bottom-width: $table_body_border_bottom_width; // table_body.border.bottom.width
+    border-bottom-color: $table_body_border_bottom_color; // table_body.border.bottom.color
   }
 
   .gt_footnotes {
     color: font-color($footnotes_background_color);
-    background-color: $footnotes_background_color; /* footnotes.background.color */
-    border-bottom-style: $footnotes_border_bottom_style; /* footnotes.border.bottom.style */
-    border-bottom-width: $footnotes_border_bottom_width; /* footnotes.border.bottom.width */
-    border-bottom-color: $footnotes_border_bottom_color; /* footnotes.border.bottom.color */
-    border-left-style:  $footnotes_border_lr_style; /* footnotes.border.lr.color */
-    border-left-width:  $footnotes_border_lr_width; /* footnotes.border.lr.color */
-    border-left-color:  $footnotes_border_lr_color; /* footnotes.border.lr.color */
-    border-right-style: $footnotes_border_lr_style; /* footnotes.border.lr.color */
-    border-right-width: $footnotes_border_lr_width; /* footnotes.border.lr.color */
-    border-right-color: $footnotes_border_lr_color; /* footnotes.border.lr.color */
+    background-color: $footnotes_background_color; // footnotes.background.color
+    border-bottom-style: $footnotes_border_bottom_style; // footnotes.border.bottom.style
+    border-bottom-width: $footnotes_border_bottom_width; // footnotes.border.bottom.width
+    border-bottom-color: $footnotes_border_bottom_color; // footnotes.border.bottom.color
+    border-left-style:  $footnotes_border_lr_style; // footnotes.border.lr.color
+    border-left-width:  $footnotes_border_lr_width; // footnotes.border.lr.color
+    border-left-color:  $footnotes_border_lr_color; // footnotes.border.lr.color
+    border-right-style: $footnotes_border_lr_style; // footnotes.border.lr.color
+    border-right-width: $footnotes_border_lr_width; // footnotes.border.lr.color
+    border-right-color: $footnotes_border_lr_color; // footnotes.border.lr.color
   }
 
   .gt_footnote {
     margin: $footnotes_margin;
-    font-size: $footnotes_font_size; /* footnotes.font.size */
-    padding: $footnotes_padding; /* footnotes.padding */
+    font-size: $footnotes_font_size; // footnotes.font.size
+    padding: $footnotes_padding; // footnotes.padding
   }
 
   .gt_sourcenotes {
     color: font-color($source_notes_background_color);
-    background-color: $source_notes_background_color; /* source_notes.background.color */
-    border-bottom-style: $source_notes_border_bottom_style; /* source_notes.border.bottom.style */
-    border-bottom-width: $source_notes_border_bottom_width; /* source_notes.border.bottom.width */
-    border-bottom-color: $source_notes_border_bottom_color; /* source_notes.border.bottom.color */
-    border-left-style:  $source_notes_border_lr_style; /* source_notes.border.lr.style */
-    border-left-width:  $source_notes_border_lr_width; /* source_notes.border.lr.style */
-    border-left-color:  $source_notes_border_lr_color; /* source_notes.border.lr.style */
-    border-right-style: $source_notes_border_lr_style; /* source_notes.border.lr.style */
-    border-right-width: $source_notes_border_lr_width; /* source_notes.border.lr.style */
-    border-right-color: $source_notes_border_lr_color; /* source_notes.border.lr.style */
+    background-color: $source_notes_background_color; // source_notes.background.color
+    border-bottom-style: $source_notes_border_bottom_style; // source_notes.border.bottom.style
+    border-bottom-width: $source_notes_border_bottom_width; // source_notes.border.bottom.width
+    border-bottom-color: $source_notes_border_bottom_color; // source_notes.border.bottom.color
+    border-left-style:  $source_notes_border_lr_style; // source_notes.border.lr.style
+    border-left-width:  $source_notes_border_lr_width; // source_notes.border.lr.style
+    border-left-color:  $source_notes_border_lr_color; // source_notes.border.lr.style
+    border-right-style: $source_notes_border_lr_style; // source_notes.border.lr.style
+    border-right-width: $source_notes_border_lr_width; // source_notes.border.lr.style
+    border-right-color: $source_notes_border_lr_color; // source_notes.border.lr.style
 
   }
 
   .gt_sourcenote {
-    font-size: $source_notes_font_size; /* source_notes.font.size */
-    padding: $source_notes_padding; /* source_notes.padding */
+    font-size: $source_notes_font_size; // source_notes.font.size
+    padding: $source_notes_padding; // source_notes.padding
   }
 
   .gt_left {

--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -100,6 +100,10 @@
     width: 97%;
   }
 
+  .gt_column_spanner_outer {
+    background-color: $column_labels_background_color; // column_labels.background.color
+  }
+
   .gt_group_heading {
     padding: $row_group_padding; // row_group.padding
     color: font-color($row_group_background_color);

--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -54,14 +54,6 @@
     border-bottom-color: $heading_border_bottom_color; /* heading.border.bottom.color */
   }
 
-  .gt_column_spanner {
-    border-bottom-style: solid;
-    border-bottom-width: 2px;
-    border-bottom-color: #D3D3D3;
-    padding-top: 4px;
-    padding-bottom: 4px;
-  }
-
   .gt_col_headings {
     border-top-style: $column_labels_border_top_style; /* column_labels.border.top.style */
     border-top-width: $column_labels_border_top_width; /* column_labels.border.top.width */
@@ -83,14 +75,29 @@
     font-size: $column_labels_font_size; /* column_labels.font.size */
     font-weight: $column_labels_font_weight; /* column_labels.font.weight */
     text-transform: $column_labels_text_transform; /* column_labels.text_transform */
-    vertical-align: middle;
-    padding: 5px;
-    margin: 10px;
+    vertical-align: bottom;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
     overflow-x: hidden;
   }
 
-  .gt_sep_right {
-    border-right: 5px solid #{$column_labels_background_color};
+  .gt_column_spanner {
+    color: font-color($column_labels_background_color);
+    background-color: $column_labels_background_color; /* column_labels.background.color */
+    font-size: $column_labels_font_size; /* column_labels.font.size */
+    font-weight: $column_labels_font_weight; /* column_labels.font.weight */
+    text-transform: $column_labels_text_transform; /* column_labels.text_transform */
+    vertical-align: bottom;
+    border-bottom-style: $column_labels_border_bottom_style; /* column_labels.border.bottom.style */
+    border-bottom-width: $column_labels_border_bottom_width; /* column_labels.border.bottom.width */
+    border-bottom-color: $column_labels_border_bottom_color; /* column_labels.border.bottom.color */
+    padding-top: 4px;
+    padding-bottom: 4px;
+    overflow-x: hidden;
+    display: inline-block;
+    width: 97%;
   }
 
   .gt_group_heading {

--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -76,32 +76,33 @@
     font-weight: $column_labels_font_weight; // column_labels.font.weight
     text-transform: $column_labels_text_transform; // column_labels.text_transform
     vertical-align: bottom;
-    padding-top: 4px;
-    padding-bottom: 4px;
+    padding-top: 5px;
+    padding-bottom: 6px;
     padding-left: 5px;
     padding-right: 5px;
     overflow-x: hidden;
   }
 
-  .gt_column_spanner {
+  .gt_column_spanner_outer {
     color: font-color($column_labels_background_color);
     background-color: $column_labels_background_color; // column_labels.background.color
     font-size: $column_labels_font_size; // column_labels.font.size
     font-weight: $column_labels_font_weight; // column_labels.font.weight
     text-transform: $column_labels_text_transform; // column_labels.text_transform
-    vertical-align: bottom;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .gt_column_spanner {
     border-bottom-style: $column_labels_border_bottom_style; // column_labels.border.bottom.style
     border-bottom-width: $column_labels_border_bottom_width; // column_labels.border.bottom.width
     border-bottom-color: $column_labels_border_bottom_color; // column_labels.border.bottom.color
-    padding-top: 4px;
-    padding-bottom: 4px;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 6px;
     overflow-x: hidden;
     display: inline-block;
     width: 97%;
-  }
-
-  .gt_column_spanner_outer {
-    background-color: $column_labels_background_color; // column_labels.background.color
   }
 
   .gt_group_heading {

--- a/tests/gt-examples/01-html-script/html-16-table_options_everywhere.R
+++ b/tests/gt-examples/01-html-script/html-16-table_options_everywhere.R
@@ -74,7 +74,7 @@ many_options_tbl <-
     heading.border.bottom.color = "purple",   # Bottom line of heading - color
     column_labels.font.size = px(16),                # Column labels - font size
     column_labels.font.weight = "normal",            # Column labels - font weight
-    column_labels.background.color = "lightgray",    # Column labels background color
+    column_labels.background.color = "olivedrab",    # Column labels background color
     row_group.background.color = "green",        # Row group background color
     row_group.font.size = px(14),                # Row group labels - font size
     row_group.font.weight = "800",               # Row group labels - font weight

--- a/tests/testthat/test-location_cells.R
+++ b/tests/testthat/test-location_cells.R
@@ -494,8 +494,8 @@ test_that("styles are correctly applied to HTML output with location functions",
     render_as_html() %>%
     tidy_grepl(
       paste0(
-        "<th class=\"gt_center gt_columns_top_border\" rowspan=\"1\" ",
-        "colspan=\"2\" style=\"color: white; font-size: 20px; ",
+        "<th class=\"gt_center gt_columns_top_border gt_column_spanner_outer\" ",
+        "rowspan=\"1\" colspan=\"2\" style=\"color: white; font-size: 20px; ",
         "background-color: #FFA500;\">.*?<span class=\"gt_column_spanner\">",
         "spanner</span>"
         )

--- a/tests/testthat/test-location_cells.R
+++ b/tests/testthat/test-location_cells.R
@@ -492,7 +492,14 @@ test_that("styles are correctly applied to HTML output with location functions",
   # Expect that the styling was applied to the correct column labels
   gt_tbl_cells_column_spanners %>%
     render_as_html() %>%
-    tidy_grepl("<th class=\".*? gt_column_spanner\".*?style=\"color: white; font-size: 20px; background-color: #FFA500;\">spanner</th>") %>%
+    tidy_grepl(
+      paste0(
+        "<th class=\"gt_center gt_columns_top_border\" rowspan=\"1\" ",
+        "colspan=\"2\" style=\"color: white; font-size: 20px; ",
+        "background-color: #FFA500;\">.*?<span class=\"gt_column_spanner\">",
+        "spanner</span>"
+        )
+      ) %>%
     expect_true()
 
   #

--- a/tests/testthat/test-tab_spanner_delim.R
+++ b/tests/testthat/test-tab_spanner_delim.R
@@ -41,7 +41,9 @@ test_that("the `tab_spanner_delim()` function works correctly", {
     xml2::read_html() %>%
     rvest::html_nodes("[colspan='2']") %>%
     rvest::html_text() %>%
-    expect_equal( c("Sepal", "Petal"))
+    grepl("Sepal|Petal", .) %>%
+    all() %>%
+    expect_true()
 
   # Expect that the columns with a colspan of `2` have the same
   # ordering in the rendered table
@@ -76,7 +78,8 @@ test_that("the `tab_spanner_delim()` function works correctly", {
     xml2::read_html() %>%
     rvest::html_nodes("[colspan='2']") %>%
     rvest::html_text() %>%
-    expect_equal("Sepal")
+    grepl("Sepal", .) %>%
+    expect_true()
 
   # Expect that the columns with a colspan of `2` have the same
   # ordering in the rendered table
@@ -112,7 +115,8 @@ test_that("the `tab_spanner_delim()` function works correctly", {
     xml2::read_html() %>%
     rvest::html_nodes("[colspan='2']") %>%
     rvest::html_text() %>%
-    expect_equal("Sepal")
+    grepl("Sepal", .) %>%
+    expect_true()
 
   # Expect that the columns with a colspan of `2` have the same
   # ordering in the rendered table

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -136,7 +136,7 @@ test_that("a gt table contains the expected spanner column labels", {
   # Expect that the content is the column heading spanning 2 columns
   # is `perimeter`
   tbl_html %>%
-    selection_text("[class='gt_center gt_columns_top_border']") %>%
+    selection_text("[class='gt_center gt_columns_top_border gt_column_spanner_outer']") %>%
     grepl("perimeter", .) %>%
     expect_true()
 

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -118,7 +118,8 @@ test_that("a gt table contains the expected spanner column labels", {
   # is `perimeter`
   tbl_html %>%
     selection_text("[colspan='2']") %>%
-    expect_equal("perimeter")
+    grepl("perimeter", .) %>%
+    expect_true()
 
   # Create a `gt_tbl` object with `gt()`; this table
   # contains the spanner heading `perimeter` over the
@@ -135,8 +136,9 @@ test_that("a gt table contains the expected spanner column labels", {
   # Expect that the content is the column heading spanning 2 columns
   # is `perimeter`
   tbl_html %>%
-    selection_text("[class='gt_col_heading gt_center gt_columns_top_border gt_column_spanner']") %>%
-    expect_equal("perimeter")
+    selection_text("[class='gt_center gt_columns_top_border']") %>%
+    grepl("perimeter", .) %>%
+    expect_true()
 
   # Create a `tbl_html` object with `gt()`; this table
   # contains the spanner heading `perimeter` that is formatted
@@ -510,7 +512,8 @@ test_that("a gt table contains custom styles at the correct locations", {
   tbl_html %>%
     rvest::html_nodes("[style='background-color: #90EE90;']") %>%
     rvest::html_text() %>%
-    expect_equal("gear_carb_cyl")
+    grepl("gear_carb_cyl", .) %>%
+    expect_true()
 
   # Expect that the `Mazdas` row group label
   # cell has a red background and white text

--- a/tests/testthat/test-util_functions.R
+++ b/tests/testthat/test-util_functions.R
@@ -360,7 +360,7 @@ test_that("the `get_css_tbl()` function works correctly", {
 
   css_tbl %>% expect_is(c("tbl_df", "tbl", "data.frame"))
 
-  css_tbl %>% dim() %>% expect_equal(c(206, 4))
+  css_tbl %>% dim() %>% expect_equal(c(208, 4))
 
   css_tbl %>%
     colnames() %>%

--- a/tests/testthat/test-util_functions.R
+++ b/tests/testthat/test-util_functions.R
@@ -360,7 +360,7 @@ test_that("the `get_css_tbl()` function works correctly", {
 
   css_tbl %>% expect_is(c("tbl_df", "tbl", "data.frame"))
 
-  css_tbl %>% dim() %>% expect_equal(c(208, 4))
+  css_tbl %>% dim() %>% expect_equal(c(212, 4))
 
   css_tbl %>%
     colnames() %>%

--- a/tests/testthat/test-util_functions.R
+++ b/tests/testthat/test-util_functions.R
@@ -360,7 +360,7 @@ test_that("the `get_css_tbl()` function works correctly", {
 
   css_tbl %>% expect_is(c("tbl_df", "tbl", "data.frame"))
 
-  css_tbl %>% dim() %>% expect_equal(c(196, 4))
+  css_tbl %>% dim() %>% expect_equal(c(206, 4))
 
   css_tbl %>%
     colnames() %>%


### PR DESCRIPTION
These changes improve the visual presentation of each spanner's bottom borders. It provides more separation between adjacent spanners and appears without defect in dark mode. 

The following code produces a gt table with two adjacent spanners:

```r
gtcars %>%
  head(10) %>%
  select(mfr, model, year, bdy_style, hp, hp_rpm, trq, trq_rpm, mpg_c, mpg_h) %>%
  gt() %>%
  tab_spanner(
    label = "Car Model",
    columns = vars(mfr,model,year)
  ) %>%
  tab_spanner(
    label = "Performance",
    columns = vars(bdy_style,hp,hp_rpm,trq,trq_rpm,mpg_c,mpg_h)
  ) %>%
  tab_header("gtcars dataset")
```

<img width="932" alt="tab_spanner_gap_width_fix" src="https://user-images.githubusercontent.com/5612024/74378290-b044b900-4db3-11ea-8ad3-cd5da49f1889.png">


Fixes: #467 
Fixes: https://github.com/rstudio/gt/issues/74