### PR TITLE
Use `rle()` to determine colspan values for spanners

### DIFF
--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -431,8 +431,13 @@ create_columns_component_h <- function(data) {
 
     spanners <- dt_spanners_print(data = data, include_hidden = FALSE)
 
-    headings_stack <- c()
-    first_set <- second_set <- list()
+    # A list of <th> elements that will go in the top row. This includes
+    # spanner labels and column labels for solo columns (don't have spanner
+    # labels); in the latter case, rowspan=2 will be used.
+    first_set <- list()
+    # A list of <th> elements that will go in the second row. This is all column
+    # labels that DO have spanners above them.
+    second_set <- list()
 
     # Create the cell for the stubhead label
     if (isTRUE(stub_available)) {
@@ -506,8 +511,6 @@ create_columns_component_h <- function(data) {
             htmltools::HTML(headings_labels[i])
           )
 
-        headings_stack <- c(headings_stack, headings_vars[i])
-
       } else if (!is.na(spanners[i])) {
 
         # If colspans[i] == 0, it means that a previous cell's colspan
@@ -544,7 +547,8 @@ create_columns_component_h <- function(data) {
       }
     }
 
-    remaining_headings <- headings_vars[!(headings_vars %in% headings_stack)]
+    solo_headings <- headings_vars[is.na(spanners)]
+    remaining_headings <- headings_vars[!(headings_vars %in% solo_headings)]
 
     remaining_headings_indices <- which(remaining_headings %in% headings_vars)
 
@@ -555,7 +559,7 @@ create_columns_component_h <- function(data) {
       unlist()
 
     col_alignment <-
-      col_alignment[-1][!(headings_vars %in% headings_stack)]
+      col_alignment[-1][!(headings_vars %in% solo_headings)]
 
     if (length(remaining_headings) > 0) {
 

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -508,18 +508,8 @@ create_columns_component_h <- function(data) {
         if (!same_spanner) {
 
           class <- "gt_column_spanner"
-          colspan <- 1
 
-          for (j in 1:length(spanners)) {
-
-            if (is.na(spanners[i + j])) {
-              break
-            } else if (duplicated(spanners)[i + j]) {
-              colspan <- colspan + 1L
-            } else {
-              break
-            }
-          }
+          colspan <- rle(spanners[i:length(spanners)])$lengths[1]
 
           styles_spanners <-
             spanner_style_attrs %>%

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -180,6 +180,45 @@ test_that("a gt table contains the expected spanner column labels", {
   )
 })
 
+test_that("`tab_spanner()` works even when columns are forcibly moved", {
+
+  # Create a table with column spanners, moving the `carb` value
+  # to the beginning of the column sequence (splitting the `group_d`
+  # column spanner into two parts)
+  tbl_html <-
+    gt(mtcars[1, ]) %>%
+    tab_spanner(
+      label = md("*group_a*"),
+      columns = vars(cyl, hp)
+    ) %>%
+    tab_spanner(
+      label = md("*group_b*"),
+      columns = vars(drat, wt)
+    ) %>%
+    tab_spanner(
+      label = md("*group_c*"),
+      columns = vars(qsec, vs, am)
+    ) %>%
+    tab_spanner(
+      label = md("*group_d*"),
+      columns = vars(gear, carb)
+    ) %>%
+    cols_move_to_start(columns = vars(carb)) %>%
+    render_as_html()
+
+
+  # Expect the sequence of `colspan` values across both
+  # <tr>s in <thead> is correct
+  tbl_html %>%
+    xml2::read_html() %>%
+    selection_value("colspan") %>%
+    expect_equal(
+      c("1", "1", "2", "1", "2", "3", "1",           # first <tr>
+        "1", "1", "1", "1", "1", "1", "1", "1", "1"  # second <tr>
+       )
+    )
+})
+
 test_that("a gt table contains the expected source note", {
 
   # Check that specific suggested packages are available

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -203,6 +203,10 @@ test_that("`tab_spanner()` works even when columns are forcibly moved", {
       label = md("*group_d*"),
       columns = vars(gear, carb)
     ) %>%
+    tab_spanner(
+      label = md("*never*"),
+      columns = ends_with("nothing")
+    ) %>%
     cols_move_to_start(columns = vars(carb)) %>%
     render_as_html()
 


### PR DESCRIPTION
This PR fixes the method in which `colspan` values for spanners are calculated, using `rle()` instead of `duplicated()` in complicated `for` loop. 

Fixes #506 