### PR TITLE
Add the `force_sign` arg to several numeric formatters

### DIFF
--- a/man/fmt_bytes.Rd
+++ b/man/fmt_bytes.Rd
@@ -17,6 +17,7 @@ fmt_bytes(
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
+  force_sign = FALSE,
   incl_space = TRUE,
   locale = NULL
 )
@@ -72,6 +73,11 @@ characters are taken to be string literals.}
 of \verb{1,000}).}
 
 \item{dec_mark}{The character to use as a decimal mark (e.g., using \code{dec_mark = ","} with \code{0.152} would result in a formatted value of \verb{0,152}).}
+
+\item{force_sign}{Should the positive sign be shown for positive numbers
+(effectively showing a sign for all numbers except zero)? If so, use \code{TRUE}
+for this option. The default is \code{FALSE}, where only negative numbers will
+display a minus sign.}
 
 \item{incl_space}{An option for whether to include a space between the value
 and the units. The default of \code{TRUE} uses a space character for separation.}

--- a/man/fmt_currency.Rd
+++ b/man/fmt_currency.Rd
@@ -19,6 +19,7 @@ fmt_currency(
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
+  force_sign = FALSE,
   placement = "left",
   incl_space = FALSE,
   locale = NULL
@@ -112,6 +113,12 @@ characters are taken to be string literals.}
 of \verb{1,000}).}
 
 \item{dec_mark}{The character to use as a decimal mark (e.g., using \code{dec_mark = ","} with \code{0.152} would result in a formatted value of \verb{0,152}).}
+
+\item{force_sign}{Should the positive sign be shown for positive values
+(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
+for this option. The default is \code{FALSE}, where only negative numbers will
+display a minus sign. This option is disregarded when using accounting
+notation with \code{accounting = TRUE}.}
 
 \item{placement}{The placement of the currency symbol. This can be either be
 \code{left} (the default) or \code{right}.}

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -14,6 +14,7 @@ fmt_engineering(
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
+  force_sign = FALSE,
   locale = NULL
 )
 }
@@ -53,6 +54,11 @@ characters are taken to be string literals.}
 of \verb{1,000}).}
 
 \item{dec_mark}{The character to use as a decimal mark (e.g., using \code{dec_mark = ","} with \code{0.152} would result in a formatted value of \verb{0,152}).}
+
+\item{force_sign}{Should the positive sign be shown for positive values
+(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
+for this option. The default is \code{FALSE}, where only negative numbers will
+display a minus sign.}
 
 \item{locale}{An optional locale ID that can be used for formatting the value
 according the locale's rules. Examples include \code{"en_US"} for English

--- a/man/fmt_integer.Rd
+++ b/man/fmt_integer.Rd
@@ -14,6 +14,7 @@ fmt_integer(
   suffixing = FALSE,
   pattern = "{x}",
   sep_mark = ",",
+  force_sign = FALSE,
   locale = NULL
 )
 }
@@ -72,6 +73,12 @@ characters are taken to be string literals.}
 \item{sep_mark}{The mark to use as a separator between groups of digits
 (e.g., using \code{sep_mark = ","} with \code{1000} would result in a formatted value
 of \verb{1,000}).}
+
+\item{force_sign}{Should the positive sign be shown for positive values
+(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
+for this option. The default is \code{FALSE}, where only negative numbers will
+display a minus sign. This option is disregarded when using accounting
+notation with \code{accounting = TRUE}.}
 
 \item{locale}{An optional locale ID that can be used for formatting the value
 according the locale's rules. Examples include \code{"en_US"} for English

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -19,6 +19,7 @@ fmt_number(
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
+  force_sign = FALSE,
   locale = NULL
 )
 }
@@ -97,6 +98,12 @@ characters are taken to be string literals.}
 of \verb{1,000}).}
 
 \item{dec_mark}{The character to use as a decimal mark (e.g., using \code{dec_mark = ","} with \code{0.152} would result in a formatted value of \verb{0,152}).}
