### PR TITLE
fixed typo in modify_columns.R documentation

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -14,7 +14,7 @@
 #'
 #' @param data A table object that is created using the [gt()] function.
 #' @param align The alignment type. This can be any of `"center"`, `"left"`, or
-#'   `"right"` for center-, left-, or center-alignment. Alternatively, the
+#'   `"right"` for center-, left-, or right-alignment. Alternatively, the
 #'   `"auto"` option (the default), will automatically align values in columns
 #'   according to the data type (see the Details section for specifics on which
 #'   alignments are applied).

--- a/man/cols_align.Rd
+++ b/man/cols_align.Rd
@@ -10,7 +10,7 @@ cols_align(data, align = c("auto", "left", "center", "right"), columns = TRUE)
 \item{data}{A table object that is created using the \code{\link[=gt]{gt()}} function.}
 
 \item{align}{The alignment type. This can be any of \code{"center"}, \code{"left"}, or
-\code{"right"} for center-, left-, or center-alignment. Alternatively, the
+\code{"right"} for center-, left-, or right-alignment. Alternatively, the
 \code{"auto"} option (the default), will automatically align values in columns
 according to the data type (see the Details section for specifics on which
 alignments are applied).}


### PR DESCRIPTION
Hey all, I noticed a small typo in the documentation for the cols_align() function, so I updated it in modify_columns.R and regenerated the docs with devtools::document().