### PR TITLE
Provide fix RTF generation in R 3.5

### DIFF
--- a/R/utils_render_rtf_redo.R
+++ b/R/utils_render_rtf_redo.R
@@ -457,6 +457,10 @@ rtf_tbl_cell <- function(x,
     tidy_gsub("\\\\super", "\\super", fixed = TRUE) %>%
     tidy_gsub("\\\\i", "\\i", fixed = TRUE)
 
+  # In R <3.6 gt's `tidy_gsub()` function will strip the class from
+  # `cell_text` so it's necessary to reinstate it here
+  class(cell_text) <- "rtf_text"
+
   # Combine all cell settings
   cell_settings <-
     rtf_paste0(

--- a/tests/testthat/test-gt_object.R
+++ b/tests/testthat/test-gt_object.R
@@ -760,38 +760,36 @@ test_that("Escapable characters in rownames are handled correctly in each output
   # when rendered as RTF
 
   # Using the data frame and setting its rownames to be the stub
-  # TODO: Escaping here is different in R 3.5 compared to later versions; this
-  #       needs to be fixed before uncommenting these tests
-  # expect_match( # stub from data frame's row names
-  #   gt(tbl, rownames_to_stub = TRUE) %>%
-  #     as_rtf() %>% as.character(),
-  #   "\\intbl {\\f0 {\\f0\\fs20 \\'7brow_rtf\\'7d}}\\cell",
-  #   fixed = TRUE
-  # )
-  # expect_match( # `column_1`
-  #   gt(tbl, rownames_to_stub = TRUE) %>%
-  #     as_rtf() %>% as.character(),
-  #   "\\intbl {\\f0 {\\f0\\fs20 \\'7brtf\\'7d}}\\cell",
-  #   fixed = TRUE
-  # )
-  # expect_match( # `column_2`
-  #   gt(tbl, rownames_to_stub = TRUE) %>%
-  #     as_rtf() %>% as.character(),
-  #   "\\intbl {\\f0 {\\f0\\fs20 rtf}}\\cell",
-  #   fixed = TRUE
-  # )
-  #
-  # # Using a tibble (removes row names) and setting `column_1` as the stub
-  # expect_match( # stub from `column_1`
-  #   gt(dplyr::as_tibble(tbl), rowname_col = "column_1") %>%
-  #     as_rtf() %>% as.character(),
-  #   "\\intbl {\\f0 {\\f0\\fs20 \\'7brtf\\'7d}}\\cell",
-  #   fixed = TRUE
-  # )
-  # expect_match( # `column_2`
-  #   gt(dplyr::as_tibble(tbl), rowname_col = "column_1") %>%
-  #     as_rtf() %>% as.character(),
-  #   "\\intbl {\\f0 {\\f0\\fs20 rtf}}\\cell",
-  #   fixed = TRUE
-  # )
+  expect_match( # stub from data frame's row names
+    gt(tbl, rownames_to_stub = TRUE) %>%
+      as_rtf() %>% as.character(),
+    "\\intbl {\\f0 {\\f0\\fs20 \\'7brow_rtf\\'7d}}\\cell",
+    fixed = TRUE
+  )
+  expect_match( # `column_1`
+    gt(tbl, rownames_to_stub = TRUE) %>%
+      as_rtf() %>% as.character(),
+    "\\intbl {\\f0 {\\f0\\fs20 \\'7brtf\\'7d}}\\cell",
+    fixed = TRUE
+  )
+  expect_match( # `column_2`
+    gt(tbl, rownames_to_stub = TRUE) %>%
+      as_rtf() %>% as.character(),
+    "\\intbl {\\f0 {\\f0\\fs20 rtf}}\\cell",
+    fixed = TRUE
+  )
+
+  # Using a tibble (removes row names) and setting `column_1` as the stub
+  expect_match( # stub from `column_1`
+    gt(dplyr::as_tibble(tbl), rowname_col = "column_1") %>%
+      as_rtf() %>% as.character(),
+    "\\intbl {\\f0 {\\f0\\fs20 \\'7brtf\\'7d}}\\cell",
+    fixed = TRUE
+  )
+  expect_match( # `column_2`
+    gt(dplyr::as_tibble(tbl), rowname_col = "column_1") %>%
+      as_rtf() %>% as.character(),
+    "\\intbl {\\f0 {\\f0\\fs20 rtf}}\\cell",
+    fixed = TRUE
+  )
 })


### PR DESCRIPTION
This PR provides a fix for the RTF generation in R versions less than 3.6.

Fixes: #734 