### PR TITLE
Don't .Rbuildignore vignettes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,4 +14,3 @@
 ^CODE_OF_CONDUCT\.md$
 ^TODOS
 tests/gt-examples
-vignettes


### PR DESCRIPTION
While this was good for the CRAN submission, pkgdown won't build articles if the `vignettes` folder is in `.Rbuildignore` (it just hangs). This will allow for the pkgdown site to regenerate (and for the build to no longer be broken). 