### PR TITLE
Transform certain X11 colors with no CSS equivalent

### DIFF
--- a/R/compile_scss.R
+++ b/R/compile_scss.R
@@ -7,6 +7,23 @@ compile_scss <- function(data, id = NULL) {
     subset(scss) %>%
     subset(!is.na(value))
 
+  gt_options_tbl <-
+    dplyr::mutate(
+      gt_options_tbl,
+      value =
+        lapply(
+          seq_len(nrow(gt_options_tbl)),
+          FUN = function(x) {
+
+            if (x %in% which(grepl("_color$", gt_options_tbl$parameter))) {
+              x11_to_suitable_html_color(gt_options_tbl[, "value", drop = TRUE][[x]])
+            } else {
+              gt_options_tbl[, "value", drop = TRUE][[x]]
+            }
+          }
+        )
+    )
+
   has_id <- !is.null(id)
 
   # Get the vector of fonts and transform to a `font-family` string
@@ -45,4 +62,22 @@ compile_scss <- function(data, id = NULL) {
         ")
     )
   )
+}
+
+x11_numbered_grays <-
+  grDevices::colors()[grepl("^gr(a|e)y[0-9]+", grDevices::colors())]
+
+x11_numbered_non_grays <-
+  base::setdiff(
+    grDevices::colors()[grepl("^[a-z]*?[1-4]+", grDevices::colors())],
+    x11_numbered_grays
+  )
+
+x11_to_suitable_html_color <- function(color) {
+
+  if (color %in% c(x11_numbered_grays, x11_numbered_non_grays)) {
+    color <- html_color(colors = color)
+  }
+
+  color
 }


### PR DESCRIPTION
This PR intercepts named colors just before sass compilation and replaces X11 color names with no CSS color equivalent with a hexadecimal color. This should likely be done in more places where colors serve as inputs (e.g., `cell_fill()`) being careful to only apply the transformation in the HTML context.

The X11 color names that don't work as CSS color names are the shades of gray (e.g., `gray1`, `gray85`, `grey50`, etc.). The ones that do work but yield small-to-large differences between X11 and CSS are the numbered variants in some colors (e.g., `Azure2`, etc.).

Fortunately, the gt package has a utility function to handle the conversion from X11 color name to hexadecimal color code (`html_color()`). This is used only in those cases where X11 colors need transformation. 

Fixes: https://github.com/rstudio/gt/issues/712