### PR TITLE
pkgdown updates

### DIFF
--- a/R/gt-package.R
+++ b/R/gt-package.R
@@ -1,3 +1,4 @@
 #' @docType package
+#' @keywords internal
 #' @aliases gt-package
 "_PACKAGE"

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -602,6 +602,7 @@ cells_row_groups <- function(groups = TRUE) {
 #'
 #' @inheritParams cells_row_groups
 #'
+#' @keywords internal
 #' @export
 cells_group <- function(groups = TRUE) {
 
@@ -792,6 +793,7 @@ cells_body <- function(columns = TRUE,
 #'
 #' @inheritParams cells_body
 #'
+#' @keywords internal
 #' @export
 cells_data <- function(columns = TRUE,
                        rows = TRUE) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -112,6 +112,8 @@ globalVariables(
 #'   \item `gt.row_group.sep`: a separator between groups for the row group
 #'   label.
 #' }
+#'
+#' @keywords internal
 #' @name gt-options
 NULL
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -162,6 +162,8 @@ reference:
     - opt_all_caps
     - opt_table_lines
     - opt_table_outline
+    - opt_table_font
+    - opt_css
 
   - title: Information Functions
     desc: >

--- a/man/cells_data.Rd
+++ b/man/cells_data.Rd
@@ -14,3 +14,4 @@ cells_data(columns = TRUE, rows = TRUE)
 \description{
 Location helper for targeting data cells in the table body (deprecated)
 }
+\keyword{internal}

--- a/man/cells_group.Rd
+++ b/man/cells_group.Rd
@@ -12,3 +12,4 @@ cells_group(groups = TRUE)
 \description{
 Location helper for targeting row groups (deprecated)
 }
+\keyword{internal}

--- a/man/gt-options.Rd
+++ b/man/gt-options.Rd
@@ -16,3 +16,4 @@ label.
 }
 }
 
+\keyword{internal}

--- a/man/gt-package.Rd
+++ b/man/gt-package.Rd
@@ -38,3 +38,4 @@ Other contributors:
 }
 
 }
+\keyword{internal}


### PR DESCRIPTION
This PR adds some help topics to the `reference` section of the `_pkgdown.yml` file. Some topics are excluded (deprecated functions, etc.) and so the `@keywords internal` roxygen tag was added to those and the help files were roxygenized. This is all to avoid the error by dev pkgdown in the GHA build that generates the pkgdown site for gt.