### PR TITLE
Remove `wait = TRUE` from `webshot()` call

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -202,7 +202,6 @@ gt_save_webshot <- function(data,
       selector = "table",
       zoom = zoom,
       expand = expand,
-      wait = TRUE,
       ...
     )
   }


### PR DESCRIPTION
This removes `wait = TRUE` from an internal `webshot()` call.

Fixes: #542 