### PR TITLE
Force `webshot()`'s `zoom` setting to be `1` for PDF export

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -210,6 +210,10 @@ gt_save_webshot <- function(data,
 
   } else {
 
+    if (gtsave_file_ext(filename) == "pdf") {
+      zoom <- 1
+    }
+
     # Save the image in the working directory
     webshot::webshot(
       url = paste0("file:///", tempfile_),


### PR DESCRIPTION
This PR simply forces a `zoom` value (in `webshot::webshot()`) to be `1` only when exporting as PDF in `gt_save_webshot()` (PNG is the other possibility, but `zoom` is set higher by default for better text clarity).

This is done so that the amount of extra whitespace below the table isn't extreme (`zoom = 1` lessens the amount of whitespace, but doesn't eliminate it as in PNG export).

Fixes: https://github.com/rstudio/gt/issues/721