### PR TITLE
Avoid use of `group_by()` `.dots` deprecation by using `group_by_at()`

### DIFF
--- a/R/utils_render_footnotes.R
+++ b/R/utils_render_footnotes.R
@@ -294,12 +294,11 @@ resolve_footnotes_styles <- function(data,
 
       tbl <-
         tbl %>%
-        dplyr::group_by_at(base::setdiff(colnames(.), c("styles", "text"))) %>%
+        dplyr::group_by(locname, grpname, colname, locnum, rownum, colnum) %>%
         dplyr::summarize(styles = list(as_style(styles))) %>%
         dplyr::ungroup()
     }
   }
-
 
   if (tbl_type == "footnotes") {
     data <- dt_footnotes_set(data = data, footnotes = tbl)

--- a/R/utils_render_footnotes.R
+++ b/R/utils_render_footnotes.R
@@ -294,7 +294,7 @@ resolve_footnotes_styles <- function(data,
 
       tbl <-
         tbl %>%
-        dplyr::group_by(locname, grpname, colname, locnum, rownum, colnum) %>%
+        dplyr::group_by_at(base::setdiff(colnames(.), c("styles", "text"))) %>%
         dplyr::summarize(styles = list(as_style(styles))) %>%
         dplyr::ungroup()
     }

--- a/R/utils_render_footnotes.R
+++ b/R/utils_render_footnotes.R
@@ -294,8 +294,7 @@ resolve_footnotes_styles <- function(data,
 
       tbl <-
         tbl %>%
-        dplyr::group_by(
-          .dots = colnames(.) %>% base::setdiff(c("styles", "text"))) %>%
+        dplyr::group_by(locname, grpname, colname, locnum, rownum, colnum) %>%
         dplyr::summarize(styles = list(as_style(styles))) %>%
         dplyr::ungroup()
     }


### PR DESCRIPTION
This changes replaces `group_by()` with `group_by_at()` to avoid using the deprecated `.dots` argument. No functionality has changed, this serves to remove the deprecation warning whenever the user calls `tab_style()` or `tab_footnote()` on a gt table.

Fixes: #709 