### PR TITLE
Add the `caption` arg to `gt()`; support bookdown crossrefs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,6 +90,7 @@ Collate:
     'helpers.R'
     'image.R'
     'info_tables.R'
+    'knitr-utils.R'
     'location_methods.R'
     'modify_columns.R'
     'modify_rows.R'

--- a/R/dt_options.R
+++ b/R/dt_options.R
@@ -50,7 +50,7 @@ dt_options_tbl <-
     "container_overflow_x",              FALSE,  "container",        "overflow","auto",
     "container_overflow_y",              FALSE,  "container",        "overflow","auto",
     "table_id",                          FALSE,  "table",            "value",   NA_character_,
-    "table_caption",                     FALSE,  "table",            "value",   NA_character_,
+    "table_caption",                     FALSE,  "table",            "value",   NULL,
     "table_width",                        TRUE,  "table",            "px",      "auto",
     "table_layout",                       TRUE,  "table",            "value",   "fixed",
     "table_margin_left",                  TRUE,  "table",            "px",      "auto",

--- a/R/dt_options.R
+++ b/R/dt_options.R
@@ -50,6 +50,7 @@ dt_options_tbl <-
     "container_overflow_x",              FALSE,  "container",        "overflow","auto",
     "container_overflow_y",              FALSE,  "container",        "overflow","auto",
     "table_id",                          FALSE,  "table",            "value",   NA_character_,
+    "table_caption",                     FALSE,  "table",            "value",   NA_character_,
     "table_width",                        TRUE,  "table",            "px",      "auto",
     "table_layout",                       TRUE,  "table",            "value",   "fixed",
     "table_margin_left",                  TRUE,  "table",            "px",      "auto",

