### PR TITLE
Update failing example

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -501,7 +501,7 @@ fmt_symbol <- function(data,
 #'   pizzaplace %>%
 #'   dplyr::mutate(month = as.numeric(substr(date, 6, 7))) %>%
 #'   dplyr::group_by(month) %>%
-#'   dplyr::summarize(pizzas_sold = n()) %>%
+#'   dplyr::summarize(pizzas_sold = dplyr::n()) %>%
 #'   dplyr::ungroup() %>%
 #'   dplyr::mutate(frac_of_quota = pizzas_sold / 4000) %>%
 #'   gt(rowname_col = "month") %>%

--- a/man/fmt_percent.Rd
+++ b/man/fmt_percent.Rd
@@ -116,7 +116,7 @@ tab_1 <-
   pizzaplace \%>\%
   dplyr::mutate(month = as.numeric(substr(date, 6, 7))) \%>\%
   dplyr::group_by(month) \%>\%
-  dplyr::summarize(pizzas_sold = n()) \%>\%
+  dplyr::summarize(pizzas_sold = dplyr::n()) \%>\%
   dplyr::ungroup() \%>\%
   dplyr::mutate(frac_of_quota = pizzas_sold / 4000) \%>\%
   gt(rowname_col = "month") \%>\%

--- a/man/gt-package.Rd
+++ b/man/gt-package.Rd
@@ -6,10 +6,13 @@
 \alias{_PACKAGE}
 \title{gt: Easily Create Presentation-Ready Display Tables}
 \description{
-Build display tables from tabular data using with an easy-to-use
-    API. With its progressive approach, we can construct display tables with a
-    clear separation of concerns: you don't have to decide how the tabular data
-    gets transformed and structured whilst also worrying about aesthetics.
+Build display tables from tabular data with an easy-to-use set of
+    functions. With its progressive approach, we can construct display tables
+    with a cohesive set of table parts. Table values can be formatted using any
+    of the included formatter functions. Footnotes and cell styles can be 
+    precisely added through gt's location targeting system. The way in which gt
+    handles things for you means that you don't often have to worry about the
+    fine details.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
This updates an example where dplyr's `n()` function wasn't found because it wasn't in the form `dplyr::n()`. This also roxygenizes the package article (`gt-package`), which was missed in an earlier PR where the package `Description` was modified.