### PR TITLE
Fix to avoid error in `gt_preview()` with columns that contain dates

### DIFF
--- a/R/gt_preview.R
+++ b/R/gt_preview.R
@@ -89,9 +89,11 @@ gt_preview <- function(data,
     # are retained (with an empty row between these row groups)
     data <-
       rbind(
-        data[seq(top_n), , drop = FALSE],
+        data[seq(top_n), , drop = FALSE] %>%
+          dplyr::mutate_all(as.character),
         rep("", ncol(data)),
-        data[(nrow(data) + 1 - rev(seq(bottom_n))), , drop = FALSE]
+        data[(nrow(data) + 1 - rev(seq(bottom_n))), , drop = FALSE] %>%
+          dplyr::mutate_all(as.character)
       )
 
     # Relabel the rowname for the ellipsis row

--- a/R/gt_preview.R
+++ b/R/gt_preview.R
@@ -89,9 +89,9 @@ gt_preview <- function(data,
     # are retained (with an empty row between these row groups)
     data <-
       rbind(
-        data[seq(top_n), ],
+        data[seq(top_n), , drop = FALSE],
         rep("", ncol(data)),
-        data[(nrow(data) + 1 - rev(seq(bottom_n))), ]
+        data[(nrow(data) + 1 - rev(seq(bottom_n))), , drop = FALSE]
       )
 
     # Relabel the rowname for the ellipsis row

--- a/R/gt_preview.R
+++ b/R/gt_preview.R
@@ -85,20 +85,17 @@ gt_preview <- function(data,
     # Prepare a rowname label that represents the hidden row numbers
     between_rownums <- c(ellipsis_row, nrow(data) - bottom_n)
 
-    # Obtain the top and bottom slices of data, and convert all
-    # data values to character with an in-place `lapply()`
+    # Obtain the top and bottom slices of data
     top_slice <- data[seq(top_n), , drop = FALSE]
-    top_slice[, ] <- lapply(top_slice[, ], as.character)
-
     bottom_slice <- data[(nrow(data) + 1 - rev(seq(bottom_n))), , drop = FALSE]
-    bottom_slice[, ] <- lapply(bottom_slice[, ], as.character)
 
-    # Modify the `data` so that only the `top_n` and `bottom_n` rows
-    # are retained (with an empty row between these row groups)
+    # Modify the `data` so that only the `top_n` (`top_slice`) and
+    # `bottom_n` (`bottom_slice`) rows are retained (with a row of
+    # NAs to clearly separate these slices)
     data <-
       rbind(
         top_slice,
-        rep("", ncol(data)),
+        rep(NA, ncol(data)),
         bottom_slice
       )
 
@@ -131,7 +128,8 @@ gt_preview <- function(data,
 
   visible_vars <- dt_boxhead_get_vars_default(data = gt_tbl)
 
-  # Add styling to ellipsis row, if it is present
+  # Replace the NA values and add styling to the ellipsis
+  # row (if it is present)
   if (isTRUE(has_ellipsis_row)) {
 
     gt_tbl <-
@@ -139,7 +137,8 @@ gt_preview <- function(data,
       tab_style(
         style = cell_fill(color = "#E4E4E4"),
         locations = cells_body(columns = visible_vars, rows = ellipsis_row)
-      )
+      ) %>%
+      fmt_missing(columns = TRUE, rows = ellipsis_row, missing_text = "")
 
     if (isTRUE(incl_rownums)) {
 
@@ -148,11 +147,10 @@ gt_preview <- function(data,
         tab_style(
           style = list(
             cell_fill(color = "#E4E4E4"),
-            cell_text(size = "10px")
+            cell_text(size = "x-small")
           ),
           locations = cells_stub(rows = ellipsis_row)
         )
-
     }
   }
 

--- a/R/gt_preview.R
+++ b/R/gt_preview.R
@@ -85,15 +85,21 @@ gt_preview <- function(data,
     # Prepare a rowname label that represents the hidden row numbers
     between_rownums <- c(ellipsis_row, nrow(data) - bottom_n)
 
+    # Obtain the top and bottom slices of data, and convert all
+    # data values to character with an in-place `lapply()`
+    top_slice <- data[seq(top_n), , drop = FALSE]
+    top_slice[, ] <- lapply(top_slice[, ], as.character)
+
+    bottom_slice <- data[(nrow(data) + 1 - rev(seq(bottom_n))), , drop = FALSE]
+    bottom_slice[, ] <- lapply(bottom_slice[, ], as.character)
+
     # Modify the `data` so that only the `top_n` and `bottom_n` rows
     # are retained (with an empty row between these row groups)
     data <-
       rbind(
-        data[seq(top_n), , drop = FALSE] %>%
-          dplyr::mutate_all(as.character),
+        top_slice,
         rep("", ncol(data)),
-        data[(nrow(data) + 1 - rev(seq(bottom_n))), , drop = FALSE] %>%
-          dplyr::mutate_all(as.character)
+        bottom_slice
       )
 
     # Relabel the rowname for the ellipsis row

--- a/R/gt_preview.R
+++ b/R/gt_preview.R
@@ -138,7 +138,10 @@ gt_preview <- function(data,
         style = cell_fill(color = "#E4E4E4"),
         locations = cells_body(columns = visible_vars, rows = ellipsis_row)
       ) %>%
-      fmt_missing(columns = TRUE, rows = ellipsis_row, missing_text = "")
+      text_transform(
+        locations = cells_body(columns = TRUE, rows = ellipsis_row),
+        fn = function(x) ""
+      )
 
     if (isTRUE(incl_rownums)) {
 

--- a/tests/testthat/test-gt_preview.R
+++ b/tests/testthat/test-gt_preview.R
@@ -101,4 +101,30 @@ test_that("the `gt_preview()` function works correctly", {
   output_tbl %>%
     colnames() %>%
     expect_equal(colnames(mtcars))
+
+  # Expect no errors when all gt datasets (plus a few more)
+  # do not error when calling `gt_preview()` on them
+  expect_error(regexp = NA, gt_preview(countrypops))
+  expect_error(regexp = NA, gt_preview(sza))
+  expect_error(regexp = NA, gt_preview(gtcars))
+  expect_error(regexp = NA, gt_preview(sp500))
+  expect_error(regexp = NA, gt_preview(pizzaplace))
+  expect_error(regexp = NA, gt_preview(exibble))
+
+  expect_error(regexp = NA, gt_preview(datasets::airquality))
+  expect_error(regexp = NA, gt_preview(datasets::cars))
+  expect_error(regexp = NA, gt_preview(datasets::chickwts))
+  expect_error(regexp = NA, gt_preview(datasets::faithful))
+  expect_error(regexp = NA, gt_preview(datasets::iris))
+  expect_error(regexp = NA, gt_preview(datasets::LifeCycleSavings))
+  expect_error(regexp = NA, gt_preview(datasets::longley))
+  expect_error(regexp = NA, gt_preview(datasets::morley))
+  expect_error(regexp = NA, gt_preview(datasets::mtcars))
+  expect_error(regexp = NA, gt_preview(datasets::Orange))
+  expect_error(regexp = NA, gt_preview(datasets::pressure))
+  expect_error(regexp = NA, gt_preview(datasets::quakes))
+  expect_error(regexp = NA, gt_preview(datasets::rock))
+  expect_error(regexp = NA, gt_preview(datasets::sleep))
+  expect_error(regexp = NA, gt_preview(datasets::swiss))
+  expect_error(regexp = NA, gt_preview(datasets::USJudgeRatings))
 })

--- a/tests/testthat/test-gt_preview.R
+++ b/tests/testthat/test-gt_preview.R
@@ -102,8 +102,8 @@ test_that("the `gt_preview()` function works correctly", {
     colnames() %>%
     expect_equal(colnames(mtcars))
 
-  # Expect no errors when all gt datasets (plus a few more)
-  # do not error when calling `gt_preview()` on them
+  # Expect no errors when using all gt datasets (plus a few more
+  # from the datasets package) with the `gt_preview()` function
   expect_error(regexp = NA, gt_preview(countrypops))
   expect_error(regexp = NA, gt_preview(sza))
   expect_error(regexp = NA, gt_preview(gtcars))


### PR DESCRIPTION
When using `gt_preview()` on a table with a `Date` column, we get an error because an empty string (which we use as a dividing row in an `rbind()` operation) cannot be coerced to a `Date`.

With:

```r
gt_preview(sp500)
```

We get the error:

```
Error in charToDate(x) : 
  character string is not in a standard unambiguous format
```

The first column `date` is of the `Date` class. We get the same error with `as.Date("")`.

Any columns that are date-times (`POSIXct`) don't fare any better. That associated error is:

```
Error in as.POSIXlt.character(x, tz, ...) : 
  character string is not in a standard unambiguous format
```

The solution is to use `NA`s for the dividing row in the `rbind()` call of `gt_preview()`. To ensure that this works across a wide variety of input tables, I've added numerous **testthat** tests to check that there are no errors.
