### PR TITLE
fix #487, allow spans to contain a single column in LaTeX output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
 # gt 0.1.0 (unreleased)
 
 * New package with 39 exported functions for building display tables
+* updated `tab_spanner` to allow single-column spans with LaTeX output
+  (@r2evans, #487)

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -115,10 +115,11 @@ create_columns_component_l <- function(data) {
 
     # Get vector of group labels (spanners)
     spanners <- dt_spanners_print(data = data, include_hidden = FALSE)
+    is_spanner <- !is.na(spanners)
 
     # Promote column labels to the group level wherever the
     # spanner label is NA
-    spanners[is.na(spanners)] <- headings_vars[is.na(spanners)]
+    spanners[!is_spanner] <- headings_vars[is.na(spanners)]
 
     if (stub_available) {
       spanners <- c(NA_character_, spanners)
@@ -131,7 +132,7 @@ create_columns_component_l <- function(data) {
 
     for (i in seq(spanners_lengths$lengths)) {
 
-      if (spanners_lengths$lengths[i] > 1) {
+      if (spanners_lengths$lengths[i] > 1 || is_spanner[i]) {
 
         if (length(multicol) > 0 &&
             grepl("\\\\multicolumn", multicol[length(multicol)])) {

--- a/tests/testthat/test-l_tab_spanner_delim.R
+++ b/tests/testthat/test-l_tab_spanner_delim.R
@@ -34,8 +34,8 @@ test_that("the `tab_spanner_delim()` function works correctly", {
   # Expect a characteristic pattern
   grepl(
     paste0(
-      ".*multicolumn\\{2\\}\\{c\\}\\{Sepal\\} & & &",
-      ".*cmidrule\\(lr\\)\\{1-2\\}",
+      ".*multicolumn\\{2\\}\\{c\\}\\{Sepal\\} & .*multicolumn\\{1\\}\\{c\\}\\{Petal.Length\\} & &",
+      ".*cmidrule\\(lr\\)\\{1-2\\}.*cmidrule\\(lr\\)\\{3-3\\}",
       ".*Length & Width & Petal.Length & Petal.Width & Species.*"),
     tbl_latex %>%
       as_latex() %>% as.character()) %>%
@@ -55,8 +55,8 @@ test_that("the `tab_spanner_delim()` function works correctly", {
   # Expect a characteristic pattern
   grepl(
     paste0(
-      ".*multicolumn\\{2\\}\\{c\\}\\{Sepal\\} & & &",
-      ".*cmidrule\\(lr\\)\\{1-2\\}",
+      ".*multicolumn\\{2\\}\\{c\\}\\{Sepal\\} & .*multicolumn\\{1\\}\\{c\\}\\{Petal.Length\\} & &",
+      ".*cmidrule\\(lr\\)\\{1-2\\}.*cmidrule\\(lr\\)\\{3-3\\}",
       ".*Length & Width & Petal.Length & Petal.Width & Species.*"),
     tbl_latex %>%
       as_latex() %>% as.character()) %>%


### PR DESCRIPTION
This allows single-span column headers to exist when defined, per #487.

Using sample data:

```r
gtbl <- mtcars %>%
  select(cyl, mpg, disp, drat) %>%
  slice(1:4) %>%
  gt() %>%
  tab_spanner("Zork", vars(mpg)) %>%
  tab_spanner("Quux", vars(disp, drat))
as_latex(gtbl)
```

Before the PR (HTML on left, LaTeX/PDF right):

> 
![image](https://user-images.githubusercontent.com/5815808/74382046-75d22080-4da1-11ea-96ec-28e6b93021ab.png)

After this PR:

> ![image](https://user-images.githubusercontent.com/5815808/74382071-808cb580-4da1-11ea-8213-4f647ef7b3eb.png)

(No change to HTML.)

Note: `devtools::test` is producing 4 failed, 4 warnings, and 1 skipped test *before this PR*, and this PR changes none of those.