### PR TITLE
Squelch warnings from tibble 3.0.0/3.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     sass (>= 0.1.1),
     scales (>= 1.1.0),
     stringr (>= 1.3.1),
-    tibble (>= 3.0.1),
+    tibble (>= 3.0.0),
     tidyselect (>= 1.0.0)
 Suggests:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     sass (>= 0.1.1),
     scales (>= 1.1.0),
     stringr (>= 1.3.1),
-    tibble (>= 3.0.0),
+    tibble (>= 3.0.1),
     tidyselect (>= 1.0.0)
 Suggests:
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt 0.2.0.9000 (in development)
 
+* Ensure compatibility with **tibble** 3.0.0. PR: [#557](https://github.com/rstudio/gt/pull/557).
+
 # gt 0.2.0.5
 
 * New package with 80 exported functions for building display tables

--- a/R/dt_styles.R
+++ b/R/dt_styles.R
@@ -13,12 +13,12 @@ dt_styles_set <- function(data, styles) {
 dt_styles_init <- function(data) {
 
   dplyr::tibble(
-    locname = NA_character_,
-    grpname = NA_character_,
-    colname = NA_character_,
-    locnum = NA_real_,
-    rownum = NA_integer_,
-    colnum = NA_integer_,
+    locname = character(0),
+    grpname = character(0),
+    colname = character(0),
+    locnum = numeric(0),
+    rownum = integer(0),
+    colnum = integer(0),
     styles = list()
   ) %>%
     dt_styles_set(styles = ., data = data)

--- a/R/dt_styles.R
+++ b/R/dt_styles.R
@@ -20,7 +20,7 @@ dt_styles_init <- function(data) {
     rownum = NA_integer_,
     colnum = NA_integer_,
     styles = list()
-  )[-1, ] %>%
+  ) %>%
     dt_styles_set(styles = ., data = data)
 }
 

--- a/R/export.R
+++ b/R/export.R
@@ -41,7 +41,8 @@
 #'   function.
 #'
 #' @examples
-#' \donttest{
+#' if (interactive()) {
+#'
 #' # Use `gtcars` to create a gt table; add
 #' # a stubhead label to describe what is
 #' # in the stub
@@ -81,6 +82,7 @@
 #' # document
 #' tab_1 %>%
 #'   gtsave("tab_1.tex", path = tempdir())
+#'
 #' }
 #'
 #' @family Export Functions

--- a/man/gtsave.Rd
+++ b/man/gtsave.Rd
@@ -58,7 +58,8 @@ to \code{...}.
 }
 
 \examples{
-\dontrun{
+if (interactive()) {
+
 # Use `gtcars` to create a gt table; add
 # a stubhead label to describe what is
 # in the stub
@@ -98,6 +99,7 @@ tab_1 \%>\%
 # document
 tab_1 \%>\%
   gtsave("tab_1.tex", path = tempdir())
+
 }
 
 }


### PR DESCRIPTION
The change made removes an unnecessary subsetting operation on a tibble. With the subsetting in place, although it gives an identical result, we get a warning in tibble 3.0.0/3.0.1. See https://cran.r-project.org/web/packages/tibble/vignettes/invariants.html for details (example is `df[10, ]`).

This PR also addresses a remaining issue with the roxygen `dontrun / donttest` directive in the `gtsave()` docs (removes it)