### PR TITLE
Adds `.col_names` param to `cols_label()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* `cols_label()` gains a new argument `.col_names()` to allow for an unnamed vector (of equal length as the column names in the original data) to be used as new labels (@jmbarbone, #830)
+* `cols_label()` gains a new argument `.col_names` to allow for an unnamed vector (of equal length as the column names in the original data) to be used as new labels (@jmbarbone, #830)
 
 # gt 0.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# gt (development version)
+
+## New features
+
+* `cols_label()` gains a new argument `.col_names()` to allow for an unnamed vector (of equal length as the column names in the original data) to be used as new labels (@jmbarbone, #830)
+
 # gt 0.3.1
 
 ## New features

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -308,6 +308,9 @@ cols_width <- function(.data,
 #'   optionally wrap the column labels with [md()] (to interpret text as
 #'   Markdown) or [html()] (to interpret text as HTML).
 #' @param .list Allows for the use of a list as an input alternative to `...`.
+#' @param col_names Allows for the use of an unnamed vector of the same length
+#'   as the number of column in the data.  This cannot be used with `...` or
+#'   `.list`
 #'
 #' @return An object of class `gt_tbl`.
 #'
@@ -355,7 +358,32 @@ cols_width <- function(.data,
 #' @export
 cols_label <- function(.data,
                        ...,
-                       .list = list2(...)) {
+                       .list = list2(...),
+                       .col_names = NULL
+  ) {
+
+  # use .col_names if present
+  if (!is_null(.col_names)) {
+    if (length(.list)) {
+      stop(
+        "col_names cannot be used in combination with ... or .list params",
+        call. = FALSE
+        )
+    }
+
+    cn <- colnames(.data$`_data`)
+
+    if (length(.col_names) != length(cn)) {
+      stop("col_names must be the same length as the number of columns", call. = FALSE)
+    }
+
+    if (!is_null(names(.col_names))) {
+      warning("names in col_names are ignored", call. = FALSE)
+    }
+
+    # override
+    .list <- set_names(.col_names, cn)
+  }
 
   # Collect a named list of column labels
   labels_list <- .list

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -308,7 +308,7 @@ cols_width <- function(.data,
 #'   optionally wrap the column labels with [md()] (to interpret text as
 #'   Markdown) or [html()] (to interpret text as HTML).
 #' @param .list Allows for the use of a list as an input alternative to `...`.
-#' @param col_names Allows for the use of an unnamed vector of the same length
+#' @param .col_names Allows for the use of an unnamed vector of the same length
 #'   as the number of column in the data.  This cannot be used with `...` or
 #'   `.list`
 #'

--- a/man/cols_label.Rd
+++ b/man/cols_label.Rd
@@ -16,7 +16,7 @@ Markdown) or \code{\link[=html]{html()}} (to interpret text as HTML).}
 
 \item{.list}{Allows for the use of a list as an input alternative to \code{...}.}
 
-\item{col_names}{Allows for the use of an unnamed vector of the same length
+\item{.col_names}{Allows for the use of an unnamed vector of the same length
 as the number of column in the data.  This cannot be used with \code{...} or
 \code{.list}}
 }

--- a/man/cols_label.Rd
+++ b/man/cols_label.Rd
@@ -4,7 +4,7 @@
 \alias{cols_label}
 \title{Relabel one or more columns}
 \usage{
-cols_label(.data, ..., .list = list2(...))
+cols_label(.data, ..., .list = list2(...), .col_names = NULL)
 }
 \arguments{
 \item{.data}{A table object that is created using the \code{\link[=gt]{gt()}} function.}
@@ -15,6 +15,10 @@ optionally wrap the column labels with \code{\link[=md]{md()}} (to interpret tex
 Markdown) or \code{\link[=html]{html()}} (to interpret text as HTML).}
 
 \item{.list}{Allows for the use of a list as an input alternative to \code{...}.}
+
+\item{col_names}{Allows for the use of an unnamed vector of the same length
+as the number of column in the data.  This cannot be used with \code{...} or
+\code{.list}}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/tests/testthat/test-cols_label.R
+++ b/tests/testthat/test-cols_label.R
@@ -124,6 +124,22 @@ test_that("the function `cols_label()` works correctly", {
     selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']") %>%
     expect_equal(c("col_a", "col_b", "col_c", "col_d"))
 
+  # Expect that .col_names can be used as an unnamed character vector
+  gt(tbl) %>%
+    cols_label(.col_names = c("col_a", "col_b", "col_c", "col_d")) %>%
+    .$`_boxh` %>%
+    .$column_label %>%
+    unlist() %>%
+    expect_equal(c("col_a", "col_b", "col_c", "col_d"))
+
+  gt(tbl) %>%
+    # list is fine?
+    cols_label(.col_names = list("col_a", "col_b", "col_c", "col_d")) %>%
+    .$`_boxh` %>%
+    .$column_label %>%
+    unlist() %>%
+    expect_equal(c("col_a", "col_b", "col_c", "col_d"))
+
   # Expect an error if any names are missing
   expect_error(
     gt(tbl) %>%
@@ -174,6 +190,50 @@ test_that("the function `cols_label()` works correctly", {
       cols_label(
         a = "label a",
         .dat = "label dat"
+      )
+  )
+
+  # expect error of .col_names and ... or .list are used
+  expect_error(
+    gt(tbl) %>%
+      cols_label(
+        col_1 = "col_a",
+        col_2 = "col_b",
+        col_3 = "col_c",
+        col_4 = "col_d",
+        .col_names = c("col_a", "col_b", "col_c", "col_d")
+      )
+  )
+
+  expect_error(
+    gt(tbl) %>%
+      cols_label(
+        .list = list(
+          col_1 = "col_a",
+          col_2 = "col_b",
+          col_3 = "col_c",
+          col_4 = "col_d"
+        ),
+        .col_names = c("col_a", "col_b", "col_c", "col_d")
+      )
+  )
+
+  # expect error if .col_names isn't the right length
+  expect_error(
+    gt(tbl) %>%
+      cols_label(.col_names = "col_a")
+  )
+
+  # expect warning if .col_names have names
+  expect_warning(
+    gt(tbl) %>%
+      cols_label(
+        .col_names = c(
+          col_1 = "col_a",
+          col_2 = "col_b",
+          col_3 = "col_c",
+          col_4 = "col_d"
+        )
       )
   )
 })


### PR DESCRIPTION
Resolves #830 

A few checks are completed:
* `.col_names` defaults to `NULL`
* If not `NULL`, `...` and `.list` should not have `length()`
* `.col_names` must be the same length as the `colnames` from the original data
* `.col_names` should not have `names` -- gives a warning as the names would be overwritten and vector is expected to be in order

Local tests didn't show any conflicts with this