### PR TITLE
Fix for bookdown table reference support

### DIFF
--- a/R/knitr-utils.R
+++ b/R/knitr-utils.R
@@ -12,7 +12,8 @@ kable_caption = function(label, caption, format) {
 # create \label{x} or (\#x); the latter is current an internal hack for bookdown
 create_label = function(..., latex = FALSE) {
   if (isTRUE(knitr::opts_knit$get('bookdown.internal.label'))) {
-    lab1 = '(\\#'; lab2 = ')'
+    # knitr use (\\# but we remove the escaping as HTML is directly written
+    lab1 = '(#'; lab2 = ')'
   } else if (latex) {
     lab1 = '\\label{'; lab2 = '}'
   } else {

--- a/tests/testthat/test-utils_render_html.R
+++ b/tests/testthat/test-utils_render_html.R
@@ -40,7 +40,7 @@ test_that("bookdown-style crossrefs are added when appropriate", {
 
   # If bookdown, then ref is generated
   knitr::opts_knit$set(bookdown.internal.label = TRUE)
-  expect_caption_eq("test", "(\\#tab:foo)test")
+  expect_caption_eq("test", "(#tab:foo)test")
 
   expect_null(create_caption_component_h(exibble %>% gt()))
 


### PR DESCRIPTION
This will fix #719 

The escaping of # in `(\\# ... )` is not needed because the syntax won't be processed by Pandoc. This does not need to be escape. 

**bookdown** reference mechanism works by matching `(#tab:label)` 

This will fix the auto numbering of the reference.

But there is also an issue because `(#tab:label)` is not removed from the caption. I think this needs to be patched in **bookdown**.

Just sharing this to easily show the fix and test. I let you decide if you want to fix differently. 