### PR TITLE
Restore row striping option in stub cells (`row.striping.include_stub = TRUE`)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/rstudio/gt/issues
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.0.9000
 Depends:
     R (>= 3.2.0)
 Imports: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt 0.2.0.9000 (in development)
 
+* Restore the ability to have row striping in stub cells (with `tab_option()`'s `row.striping.include_stub = TRUE`). Thanks [@gergness](https://github.com/gergness) for creating the PR that prompted this final fix ([#537](https://github.com/rstudio/gt/pull/537)). PR: [#564](https://github.com/rstudio/gt/pull/564).
+
 # gt 0.2.0.5
 
 * New package with 80 exported functions for building display tables

--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -163,10 +163,6 @@
     vertical-align: middle;
   }
 
-  .gt_striped {
-     background-color: $row_striping_background_color; // row.striping.background_color
-  }
-
   .gt_from_md > :first-child {
     margin-top: 0;
   }
@@ -244,6 +240,10 @@
     border-top-style: $grand_summary_row_border_style; // grand_summary_row.border.style
     border-top-width: $grand_summary_row_border_width; // grand_summary_row.border.width
     border-top-color: $grand_summary_row_border_color; // grand_summary_row.border.color
+  }
+
+  .gt_striped {
+     background-color: $row_striping_background_color; // row.striping.background_color
   }
 
   .gt_table_body {

--- a/man/data_color.Rd
+++ b/man/data_color.Rd
@@ -21,8 +21,8 @@ data_color(
 \item{colors}{Either a color mapping function from the \strong{scales} package or
 a vector of colors to use for each distinct value or level in each of the
 provided \code{columns}. The color mapping functions are:
-\code{\link[scales:col_quantile]{scales::col_quantile()}}, \code{\link[scales:col_bin]{scales::col_bin()}}, \code{\link[scales:col_numeric]{scales::col_numeric()}}, and
-\code{\link[scales:col_factor]{scales::col_factor()}}. If providing a vector of colors as a palette, each
+\code{\link[scales:col_numeric]{scales::col_quantile()}}, \code{\link[scales:col_numeric]{scales::col_bin()}}, \code{\link[scales:col_numeric]{scales::col_numeric()}}, and
+\code{\link[scales:col_numeric]{scales::col_factor()}}. If providing a vector of colors as a palette, each
 color value provided must either be a color name (in the set of colors
 provided by \code{\link[grDevices:colors]{grDevices::colors()}}) or a hexadecimal string in the form of
 "#RRGGBB" or "#RRGGBBAA".}
@@ -63,12 +63,12 @@ the \code{colors} argument. These functions map data values (\code{numeric} or
 \itemize{
 \item \code{\link[scales:col_numeric]{scales::col_numeric()}}: provides a simple linear mapping from
 continuous numeric data to an interpolated palette.
-\item \code{\link[scales:col_bin]{scales::col_bin()}}: provides a mapping of continuous numeric data to
+\item \code{\link[scales:col_numeric]{scales::col_bin()}}: provides a mapping of continuous numeric data to
 value-based bins. This internally uses the \code{\link[base:cut]{base::cut()}} function.
-\item \code{\link[scales:col_quantile]{scales::col_quantile()}}: provides a mapping of continuous
+\item \code{\link[scales:col_numeric]{scales::col_quantile()}}: provides a mapping of continuous
 numeric data to quantiles. This internally uses the
 \code{\link[stats:quantile]{stats::quantile()}} function.
-\item \code{\link[scales:col_factor]{scales::col_factor()}}: provides a mapping of factors to colors. If the
+\item \code{\link[scales:col_numeric]{scales::col_factor()}}: provides a mapping of factors to colors. If the
 palette is discrete and has a different number of colors than the number of
 factors, interpolation is used.
 }

--- a/man/gt-package.Rd
+++ b/man/gt-package.Rd
@@ -9,8 +9,8 @@
 Build display tables from tabular data with an easy-to-use set of
     functions. With its progressive approach, we can construct display tables
     with a cohesive set of table parts. Table values can be formatted using any
-    of the included formatter functions. Footnotes and cell styles can be 
-    precisely added through gt's location targeting system. The way in which gt
+    of the included formatting functions. Footnotes and cell styles can be 
+    precisely added through a location targeting system. The way in which 'gt'
     handles things for you means that you don't often have to worry about the
     fine details.
 }

--- a/man/gtsave.Rd
+++ b/man/gtsave.Rd
@@ -99,7 +99,6 @@ tab_1 \%>\%
 # document
 tab_1 \%>\%
   gtsave("tab_1.tex", path = tempdir())
-
 }
 
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -19,6 +19,6 @@ below to see their documentation.
 \describe{
   \item{dplyr}{\code{\link[dplyr]{vars}}}
 
-  \item{tidyselect}{\code{\link[tidyselect]{contains}}, \code{\link[tidyselect]{ends_with}}, \code{\link[tidyselect]{everything}}, \code{\link[tidyselect]{matches}}, \code{\link[tidyselect]{one_of}}, \code{\link[tidyselect]{starts_with}}}
+  \item{tidyselect}{\code{\link[tidyselect:starts_with]{contains}}, \code{\link[tidyselect:starts_with]{ends_with}}, \code{\link[tidyselect]{everything}}, \code{\link[tidyselect:starts_with]{matches}}, \code{\link[tidyselect]{one_of}}, \code{\link[tidyselect]{starts_with}}}
 }}
 


### PR DESCRIPTION
This simply moves the `.gt_striped` rule below others to increase precedence.

Thanks @gergness for creating the PR that prompted this one (https://github.com/rstudio/gt/pull/537). We ultimately decided to go with this change (which restores the earlier behavior) since it work better with HTML style inlining (using `as_raw_html()`).

Testable code from @gergness, where the yellow row stripes are also present in the stub cells (leftmost column).

```r
library(gt)

exibble %>% 
  gt(rowname_col = "row") %>% 
  opt_row_striping() %>% 
  tab_options(
    row.striping.include_stub = TRUE,
    row.striping.background_color = "yellow"
  )
```

<img width="821" alt="striping_in_stub" src="https://user-images.githubusercontent.com/5612024/80414226-b4568200-889e-11ea-885f-71f3cfb58c3e.png">

Fixes: https://github.com/rstudio/gt/issues/536
