### PR TITLE
Ensure that `gt_workflow_diagram.svg` has a white background set for Dark Mode GH users

### DIFF
--- a/man/figures/gt_workflow_diagram.svg
+++ b/man/figures/gt_workflow_diagram.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="600px" height="224px" viewBox="0 0 600 224" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="600px" height="224px" viewBox="0 0 600 224" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background: #FFFFFF;">
     <title>gt_workflow_diagram</title>
     <defs>
         <pattern id="pattern-1" width="8.37928922" height="8.37928922" x="-7.10269347" y="-8.37928922" patternUnits="userSpaceOnUse">


### PR DESCRIPTION
This corrects the `gt_workflow_diagram.svg` file, which is used in `README.md`. Previously, there wasn't a background set, making the image difficult to read when in Dark Mode. This change adds a white background to the aforementioned SVG file (as with the other SVGs in the README).