+
+\item{force_sign}{Should the positive sign be shown for positive values
+(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
+for this option. The default is \code{FALSE}, where only negative numbers will
+display a minus sign. This option is disregarded when using accounting
+notation with \code{accounting = TRUE}.}
 
 \item{locale}{An optional locale ID that can be used for formatting the value
 according the locale's rules. Examples include \code{"en_US"} for English

--- a/man/fmt_percent.Rd
+++ b/man/fmt_percent.Rd
@@ -17,6 +17,7 @@ fmt_percent(
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
+  force_sign = FALSE,
   incl_space = FALSE,
   placement = "right",
   locale = NULL
@@ -73,6 +74,12 @@ characters are taken to be string literals.}
 of \verb{1,000}).}
 
 \item{dec_mark}{The character to use as a decimal mark (e.g., using \code{dec_mark = ","} with \code{0.152} would result in a formatted value of \verb{0,152}).}
+
+\item{force_sign}{Should the positive sign be shown for positive values
+(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
+for this option. The default is \code{FALSE}, where only negative numbers will
+display a minus sign. This option is disregarded when using accounting
+notation with \code{accounting = TRUE}.}
 
 \item{incl_space}{An option for whether to include a space between the value
 and the percent sign. The default is to not introduce a space character.}

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -14,6 +14,7 @@ fmt_scientific(
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
+  force_sign = FALSE,
   locale = NULL
 )
 }
@@ -53,6 +54,11 @@ characters are taken to be string literals.}
 of \verb{1,000}).}
 
 \item{dec_mark}{The character to use as a decimal mark (e.g., using \code{dec_mark = ","} with \code{0.152} would result in a formatted value of \verb{0,152}).}