--- a/R/gt.R
+++ b/R/gt.R
@@ -82,6 +82,7 @@
 gt <- function(data,
                rowname_col = "rowname",
                groupname_col = dplyr::group_vars(data),
+               caption = NULL,
                rownames_to_stub = FALSE,
                auto_align = TRUE,
                id = NULL,

--- a/R/gt.R
+++ b/R/gt.R
@@ -28,6 +28,8 @@
 #'   group labels for generation of stub row groups. If the input `data` table
 #'   has the `grouped_df` class (through use of the [dplyr::group_by()] function
 #'   or associated `group_by*()` functions) then any input here is ignored.
+#' @param caption An optional table caption to use for cross-referencing
+#'   in R Markdown documents and **bookdown** book projects.
 #' @param rownames_to_stub An option to take rownames from the input `data`
 #'   table as row captions in the display table stub.
 #' @param auto_align Optionally have column data be aligned depending on the
@@ -145,7 +147,26 @@ gt <- function(data,
   # Add any user-defined table ID to the `table_id` parameter
   # (if NULL, the default setting will generate a random ID)
   if (!is.null(id)) {
-    data <- dt_options_set_value(data = data, option = "table_id", value = id)
+    data <-
+      dt_options_set_value(
+        data = data,
+        option = "table_id",
+        value = id
+      )
+  }
+
+  # Add any user-defined table caption to the `table_id` parameter
+  # TODO: consider whether this might take a string or a logical (to say that
+  # we'll use the header from `tab_header` as the table caption); this might
+  # require some more thought still because a `caption` arg might also be
+  # sensible in `tab_header`
+  if (!is.null(caption)) {
+    data <-
+      dt_options_set_value(
+        data = data,
+        option = "table_caption",
+        value = caption
+      )
   }
 
   # Apply the `gt_tbl` class to the object while

--- a/R/knitr-utils.R
+++ b/R/knitr-utils.R
@@ -1,0 +1,22 @@
+# These functions are copies of unexported functions in knitr
+
+kable_caption = function(label, caption, format) {
+  # create a label for bookdown if applicable
+  if (is.null(label)) label = knitr::opts_current$get('label')
+  if (!is.null(caption) && !is.na(caption)) caption = paste0(
+    create_label('tab:', label, latex = (format == 'latex')), caption
+  )
+  caption
+}
+
+# create \label{x} or (\#x); the latter is current an internal hack for bookdown
+create_label = function(..., latex = FALSE) {
+  if (isTRUE(knitr::opts_knit$get('bookdown.internal.label'))) {
+    lab1 = '(\\#'; lab2 = ')'
+  } else if (latex) {
+    lab1 = '\\label{'; lab2 = '}'
+  } else {
+    return('')  # we don't want the label at all
+  }
+  paste(c(lab1, ..., lab2), collapse = '')
+}

--- a/R/render_as_html.R
+++ b/R/render_as_html.R
@@ -16,6 +16,8 @@ render_as_html <- function(data) {
   # Upgrade `_styles` to gain a `html_style` column with CSS style rules
   data <- add_css_styles(data = data)
 
+  caption_component <- create_caption_component_h(data = data)
+
   # Create the heading component
   heading_component <- create_heading_component(data = data, context = "html")
 
@@ -33,91 +35,6 @@ render_as_html <- function(data) {
 
   # Get attributes for the gt table
   table_defs <- get_table_defs(data = data)
-
-  # Create the table caption if available
-  table_caption <- dt_options_get_value(data = data, option = "table_caption")
-
-  if (!is.na(table_caption)) {
-
-    # Reference Implementation (knitr): knitr/table.R
-    # kable_caption = function(label, caption, format) {
-    #   # create a label for bookdown if applicable
-    #   if (is.null(label)) label = opts_current$get('label')
-    #   if (!is.null(caption) && !is.na(caption)) caption = paste0(
-    #     create_label('tab:', label, latex = (format == 'latex')), caption
-    #   )
-    #   caption
-    # }
-    #
-    # `create_label()`: knitr/utils.R
-    # # create \label{x} or (\#x); the latter is current an internal hack for bookdown
-    # create_label = function(..., latex = FALSE) {
-    #   if (isTRUE(opts_knit$get('bookdown.internal.label'))) {
-    #     lab1 = '(\\#'; lab2 = ')'
-    #   } else if (latex) {
-    #     lab1 = '\\label{'; lab2 = '}'
-    #   } else {
-    #     return('')  # we don't want the label at all
-    #   }
-    #   paste(c(lab1, ..., lab2), collapse = '')
-    # }
-
-    # Reference Implementation (bookdown): bookdown/html.R
-    # resolve_refs_html = function(content, global = FALSE) {
-    #   content = resolve_ref_links_html(content)
-    #
-    #   res = parse_fig_labels(content, global)
-    #   content = res$content
-    #   ref_table = c(res$ref_table, parse_section_labels(content))
-    #
-    #   # look for @ref(label) and resolve to actual figure/table/section numbers
-    #   m = gregexpr('(?<!\\\\)@ref\\(([-:[:alnum:]]+)\\)', content, perl = TRUE)
-    #   refs = regmatches(content, m)
-    #   for (i in seq_along(refs)) {
-    #     if (length(refs[[i]]) == 0) next
-    #     # strip off html tags when resolve numbers in <img>'s alt attribute because
-    #     # the numbers may contain double quotes, e.g. <img alt="<a
-    #     # href="#foo">1.2</a>"" width=...
-    #     ref = ref_to_number(refs[[i]], ref_table, FALSE)
-    #     if (is_img_line(content[i])) ref = strip_html(ref)
-    #     refs[[i]] = ref
-    #   }
-    #   regmatches(content, m) = refs
-    #   content
-    # }
-    #
-    # `resolve_ref_links_html()`
-    #
-    # `parse_fig_labels()`
-    #
-    # `parse_section_labels()`
-    #
-    # `ref_to_number()`
-    #
-    # `is_img_line()`
-    #
-    # `strip_html()`
-
-    # TODO: Create the <span> tag
-    chunk_name <- "chunk_name" # <- TODO: get the chunk name
-    span_id <- paste0("tab:", chunk_name)
-    table_number <- "1.1" # <- TODO: get the table number
-    span_content <- paste0("Table ", table_number, ": ")
-
-    # TODO: Create the <caption> tag
-    caption_component <-
-      htmltools::tags$caption(
-        htmltools::tags$span(
-          id = span_id,
-          span_content
-        ),
-        table_caption
-      )
-
-    heading_component <- ""
-  } else {
-    caption_component <- ""
-  }
 
   # Compose the HTML table
   as.character(

--- a/R/render_as_html.R
+++ b/R/render_as_html.R
@@ -34,11 +34,97 @@ render_as_html <- function(data) {
   # Get attributes for the gt table
   table_defs <- get_table_defs(data = data)
 
+  # Create the table caption if available
+  table_caption <- dt_options_get_value(data = data, option = "table_caption")
+
+  if (!is.na(table_caption)) {
+
+    # Reference Implementation (knitr): knitr/table.R
+    # kable_caption = function(label, caption, format) {
+    #   # create a label for bookdown if applicable
+    #   if (is.null(label)) label = opts_current$get('label')
+    #   if (!is.null(caption) && !is.na(caption)) caption = paste0(
+    #     create_label('tab:', label, latex = (format == 'latex')), caption
+    #   )
+    #   caption
+    # }
+    #
+    # `create_label()`: knitr/utils.R
+    # # create \label{x} or (\#x); the latter is current an internal hack for bookdown
+    # create_label = function(..., latex = FALSE) {
+    #   if (isTRUE(opts_knit$get('bookdown.internal.label'))) {
+    #     lab1 = '(\\#'; lab2 = ')'
+    #   } else if (latex) {
+    #     lab1 = '\\label{'; lab2 = '}'
+    #   } else {
+    #     return('')  # we don't want the label at all
+    #   }
+    #   paste(c(lab1, ..., lab2), collapse = '')
+    # }
+
+    # Reference Implementation (bookdown): bookdown/html.R
+    # resolve_refs_html = function(content, global = FALSE) {
+    #   content = resolve_ref_links_html(content)
+    #
+    #   res = parse_fig_labels(content, global)
+    #   content = res$content
+    #   ref_table = c(res$ref_table, parse_section_labels(content))
+    #
+    #   # look for @ref(label) and resolve to actual figure/table/section numbers
+    #   m = gregexpr('(?<!\\\\)@ref\\(([-:[:alnum:]]+)\\)', content, perl = TRUE)
+    #   refs = regmatches(content, m)
+    #   for (i in seq_along(refs)) {
+    #     if (length(refs[[i]]) == 0) next
+    #     # strip off html tags when resolve numbers in <img>'s alt attribute because
+    #     # the numbers may contain double quotes, e.g. <img alt="<a
+    #     # href="#foo">1.2</a>"" width=...
+    #     ref = ref_to_number(refs[[i]], ref_table, FALSE)
+    #     if (is_img_line(content[i])) ref = strip_html(ref)
+    #     refs[[i]] = ref
+    #   }
+    #   regmatches(content, m) = refs
+    #   content
+    # }
+    #
+    # `resolve_ref_links_html()`
+    #
+    # `parse_fig_labels()`
+    #
+    # `parse_section_labels()`
+    #
+    # `ref_to_number()`
+    #
+    # `is_img_line()`
+    #
+    # `strip_html()`
+
+    # TODO: Create the <span> tag
+    chunk_name <- "chunk_name" # <- TODO: get the chunk name
+    span_id <- paste0("tab:", chunk_name)
+    table_number <- "1.1" # <- TODO: get the table number
+    span_content <- paste0("Table ", table_number, ": ")
+
+    # TODO: Create the <caption> tag
+    caption_component <-
+      htmltools::tags$caption(
+        htmltools::tags$span(
+          id = span_id,
+          span_content
+        ),
+        table_caption
+      )
+
+    heading_component <- ""
+  } else {
+    caption_component <- ""
+  }
+
   # Compose the HTML table
   as.character(
     htmltools::tags$table(
       class = "gt_table",
       style = table_defs$table_style,
+      caption_component,
       table_defs$table_colgroups,
       heading_component,
       columns_component,

--- a/R/utils.R
+++ b/R/utils.R
@@ -204,7 +204,7 @@ process_text <- function(text,
 
       return(text)
 
-    } else if (is_html(text)) {
+    } else if (is_html(text) || inherits(text, "shiny.tag") || inherits(text, "shiny.tag.list")) {
 
       text <- as.character(text)
 

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -163,13 +163,25 @@ create_caption_component_h <- function(data) {
     table_caption <- process_text(table_caption, context = "html")
     if (isTRUE(getOption("knitr.in.progress"))) {
       table_caption <- knitr:::kable_caption(label = NULL, table_caption, "html")
-      table_caption <- paste0(
-        "<!--/html_preserve-->",
-        table_caption,
-        "<!--html_preserve-->"
-      )
     }
-    htmltools::tags$caption(htmltools::HTML(table_caption))
+    # <!--/html_preserve--> ... <!--html_preserve--> is because bookdown scans
+    # the .md file, looking for references in the form of:
+    # <caption>(#tab:mytable)
+    # Ref:
+    # https://github.com/rstudio/bookdown/blob/00987215b7572def2f5cd73a623efc38f4f30ab7/R/html.R#L629
+    # https://github.com/rstudio/bookdown/blob/00987215b7572def2f5cd73a623efc38f4f30ab7/R/html.R#L667
+    #
+    # Normally, the gt table in its entirety is excluded from the .md, to
+    # prevent it from being corrupted by pandoc's md-to-html rendering. We do
+    # this by wrapping the whole table in htmltools::htmlPreserve (I think this
+    # actually happens in htmlwidgets). So the extra markup here is used to
+    # temporarily suspend that protection, emit the caption (including the HTML
+    # <caption> tag, which bookdown searches for), and then resume protection.
+    htmltools::HTML(paste0(
+      "<!--/html_preserve--><caption>",
+      table_caption,
+      "</caption><!--html_preserve-->"
+    ))
   } else {
     NULL
   }

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -159,10 +159,10 @@ create_caption_component_h <- function(data) {
   # Create the table caption if available
   table_caption <- dt_options_get_value(data = data, option = "table_caption")
 
-  if (!is.na(table_caption)) {
+  if (!is.null(table_caption)) {
     table_caption <- process_text(table_caption, context = "html")
     if (isTRUE(getOption("knitr.in.progress"))) {
-      table_caption <- knitr:::kable_caption(label = NULL, table_caption, "html")
+      table_caption <- kable_caption(label = NULL, table_caption, "html")
     }
     # <!--/html_preserve--> ... <!--html_preserve--> is because bookdown scans
     # the .md file, looking for references in the form of:

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -154,6 +154,27 @@ get_table_defs <- function(data) {
   )
 }
 
+create_caption_component_h <- function(data) {
+
+  # Create the table caption if available
+  table_caption <- dt_options_get_value(data = data, option = "table_caption")
+
+  if (!is.na(table_caption)) {
+    table_caption <- process_text(table_caption, context = "html")
+    if (isTRUE(getOption("knitr.in.progress"))) {
+      table_caption <- knitr:::kable_caption(label = NULL, table_caption, "html")
+      table_caption <- paste0(
+        "<!--/html_preserve-->",
+        table_caption,
+        "<!--html_preserve-->"
+      )
+    }
+    htmltools::tags$caption(htmltools::HTML(table_caption))
+  } else {
+    NULL
+  }
+}
+
 #' Create the heading component of a table
 #'
 #' The table heading component contains the title and possibly a subtitle; if

--- a/man/gt.Rd
+++ b/man/gt.Rd
@@ -8,6 +8,7 @@ gt(
   data,
   rowname_col = "rowname",
   groupname_col = dplyr::group_vars(data),
+  caption = NULL,
   rownames_to_stub = FALSE,
   auto_align = TRUE,
   id = NULL,
@@ -26,6 +27,9 @@ ignored.}
 group labels for generation of stub row groups. If the input \code{data} table
 has the \code{grouped_df} class (through use of the \code{\link[dplyr:group_by]{dplyr::group_by()}} function
 or associated \verb{group_by*()} functions) then any input here is ignored.}
+
+\item{caption}{An optional table caption to use for cross-referencing
+in R Markdown documents and \strong{bookdown} book projects.}
 
 \item{rownames_to_stub}{An option to take rownames from the input \code{data}
 table as row captions in the display table stub.}

--- a/tests/testthat/helper-gt_attr_expectations.R
+++ b/tests/testthat/helper-gt_attr_expectations.R
@@ -102,7 +102,7 @@ expect_tab <- function(tab,
 
   dt_options_get(data = tab) %>%
     dim() %>%
-    expect_equal(c(133, 5))
+    expect_equal(c(134, 5))
 
   dt_transforms_get(data = tab) %>%
     length() %>%

--- a/tests/testthat/test-utils_render_html.R
+++ b/tests/testthat/test-utils_render_html.R
@@ -1,0 +1,50 @@
+expect_caption_eq <- function(caption, expected) {
+  result <- create_caption_component_h(gt(exibble, caption = caption))
+  expect_identical(
+    result,
+    htmltools::HTML(paste0(
+      "<!--/html_preserve--><caption>",
+      expected,
+      "</caption><!--html_preserve-->"
+    ))
+  )
+}
+
+test_that("captioning processes text correctly", {
+
+  # No caption if not specified
+  expect_null(create_caption_component_h(exibble %>% gt()))
+
+  expect_caption_eq("**hello & goodbye**", "**hello &amp; goodbye**")
+  expect_caption_eq(md("**hello & goodbye**"), "<strong>hello &amp; goodbye</strong>")
+  expect_caption_eq(I("**hello & goodbye**"), "**hello & goodbye**")
+  expect_caption_eq(htmltools::strong("hello & goodbye"), "<strong>hello &amp; goodbye</strong>")
+  expect_caption_eq(htmltools::HTML("<strong>hello &amp; goodbye</strong>"), "<strong>hello &amp; goodbye</strong>")
+  expect_caption_eq(I("<strong>hello &amp; goodbye</strong>"), "<strong>hello &amp; goodbye</strong>")
+
+  expect_caption_eq("", "")
+})
+
+test_that("bookdown-style crossrefs are added when appropriate", {
+  op <- options(knitr.in.progress = TRUE)
+  on.exit(options(op), add = TRUE)
+
+  stopifnot(is.null(knitr::opts_current$get("label")))
+  stopifnot(is.null(knitr::opts_knit$get("bookdown.internal.label")))
+  on.exit({
+    knitr::opts_current$set(label = NULL)
+    knitr::opts_knit$set(bookdown.internal.label = NULL)
+  }, add = TRUE)
+
+  knitr::opts_current$set(label = "foo")
+
+  # If bookdown, then ref is generated
+  knitr::opts_knit$set(bookdown.internal.label = TRUE)
+  expect_caption_eq("test", "(\\#tab:foo)test")
+
+  expect_null(create_caption_component_h(exibble %>% gt()))
+
+  # If bookdown.internal.label is unset, ref is not generated
+  knitr::opts_knit$set(bookdown.internal.label = NULL)
+  expect_caption_eq("test", "test")
+})


### PR DESCRIPTION
This PR adds caption support for gt tables, making captions work in R Markdown and in bookdown.

Fixes: #115 