### PR TITLE
Add shadow DOM compatibility

### DIFF
--- a/R/compile_scss.R
+++ b/R/compile_scss.R
@@ -18,7 +18,7 @@ compile_scss <- function(data, id = NULL) {
       glue::glue(
         .open = "<<", .close = ">>",
         "
-        <<ifelse(has_id, 'html', '.gt_table')>> {
+        <<ifelse(has_id, 'html, :host', '.gt_table')>> {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
             Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans',
             Arial, sans-serif;


### PR DESCRIPTION
This rule sets the default font not only for the root html
element, but also for the host of the shadow DOM, if any.