+
+\item{force_sign}{Should the positive sign be shown for positive values
+(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
+for this option. The default is \code{FALSE}, where only negative numbers will
+display a minus sign.}
 
 \item{locale}{An optional locale ID that can be used for formatting the value
 according the locale's rules. Examples include \code{"en_US"} for English

--- a/tests/testthat/test-fmt_bytes.R
+++ b/tests/testthat/test-fmt_bytes.R
@@ -202,6 +202,37 @@ test_that("the `fmt_bytes()` function works correctly", {
     )
   )
 
+  # Format the `num` column to 3 decimal places, force the sign
+  expect_equal(
+    (tab %>%
+       fmt_bytes(
+         columns = num, decimals = 3, force_sign = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "&minus;500 B", "0 B", "0 B", "0 B", "+500 B", "+1.023 kB",
+      "+1.001 kB", "+1.024 kB", "+1.049 MB", "+1.074 GB", "+1.1 TB",
+      "+1.126 PB", "+1.153 EB", "+1.181 ZB", "+1.209 YB", "+1 kB",
+      "+1 MB", "+1 GB", "+1 TB", "+1 PB", "+1 EB", "+1 ZB", "+1 YB",
+      "+15 YB", "+150 YB", "+1,500 YB", "+15,000 YB", "NA"
+    )
+  )
+
+  # Format the `num` column, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tab %>%
+       fmt_bytes(
+         columns = num, pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "*&minus;500 B*", "*0 B*", "*0 B*", "*0 B*", "*+500 B*", "*+1 kB*",
+      "*+1 kB*", "*+1 kB*", "*+1 MB*", "*+1.1 GB*", "*+1.1 TB*", "*+1.1 PB*",
+      "*+1.2 EB*", "*+1.2 ZB*", "*+1.2 YB*", "*+1 kB*", "*+1 MB*",
+      "*+1 GB*", "*+1 TB*", "*+1 PB*", "*+1 EB*", "*+1 ZB*", "*+1 YB*",
+      "*+15 YB*", "*+150 YB*", "*+1,500 YB*", "*+15,000 YB*", "NA"
+    )
+  )
+
   # Format the `num` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults; extract `output_df` and compare
   # to expected values

--- a/tests/testthat/test-fmt_engineering.R
+++ b/tests/testthat/test-fmt_engineering.R
@@ -242,6 +242,71 @@ test_that("the `fmt_engineering()` function works correctly", {
     )
   )
 
+  # Format the `num` column to 2 decimal places, force the sign
+  expect_equal(
+    (tab %>%
+       fmt_engineering(
+         columns = "num", decimals = 3, force_sign = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "+82.030 &times; 10<sup class='gt_super'>30</sup>",
+      "+829.300 &times; 10<sup class='gt_super'>18</sup>",
+      "+492.032 &times; 10<sup class='gt_super'>9</sup>",
+      "+84.930 &times; 10<sup class='gt_super'>9</sup>",
+      "+5.043 &times; 10<sup class='gt_super'>9</sup>",
+      "+203.821 &times; 10<sup class='gt_super'>6</sup>",
+      "+84.729 &times; 10<sup class='gt_super'>6</sup>",
+      "+2.323 &times; 10<sup class='gt_super'>6</sup>",
+      "+230.323 &times; 10<sup class='gt_super'>3</sup>",
+      "+50.000 &times; 10<sup class='gt_super'>3</sup>",
+      "+1.000 &times; 10<sup class='gt_super'>3</sup>", "+10.000",
+      "+12.345 &times; 10<sup class='gt_super'>3</sup>",
+      "+1.234 &times; 10<sup class='gt_super'>3</sup>", "+123.450", "+1.234",
+      "+123.450 &times; 10<sup class='gt_super'>&minus;3</sup>",
+      "+12.346 &times; 10<sup class='gt_super'>&minus;6</sup>",
+      "&minus;50.000 &times; 10<sup class='gt_super'>3</sup>",
+      "&minus;1.000 &times; 10<sup class='gt_super'>3</sup>", "&minus;10.000",
+      "&minus;12.345 &times; 10<sup class='gt_super'>3</sup>",
+      "&minus;1.234 &times; 10<sup class='gt_super'>3</sup>",
+      "&minus;123.450", "&minus;1.234",
+      "&minus;123.450 &times; 10<sup class='gt_super'>&minus;3</sup>",
+      "&minus;12.346 &times; 10<sup class='gt_super'>&minus;6</sup>"
+    )
+  )
+
+  # Format the `num` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tab %>%
+       fmt_engineering(
+         columns = "num", pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "*+82.03 &times; 10<sup class='gt_super'>30</sup>*",
+      "*+829.30 &times; 10<sup class='gt_super'>18</sup>*",
+      "*+492.03 &times; 10<sup class='gt_super'>9</sup>*",
+      "*+84.93 &times; 10<sup class='gt_super'>9</sup>*",
+      "*+5.04 &times; 10<sup class='gt_super'>9</sup>*",
+      "*+203.82 &times; 10<sup class='gt_super'>6</sup>*",
+      "*+84.73 &times; 10<sup class='gt_super'>6</sup>*",
+      "*+2.32 &times; 10<sup class='gt_super'>6</sup>*",
+      "*+230.32 &times; 10<sup class='gt_super'>3</sup>*",
+      "*+50.00 &times; 10<sup class='gt_super'>3</sup>*",
+      "*+1.00 &times; 10<sup class='gt_super'>3</sup>*", "*+10.00*",
+      "*+12.35 &times; 10<sup class='gt_super'>3</sup>*",
+      "*+1.23 &times; 10<sup class='gt_super'>3</sup>*", "*+123.45*", "*+1.23*",
+      "*+123.45 &times; 10<sup class='gt_super'>&minus;3</sup>*",
+      "*+12.35 &times; 10<sup class='gt_super'>&minus;6</sup>*",
+      "*&minus;50.00 &times; 10<sup class='gt_super'>3</sup>*",
+      "*&minus;1.00 &times; 10<sup class='gt_super'>3</sup>*", "*&minus;10.00*",
+      "*&minus;12.35 &times; 10<sup class='gt_super'>3</sup>*",
+      "*&minus;1.23 &times; 10<sup class='gt_super'>3</sup>*",
+      "*&minus;123.45*", "*&minus;1.23*",
+      "*&minus;123.45 &times; 10<sup class='gt_super'>&minus;3</sup>*",
+      "*&minus;12.35 &times; 10<sup class='gt_super'>&minus;6</sup>*"
+    )
+  )
+
   # Format the `num` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults
   expect_equal(

--- a/tests/testthat/test-fmt_integer.R
+++ b/tests/testthat/test-fmt_integer.R
@@ -129,6 +129,38 @@ test_that("the `fmt_integer()` function works correctly in the HTML context", {
     c("a1,836b", "a2,763b", "a937b", "a643b", "a212b", "a0b", "a(23)b")
   )
 
+  # Format the `num_1` column to 2 decimal places, force the sign
+  expect_equal(
+    (tab %>%
+       fmt_integer(
+         columns = num_1, force_sign = TRUE) %>%
+       render_formats_test("html"))[["num_1"]],
+    c("+1,836", "+2,763", "+937", "+643", "+212", "0", "&minus;23")
+  )
+
+  # Expect that using `force_sign = TRUE` with `accounting = TRUE`
+  # will render values in accounting format
+  expect_equal(
+    (tab %>%
+       fmt_integer(
+         columns = num_1, accounting = TRUE, force_sign = TRUE) %>%
+       render_formats_test("html"))[["num_1"]],
+    (tab %>%
+       fmt_integer(
+         columns = num_1, accounting = TRUE) %>%
+       render_formats_test("html"))[["num_1"]]
+  )
+
+  # Format the `num_1` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tab %>%
+       fmt_integer(
+         columns = num_1, pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("html"))[["num_1"]],
+    c("*+1,836*", "*+2,763*", "*+937*", "*+643*", "*+212*", "*0*", "*&minus;23*")
+  )
+
   # Format the `num_1`, apply the `en_US`
   # locale and use all other defaults
   expect_equal(

--- a/tests/testthat/test-fmt_number.R
+++ b/tests/testthat/test-fmt_number.R
@@ -185,6 +185,41 @@ test_that("the `fmt_number()` function works correctly in the HTML context", {
     c("1,836.23", "2,763.39", "937.29", "643", "212.232", "0", "(23.24)")
   )
 
+  # Format the `num_1` column to 2 decimal places, force the sign
+  expect_equal(
+    (tab %>%
+       fmt_number(
+         columns = num_1, decimals = 3, force_sign = TRUE) %>%
+       render_formats_test("html"))[["num_1"]],
+    c("+1,836.230", "+2,763.390", "+937.290", "+643.000", "+212.232", "0.000", "&minus;23.240")
+  )
+
+  # Expect that using `force_sign = TRUE` with `accounting = TRUE`
+  # will render values in accounting format
+  expect_equal(
+    (tab %>%
+       fmt_number(
+         columns = num_1, decimals = 3, accounting = TRUE, force_sign = TRUE) %>%
+       render_formats_test("html"))[["num_1"]],
+    (tab %>%
+       fmt_number(
+         columns = num_1, decimals = 3, accounting = TRUE) %>%
+       render_formats_test("html"))[["num_1"]]
+  )
+
+  # Format the `num_1` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tab %>%
+       fmt_number(
+         columns = num_1, pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("html"))[["num_1"]],
+    c(
+      "*+1,836.23*", "*+2,763.39*", "*+937.29*", "*+643.00*", "*+212.23*",
+      "*0.00*", "*&minus;23.24*"
+    )
+  )
+
   # Format the `num_1` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults
   expect_equal(

--- a/tests/testthat/test-fmt_percent.R
+++ b/tests/testthat/test-fmt_percent.R
@@ -202,6 +202,53 @@ test_that("the `fmt_percent()` function works correctly in the HTML context", {
     )
   )
 
+  # Format the `num_1` column to 2 decimal places, force the sign
+  expect_equal(
+    (tab %>%
+       fmt_percent(
+         columns = num_1, decimals = 2,  drop_trailing_zeros = TRUE,
+         scale_values = FALSE, force_sign = TRUE
+       ) %>%
+       render_formats_test("html"))[["num_1"]],
+    c(
+      "+1,836.23&percnt;", "+2,763.39&percnt;", "+937.29&percnt;",
+      "+643&percnt;", "+212.23&percnt;", "0&percnt;", "&minus;23.24&percnt;"
+    )
+  )
+
+  # Expect that using `force_sign = TRUE` with `accounting = TRUE`
+  # will render values in accounting format
+  expect_equal(
+    (tab %>%
+       fmt_percent(
+         columns = num_1, decimals = 2, drop_trailing_zeros = TRUE,
+         scale_values = FALSE, accounting = TRUE, force_sign = TRUE
+       ) %>%
+       render_formats_test("html"))[["num_1"]],
+    (tab %>%
+       fmt_percent(
+         columns = num_1, decimals = 2,  drop_trailing_zeros = TRUE,
+         scale_values = FALSE, accounting = TRUE
+       ) %>%
+       render_formats_test("html"))[["num_1"]]
+  )
+
+  # Format the `num_1` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tab %>%
+       fmt_percent(
+         columns = num_1, decimals = 2, drop_trailing_zeros = TRUE,
+         pattern = "*{x}*", force_sign = TRUE
+       ) %>%
+       render_formats_test("html"))[["num_1"]],
+    c(
+      "*+183,623&percnt;*", "*+276,339&percnt;*", "*+93,729&percnt;*",
+      "*+64,300&percnt;*", "*+21,223.2&percnt;*", "*0&percnt;*",
+      "*&minus;2,324&percnt;*"
+    )
+  )
+
   # Format the `num_1` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults
   expect_equal(

--- a/tests/testthat/test-fmt_scientific.R
+++ b/tests/testthat/test-fmt_scientific.R
@@ -226,6 +226,38 @@ test_that("the `fmt_scientific()` function works correctly", {
     )
   )
 
+  # Format the `num_1` column to 2 decimal places, force the sign
+  expect_equal(
+    (tab %>%
+       fmt_scientific(
+         columns = num_1, decimals = 3, force_sign = TRUE) %>%
+       render_formats_test("html"))[["num_1"]],
+    c(
+      "+1.836 &times; 10<sup class='gt_super'>3</sup>",
+      "+2.763 &times; 10<sup class='gt_super'>3</sup>",
+      "+9.373 &times; 10<sup class='gt_super'>2</sup>",
+      "+6.430 &times; 10<sup class='gt_super'>2</sup>",
+      "+2.232", "0.000", "&minus;2.324 &times; 10<sup class='gt_super'>1</sup>"
+    )
+  )
+
+  # Format the `num_1` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tab %>%
+       fmt_scientific(
+         columns = num_1, pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("html"))[["num_1"]],
+    c(
+      "*+1.84 &times; 10<sup class='gt_super'>3</sup>*",
+      "*+2.76 &times; 10<sup class='gt_super'>3</sup>*",
+      "*+9.37 &times; 10<sup class='gt_super'>2</sup>*",
+      "*+6.43 &times; 10<sup class='gt_super'>2</sup>*",
+      "*+2.23*", "*0.00*",
+      "*&minus;2.32 &times; 10<sup class='gt_super'>1</sup>*"
+    )
+  )
+
   # Format the `num_1` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults; extract `output_df` in the HTML
   # context and compare to expected values

--- a/tests/testthat/test-l_fmt_engineering.R
+++ b/tests/testthat/test-l_fmt_engineering.R
@@ -165,6 +165,49 @@ test_that("the `fmt_engineering()` function works correctly in the LaTeX context
     )
   )
 
+  # Format the `num` column to 2 decimal places, force the sign
+  expect_equal(
+    (tab %>%
+       fmt_engineering(
+         columns = "num", decimals = 3, force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num"]],
+    c(
+      "$+82.030 \\times 10^{30}$", "$+829.300 \\times 10^{18}$",
+      "$+492.032 \\times 10^{9}$", "$+84.930 \\times 10^{9}$",
+      "$+5.043 \\times 10^{9}$", "$+203.821 \\times 10^{6}$",
+      "$+84.729 \\times 10^{6}$", "$+2.323 \\times 10^{6}$",
+      "$+230.323 \\times 10^{3}$", "$+50.000 \\times 10^{3}$",
+      "$+1.000 \\times 10^{3}$", "$+10.000$", "$+12.345 \\times 10^{3}$",
+      "$+1.234 \\times 10^{3}$", "$+123.450$", "$+1.234$",
+      "$+123.450 \\times 10^{-3}$", "$+12.346 \\times 10^{-6}$",
+      "$-50.000 \\times 10^{3}$", "$-1.000 \\times 10^{3}$", "$-10.000$",
+      "$-12.345 \\times 10^{3}$", "$-1.234 \\times 10^{3}$", "$-123.450$",
+      "$-1.234$", "$-123.450 \\times 10^{-3}$", "$-12.346 \\times 10^{-6}$"
+    )
+  )
+
+  # Format the `num` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tab %>%
+       fmt_engineering(
+         columns = "num", pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num"]],
+    c(
+      "*$+82.03 \\times 10^{30}$*", "*$+829.30 \\times 10^{18}$*",
+      "*$+492.03 \\times 10^{9}$*", "*$+84.93 \\times 10^{9}$*",
+      "*$+5.04 \\times 10^{9}$*", "*$+203.82 \\times 10^{6}$*",
+      "*$+84.73 \\times 10^{6}$*", "*$+2.32 \\times 10^{6}$*",
+      "*$+230.32 \\times 10^{3}$*", "*$+50.00 \\times 10^{3}$*",
+      "*$+1.00 \\times 10^{3}$*", "*$+10.00$*", "*$+12.35 \\times 10^{3}$*",
+      "*$+1.23 \\times 10^{3}$*", "*$+123.45$*", "*$+1.23$*",
+      "*$+123.45 \\times 10^{-3}$*", "*$+12.35 \\times 10^{-6}$*",
+      "*$-50.00 \\times 10^{3}$*", "*$-1.00 \\times 10^{3}$*", "*$-10.00$*",
+      "*$-12.35 \\times 10^{3}$*", "*$-1.23 \\times 10^{3}$*", "*$-123.45$*",
+      "*$-1.23$*", "*$-123.45 \\times 10^{-3}$*", "*$-12.35 \\times 10^{-6}$*"
+    )
+  )
+
   # Format the `num` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults
   expect_equal(

--- a/tests/testthat/test-l_fmt_integer.R
+++ b/tests/testthat/test-l_fmt_integer.R
@@ -130,6 +130,41 @@ test_that("the `fmt_integer()` function works correctly in the LaTeX context", {
       "a$0$b", "a$(23)$b")
   )
 
+  # Format the `num_1` column to 2 decimal places, force the sign
+  expect_equal(
+    (tab %>%
+       fmt_integer(
+         columns = num_1, force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]],
+    c("$+1,836$", "$+2,763$", "$+937$", "$+643$", "$+212$", "$0$", "$-23$")
+  )
+
+  # Expect that using `force_sign = TRUE` with `accounting = TRUE`
+  # will render values in accounting format
+  expect_equal(
+    (tab %>%
+       fmt_integer(
+         columns = num_1, accounting = TRUE, force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]],
+    (tab %>%
+       fmt_integer(
+         columns = num_1, accounting = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]]
+  )
+
+  # Format the `num_1` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tab %>%
+       fmt_integer(
+         columns = num_1, pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]],
+    c(
+      "*$+1,836$*", "*$+2,763$*", "*$+937$*", "*$+643$*", "*$+212$*",
+      "*$0$*", "*$-23$*"
+    )
+  )
+
   # Format the `num_1`, apply the `en_US`
   # locale and use all other defaults
   expect_equal(

--- a/tests/testthat/test-l_fmt_number.R
+++ b/tests/testthat/test-l_fmt_number.R
@@ -182,6 +182,44 @@ test_that("the `fmt_number()` function works correctly in the LaTeX context", {
     )
   )
 
+  # Format the `num_1` column to 2 decimal places, force the sign
+  expect_equal(
+    (tbl_latex %>%
+       fmt_number(
+         columns = num_1, decimals = 3, force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]],
+    c(
+      "$+1,836.230$", "$+2,763.390$", "$+937.290$", "$+643.000$",
+      "$+212.232$", "$0.000$", "$-23.240$"
+    )
+  )
+
+  # Expect that using `force_sign = TRUE` with `accounting = TRUE`
+  # will render values in accounting format
+  expect_equal(
+    (tbl_latex %>%
+       fmt_number(
+         columns = num_1, decimals = 3, accounting = TRUE, force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]],
+    (tbl_latex %>%
+       fmt_number(
+         columns = num_1, decimals = 3, accounting = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]]
+  )
+
+  # Format the `num_1` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tbl_latex %>%
+       fmt_number(
+         columns = num_1, pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]],
+    c(
+      "*$+1,836.23$*", "*$+2,763.39$*", "*$+937.29$*", "*$+643.00$*",
+      "*$+212.23$*", "*$0.00$*", "*$-23.24$*"
+    )
+  )
+
   # Format the `num_1` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults
   expect_equal(

--- a/tests/testthat/test-l_fmt_percent.R
+++ b/tests/testthat/test-l_fmt_percent.R
@@ -196,6 +196,52 @@ test_that("the `fmt_percent()` function works correctly in the LaTeX context", {
     )
   )
 
+  # Format the `num_1` column to 2 decimal places, force the sign
+  expect_equal(
+    (tbl_latex %>%
+       fmt_percent(
+         columns = num_1, decimals = 2,  drop_trailing_zeros = TRUE,
+         scale_values = FALSE, force_sign = TRUE
+       ) %>%
+       render_formats_test("latex"))[["num_1"]],
+    c(
+      "$+1,836.23\\%$", "$+2,763.39\\%$", "$+937.29\\%$", "$+643\\%$",
+      "$+212.23\\%$", "$0\\%$", "$-23.24\\%$"
+    )
+  )
+
+  # Expect that using `force_sign = TRUE` with `accounting = TRUE`
+  # will render values in accounting format
+  expect_equal(
+    (tbl_latex %>%
+       fmt_percent(
+         columns = num_1, decimals = 2, drop_trailing_zeros = TRUE,
+         scale_values = FALSE, accounting = TRUE, force_sign = TRUE
+       ) %>%
+       render_formats_test("latex"))[["num_1"]],
+    (tbl_latex %>%
+       fmt_percent(
+         columns = num_1, decimals = 2,  drop_trailing_zeros = TRUE,
+         scale_values = FALSE, accounting = TRUE
+       ) %>%
+       render_formats_test("latex"))[["num_1"]]
+  )
+
+  # Format the `num_1` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tbl_latex %>%
+       fmt_percent(
+         columns = num_1, decimals = 2, drop_trailing_zeros = TRUE,
+         pattern = "*{x}*", force_sign = TRUE
+       ) %>%
+       render_formats_test("latex"))[["num_1"]],
+    c(
+      "*$+183,623\\%$*", "*$+276,339\\%$*", "*$+93,729\\%$*",
+      "*$+64,300\\%$*", "*$+21,223.2\\%$*", "*$0\\%$*", "*$-2,324\\%$*"
+    )
+  )
+
   # Format the `num_1` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults; extract `output_df` and compare
   # to expected values

--- a/tests/testthat/test-l_fmt_scientific.R
+++ b/tests/testthat/test-l_fmt_scientific.R
@@ -88,6 +88,33 @@ test_that("the `fmt_scientific()` function works correctly", {
       "a $2.23$ b", "a $0.00$ b", "a $-2.32 \\times 10^{1}$ b")
   )
 
+  # Format the `num_1` column to 2 decimal places, force the sign
+  expect_equal(
+    (tbl_latex %>%
+       fmt_scientific(
+         columns = num_1, decimals = 3, force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]],
+    c(
+      "$+1.836 \\times 10^{3}$", "$+2.763 \\times 10^{3}$",
+      "$+9.373 \\times 10^{2}$", "$+6.430 \\times 10^{2}$",
+      "$+2.232$", "$0.000$", "$-2.324 \\times 10^{1}$"
+    )
+  )
+
+  # Format the `num_1` column to 2 decimal places, force the sign and
+  # define a pattern for decorating values
+  expect_equal(
+    (tbl_latex %>%
+       fmt_scientific(
+         columns = num_1, pattern = "*{x}*", force_sign = TRUE) %>%
+       render_formats_test("latex"))[["num_1"]],
+    c(
+      "*$+1.84 \\times 10^{3}$*", "*$+2.76 \\times 10^{3}$*",
+      "*$+9.37 \\times 10^{2}$*", "*$+6.43 \\times 10^{2}$*",
+      "*$+2.23$*", "*$0.00$*", "*$-2.32 \\times 10^{1}$*"
+    )
+  )
+
   # Format the `num_1` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults; extract `output_df` in the HTML
   # context and compare to expected values


### PR DESCRIPTION
This PR adds the option to always show either a positive or negative sign. This is especially important when reporting change values. Exceptions to this rule occur with exact zero values and when using the accounting format.

Fixes: https://github.com/rstudio/gt/issues/773