### PR TITLE
Adds env argument to cols_width eval_tidy function

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -222,10 +222,11 @@ cols_width <- function(data,
 
     columns_used <- c(columns_used, columns)
 
+    e <- rlang::caller_env()
     width <-
       width_item %>%
       rlang::f_rhs() %>%
-      rlang::eval_tidy()
+      rlang::eval_tidy(env = e)
 
     # If a bare numeric value is provided, give that the `px` dimension
     if (is.numeric(width)) width <- paste_right(as.character(width), "px")


### PR DESCRIPTION
Hi,

This PR addresses a bug in `cols_width` when the value passed to `px` is given as a variable. I think this is the same issue mantioned in #641.

The following example currently causes the error `Error in mode(x) : object 'yy' not found` -this PR fixes that.

```
library(gt)
f <- function(xx, yy) {
  
  gt(xx) %>%
    cols_width(z ~ px(yy))
  
}

d <- tibble::tibble(x = letters[1:3], y = 1:3, z = 4:6)
f(xx = d, yy = 70)
```

This is the first time I have ever made a pull request and it is failing the checks with `Packages required but not available: 'dplyr' 'tidyselect'`, which I don't know how to fix.
