### PR TITLE
Bump cache on pkgdown.yaml for GH workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: macOS-r-3.6-${{ hashFiles('depends.Rds') }}
-          restore-keys: macOS-r-3.6-
+          key: macOS-r-3.6-1-${{ hashFiles('depends.Rds') }}
+          restore-keys: macOS-r-3.6-1
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This attempts to resolve the issue where the package cache needs to be cleared because of an install issue. (Hoping that GitHub will make this easier in the future.)