### PR TITLE
Rendering fix for LaTeX tables that have a stub column

### DIFF
--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -423,12 +423,13 @@ create_data_rows <- function(n_rows,
   unname(
     unlist(
       lapply(
-        seq(n_rows),
+        seq_len(n_rows),
         FUN = function(x) {
           if (context == "latex") {
             latex_body_row(content = row_splits[[x]], type = "row")
           }
-        })
+        }
+      )
     )
   )
 }

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -213,11 +213,15 @@ create_body_component_l <- function(data) {
   group_rows <- create_group_rows(n_rows, groups_rows_df, context = "latex")
 
   if (stub_available && "__GT_ROWNAME_PRIVATE__" %in% names(body)) {
-    default_vars <- c("__GT_ROWNAME_PRIVATE__", default_vars)
+    visible_vars <- c("__GT_ROWNAME_PRIVATE__", default_vars)
+  } else if (stub_available) {
+    visible_vars <- c(dt_boxhead_get_var_stub(data), default_vars)
+  } else {
+    visible_vars <- default_vars
   }
 
   # Split `body_content` by slices of rows and create data rows
-  body_content <- as.vector(t(body[, default_vars]))
+  body_content <- as.vector(t(body[, visible_vars]))
   row_splits <- split(body_content, ceiling(seq_along(body_content) / n_cols))
   data_rows <- create_data_rows(n_rows, row_splits, context = "latex")
 

--- a/tests/testthat/test-gt_object.R
+++ b/tests/testthat/test-gt_object.R
@@ -748,13 +748,12 @@ test_that("Escapable characters in rownames are handled correctly in each output
   )
 
   # Using a tibble (removes row names) and setting `column_1` as the stub
-  # TODO: does not work: `Error in row_splits[[x]] : subscript out of bounds`
-  # expect_match(
-  #   gt(dplyr::as_tibble(tbl), rowname_col = "column_1") %>%
-  #     as_latex() %>% as.character(),
-  #   "\\$latex & latex \\\\ ",
-  #   fixed = TRUE
-  # )
+  expect_match(
+    gt(dplyr::as_tibble(tbl), rowname_col = "column_1") %>%
+      as_latex() %>% as.character(),
+    "\\$latex & latex \\\\ ",
+    fixed = TRUE
+  )
 
   # Expect that the stub and body rows are escaped correctly
   # when rendered as RTF


### PR DESCRIPTION
This PR is a bugfix for rendering LaTeX tables that have a stub. The issue in the rendering was that row splits were incorrectly made because there was no consideration of the stub var in the vector of visible vars.