### PR TITLE
Add \dontrun{} around `gtsave()` examples

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -41,6 +41,7 @@
 #'   function.
 #'
 #' @examples
+#' \dontrun{
 #' # Use `gtcars` to create a gt table; add
 #' # a stubhead label to describe what is
 #' # in the stub
@@ -80,6 +81,7 @@
 #' # document
 #' tab_1 %>%
 #'   gtsave("tab_1.tex", path = tempdir())
+#' }
 #'
 #' @family Export Functions
 #' @section Function ID:

--- a/R/export.R
+++ b/R/export.R
@@ -41,7 +41,7 @@
 #'   function.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Use `gtcars` to create a gt table; add
 #' # a stubhead label to describe what is
 #' # in the stub

--- a/R/export.R
+++ b/R/export.R
@@ -202,6 +202,7 @@ gt_save_webshot <- function(data,
       selector = "table",
       zoom = zoom,
       expand = expand,
+      wait = TRUE,
       ...
     )
   }

--- a/man/gtsave.Rd
+++ b/man/gtsave.Rd
@@ -58,6 +58,7 @@ to \code{...}.
 }
 
 \examples{
+\dontrun{
 # Use `gtcars` to create a gt table; add
 # a stubhead label to describe what is
 # in the stub
@@ -97,6 +98,7 @@ tab_1 \%>\%
 # document
 tab_1 \%>\%
   gtsave("tab_1.tex", path = tempdir())
+}
 
 }
 \seealso{


### PR DESCRIPTION
This PR wraps `\dontrun{}` around the examples in the `gtsave()` doc to avoid a R CMD check issue on Travis.