### PR TITLE
Remove test of scales behaviour

### DIFF
--- a/tests/testthat/test-data_color.R
+++ b/tests/testthat/test-data_color.R
@@ -625,18 +625,6 @@ test_that("the correct color values are obtained when defining a palette", {
       )
   )
 
-  # Expect an error when providing an `NA` along
-  # with valid color names to `colors`
-  expect_error(
-    test_tbl %>%
-      gt() %>%
-      data_color(
-        columns = vars(min_sza),
-        colors = c("green", "blue", NA),
-        autocolor_text = TRUE
-      )
-  )
-
   # Expect an error when providing a numeric vector
   # to `colors`
   expect_error(


### PR DESCRIPTION
You accidentally depended on a scales 1.1.0 bug (and in general,  it's a bad idea to test errors generated by other packages).

Is there any chance you could do a quick gt release with this fix so I can submit scales to CRAN in the near future?