### PR TITLE
stubs get striped behavior

### DIFF
--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -163,7 +163,7 @@
     vertical-align: middle;
   }
 
-  .gt_striped {
+  .gt_striped, .gt_stub.gt_striped {
      background-color: $row_striping_background_color; // row.striping.background_color
   }
 


### PR DESCRIPTION
Fixes #536 

Code:
```r
library(gt)
exibble %>% 
  gt(rowname_col = "row") %>% 
  opt_row_striping() %>% 
  tab_options(row.striping.include_stub = TRUE, row.striping.background_color = "yellow")
```

Before:
<img width="475" alt="Screen Shot 2020-04-09 at 12 34 58 PM" src="https://user-images.githubusercontent.com/2104579/78923902-88459f00-7a5e-11ea-9ae8-bd8826d0f1d3.png">

After:
<img width="475" alt="Screen Shot 2020-04-09 at 12 35 58 PM" src="https://user-images.githubusercontent.com/2104579/78923977-ac08e500-7a5e-11ea-99da-730a2e06b066.png">


Thanks!