### PR TITLE
Add `group` arg to `tab_row_group` for deprecation

### DIFF
--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -389,12 +389,26 @@ tab_row_group <- function(data,
                           label,
                           rows,
                           id = label,
-                          others_label = NULL) {
+                          others_label = NULL,
+                          group = NULL) {
 
   # Perform input object validation
   stop_if_not_gt(data = data)
 
   arrange_groups_vars <- dt_row_groups_get(data = data)
+
+  if (!missing(group)) {
+
+    if (missing(label)) {
+      label <- group
+    }
+
+    warning(
+      "The `group` argument has been deprecated in gt 0.3.3:\n",
+      "* use the `label` argument to specify the group label.",
+      call. = FALSE
+    )
+  }
 
   # Warn user about `others_label` deprecation
   if (!is.null(others_label)) {

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -337,6 +337,7 @@ tab_spanner_delim <- function(data,
 #'   function will stop if `id` isn't unique).
 #' @param others_label This argument is deprecated. Instead use
 #'   `tab_options(row_group.default_label = <label>)`.
+#' @param group This argument is deprecated. Instead use `label`.
 #'
 #' @return An object of class `gt_tbl`.
 #'

--- a/man/tab_row_group.Rd
+++ b/man/tab_row_group.Rd
@@ -4,7 +4,7 @@
 \alias{tab_row_group}
 \title{Add a row group to a \strong{gt} table}
 \usage{
-tab_row_group(data, label, rows, id = label, others_label = NULL)
+tab_row_group(data, label, rows, id = label, others_label = NULL, group = NULL)
 }
 \arguments{
 \item{data}{A table object that is created using the \code{\link[=gt]{gt()}} function.}
@@ -29,6 +29,8 @@ function will stop if \code{id} isn't unique).}
 
 \item{others_label}{This argument is deprecated. Instead use
 \verb{tab_options(row_group.default_label = <label>)}.}
+
+\item{group}{This argument is deprecated. Instead use \code{label}.}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -530,6 +530,29 @@ test_that("row groups can be successfully generated with `tab_row_group()", {
       tab_row_group(others = "foo")
   )
 
+  # Expect a warning if using the `group` argument
+  expect_warning(
+    gt(exibble, rowname_col = "row") %>%
+      tab_row_group(group = "group", rows = 1:3)
+  )
+
+  # Expect a warning if using both the `label` and `group` argument
+  expect_warning(
+    gt_tbl <-
+      gt(exibble, rowname_col = "row") %>%
+      tab_row_group(label = "group_prioritized", group = "group", rows = 1:3)
+  )
+
+  # Expect that the label text specified in `label` was used over the
+  # text given in `group`
+  expect_equal(
+    gt_tbl %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      get_row_group_text(),
+    c("group_prioritized", "")
+  )
+
   # Expect that `tab_options(row_group.default_label = <label>)`
   # is called internally if using the deprecated `others_label` argument
   gt_tbl <-


### PR DESCRIPTION
This reinstates the `group` argument in `tab_row_group()` and uses any value present for `group` (while issuing a warning). New unit tests check that the added logic is correct.