### PR TITLE
Make corrections to some examples

### DIFF
--- a/tests/gt-examples/01-html-script/html-06-mtcars.R
+++ b/tests/gt-examples/01-html-script/html-06-mtcars.R
@@ -23,13 +23,13 @@ mtcars_tbl <-
     after = c(gear)
   ) %>%
   tab_row_group(
-    group = "Mercs",
+    label = "Mercs",
     rows = c(
       "Merc 240D", "Merc 230", "Merc 280C", "Merc 280",
       "Merc 450SE", "Merc 450SL", "Merc 450SLC")
   ) %>%
   tab_row_group(
-    group = "Supercars",
+    label = "Supercars",
     rows = c("Ferrari Dino", "Maserati Bora", "Porsche 914-2", "Ford Pantera L")
   ) %>%
   row_group_order(groups = c("Supercars", "Mercs")) %>%

--- a/tests/gt-examples/01-html-script/html-15-styles_everywhere.R
+++ b/tests/gt-examples/01-html-script/html-15-styles_everywhere.R
@@ -12,11 +12,11 @@ many_styles_tbl <-
   cols_hide(columns = "mpg") %>%
   cols_hide(columns = "vs") %>%
   tab_row_group(
-    group = "Mercs",
+    label = "Mercs",
     rows = contains("Merc")
   ) %>%
   tab_row_group(
-    group = "Mazdas",
+    label = "Mazdas",
     rows = contains("Mazda")
   ) %>%
   tab_spanner(

--- a/tests/gt-examples/02-html-rmd/html-06-mtcars.Rmd
+++ b/tests/gt-examples/02-html-rmd/html-06-mtcars.Rmd
@@ -33,13 +33,13 @@ gt(mtcars, rownames_to_stub = TRUE) %>%
     after = c(gear)
   ) %>%
   tab_row_group(
-    group = "Mercs",
+    label = "Mercs",
     rows = c(
       "Merc 240D", "Merc 230", "Merc 280C", "Merc 280",
       "Merc 450SE", "Merc 450SL", "Merc 450SLC")
   ) %>%
   tab_row_group(
-    group = "Supercars",
+    label = "Supercars",
     rows = c("Ferrari Dino", "Maserati Bora", "Porsche 914-2", "Ford Pantera L")
   ) %>%
   row_group_order(groups = c("Supercars", "Mercs")) %>%

--- a/tests/gt-examples/02-html-rmd/html-15-styles_everywhere.Rmd
+++ b/tests/gt-examples/02-html-rmd/html-15-styles_everywhere.Rmd
@@ -21,11 +21,11 @@ gt(
   cols_hide(columns = "mpg") %>%
   cols_hide(columns = "vs") %>%
   tab_row_group(
-    group = "Mercs",
+    label = "Mercs",
     rows = contains("Merc")
   ) %>%
   tab_row_group(
-    group = "Mazdas",
+    label = "Mazdas",
     rows = contains("Mazda")
   ) %>%
   tab_spanner(

--- a/tests/gt-examples/03-latex/latex-06-mtcars.Rmd
+++ b/tests/gt-examples/03-latex/latex-06-mtcars.Rmd
@@ -34,13 +34,13 @@ gt(mtcars, rownames_to_stub = TRUE) %>%
     after = c(gear)
   ) %>%
   tab_row_group(
-    group = "Mercs",
+    label = "Mercs",
     rows = c(
       "Merc 240D", "Merc 230", "Merc 280C", "Merc 280",
       "Merc 450SE", "Merc 450SL", "Merc 450SLC")
   ) %>%
   tab_row_group(
-    group = "Supercars",
+    label = "Supercars",
     rows = c("Ferrari Dino", "Maserati Bora", "Porsche 914-2", "Ford Pantera L")
   ) %>%
   row_group_order(groups = c("Supercars", "Mercs")) %>%


### PR DESCRIPTION
Some examples in `tests/gt-examples` failed because the call to `tab_row_group()` wasn't updated to the new API. This PR corrects those examples.

Fixes: #740 