### PR TITLE
Update testthat tests for UTF-8 characters across system locales

### DIFF
--- a/tests/testthat/test-gt_object.R
+++ b/tests/testthat/test-gt_object.R
@@ -188,6 +188,11 @@ test_that("a gt table can use UTF-8 chars in any system locale", {
       "C", "POSIX"
     )
 
+  # Intersect the vector of available locales (on a given test system)
+  # with the `system_locales` vector
+  available_locales <- system("locale -a", intern = TRUE)
+  system_locales <- intersect(system_locales, available_locales)
+
   names_df <-
     data.frame(
       first = c("\u6625", "Fred"),


### PR DESCRIPTION
This PR ensures that system locales are available on the test system and also it constrains them to an already specified set.