### PR TITLE
Add `row_limit` arg to `gt()`

### DIFF
--- a/R/gt.R
+++ b/R/gt.R
@@ -39,6 +39,10 @@
 #' @param row_group.sep The separator to use between consecutive group names (a
 #'   possibility when providing `data` as a `grouped_df` with multiple groups)
 #'   in the displayed stub row group label.
+#' @param row_limit A row limit for rendering a **gt** table in an interactive
+#'   session Tables meeting or exceeding `row_limit` won't be rendered when
+#'   interactively using the **gt** API. To effectively disable this limit,
+#'   `Inf` can be used here.
 #'
 #' @return An object of class `gt_tbl`.
 #'
@@ -85,11 +89,21 @@ gt <- function(data,
                rownames_to_stub = FALSE,
                auto_align = TRUE,
                id = NULL,
-               row_group.sep = getOption("gt.row_group.sep", " - ")) {
+               row_group.sep = getOption("gt.row_group.sep", " - "),
+               row_limit = 1000) {
 
   # Stop function if the supplied `id` doesn't conform
   # to character(1) input or isn't NULL
-  validate_table_id(id)
+  validate_table_id(id = id)
+
+  # Stop function if the row count of `data` exceeds `row_limit`
+  # in the an interactive session
+  if (interactive() && nrow(data) >= row_limit) {
+    stop("The `data` provided has a row count that exceeds `row_limit`:\n",
+         "* Make `row_limit` higher than `nrow(data)` to render, or\n",
+         "* Use `row_limit = Inf` to completely disregard this limit check",
+         call. = FALSE)
+  }
 
   if (rownames_to_stub) {
     # Just a column name that's unlikely to collide with user data

--- a/man/gt.Rd
+++ b/man/gt.Rd
@@ -11,7 +11,8 @@ gt(
   rownames_to_stub = FALSE,
   auto_align = TRUE,
   id = NULL,
-  row_group.sep = getOption("gt.row_group.sep", " - ")
+  row_group.sep = getOption("gt.row_group.sep", " - "),
+  row_limit = 1000
 )
 }
 \arguments{
@@ -41,6 +42,11 @@ table ID can be used with any single-length character vector.}
 \item{row_group.sep}{The separator to use between consecutive group names (a
 possibility when providing \code{data} as a \code{grouped_df} with multiple groups)
 in the displayed stub row group label.}
+
+\item{row_limit}{A row limit for rendering a \strong{gt} table in an interactive
+session Tables meeting or exceeding \code{row_limit} won't be rendered when
+interactively using the \strong{gt} API. To effectively disable this limit,
+\code{Inf} can be used here.}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/tests/testthat/test-gt_object.R
+++ b/tests/testthat/test-gt_object.R
@@ -1,5 +1,3 @@
-context("Ensuring that the `gt()` function works as expected")
-
 # Function to skip tests if Suggested packages not available on system
 check_suggests <- function() {
   skip_if_not_installed("rvest")
@@ -668,5 +666,16 @@ test_that("Any shared names in `rowname_col` and `groupname_col` will be disallo
     exibble %>%
       dplyr::group_by(date, row) %>%
       gt(rowname_col = "row")
+  )
+})
+
+test_that("A gt table won't be interactively generated past a row limit", {
+
+  # Don't expect an error with row limits when the
+  # gt table is generated non-interactively (as is the
+  # case in testthat tests)
+  expect_error(
+    regexp = NA,
+    exibble %>% gt(row_limit = 5)
   )
 })


### PR DESCRIPTION
This addition imposes a row limit on rendering a gt table in an interactive session (stopping if meeting or exceeding the limit).  This can be entirely circumvented in the interactive case when setting `row_limit` to `Inf`.

Fixes: https://github.com/rstudio/gt/issues/210