### PR TITLE
Link to documentation site

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
     person("RStudio", role = c("cph", "fnd"))
     )
 License: MIT + file LICENSE
-URL: https://github.com/rstudio/gt
+URL: https://gt.rstudio.com/, https://github.com/rstudio/gt
 BugReports: https://github.com/rstudio/gt/issues
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
from `DESCRIPTION`. This ensures that the site is found from the CRAN package page and that pkgdown autolinking forwards to that documentation.