### PR TITLE
FIX: Fix LaTeX rendering of summary rows

### DIFF
--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -454,9 +454,13 @@ create_summary_rows <- function(n_rows,
                                 n_cols,
                                 list_of_summaries,
                                 groups_rows_df,
+                                boxh,
                                 stub_available,
                                 summaries_present,
                                 context = "latex") {
+  default_vars <-
+    dplyr::filter(boxh, type == "default") %>%
+    dplyr::pull(var)
 
   lapply(
     seq(n_rows),
@@ -479,7 +483,7 @@ create_summary_rows <- function(n_rows,
 
       summary_df <-
         list_of_summaries$summary_df_display_list[[group]] %>%
-        dplyr::select(-groups) %>%
+        dplyr::select(rowname, .env$default_vars) %>%
         as.data.frame(stringsAsFactors = FALSE)
 
       body_content_summary <- as.vector(t(summary_df))

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -221,7 +221,7 @@ create_body_component_l <- function(data) {
   }
 
   # Split `body_content` by slices of rows and create data rows
-  body_content <- as.vector(t(body[, visible_vars]))
+  body_content <- as.vector(t(body[, unique(visible_vars)]))
   row_splits <- split(body_content, ceiling(seq_along(body_content) / n_cols))
   data_rows <- create_data_rows(n_rows, row_splits, context = "latex")
 
@@ -231,6 +231,7 @@ create_body_component_l <- function(data) {
       n_cols = n_cols,
       list_of_summaries = list_of_summaries,
       groups_rows_df = groups_rows_df,
+      boxh = boxh,
       stub_available = stub_available,
       summaries_present = summaries_present,
       context = "latex"


### PR DESCRIPTION
Add `boxh` formal argument to `create_summary_rows()`.
`boxh` in `create_summary_rows()` allows the creation of `default_vars` in a manner consistent with the method in `summary_row_tags()`.
`default_vars` is used in the selection for `summary_df`.

Wrapped `visible_vars` with a call to `unique()`. Line 218 could add `"rowname"` to `visible_vars` even if it already exists in `default_vars` (from line 184). This keeps the table body from becoming misaligned.