### PR TITLE
Allow use of `NULL` to remove any previously set source notes and footnotes

### DIFF
--- a/R/dt_source_notes.R
+++ b/R/dt_source_notes.R
@@ -18,6 +18,13 @@ dt_source_notes_init <- function(data) {
 
 dt_source_notes_add <- function(data, source_note) {
 
+  # There is the option to remove all source notes with
+  # `tab_source_note(source_note = NULL)`; this will
+  # essentially reinitialize the list
+  if (is.null(source_note)) {
+    return(dt_source_notes_init(data = data))
+  }
+
   data %>%
     dt_source_notes_get() %>%
     append(

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -857,7 +857,8 @@ set_footnote.cells_footnotes <- function(loc, data, footnote) {
 #' @inheritParams fmt_number
 #' @param source_note Text to be used in the source note. We can optionally use
 #'   the [md()] and [html()] functions to style the text as Markdown or to
-#'   retain HTML elements in the text.
+#'   retain HTML elements in the text. Using `NULL` will remove all existing
+#'   source notes.
 #'
 #' @return An object of class `gt_tbl`.
 #'

--- a/man/tab_source_note.Rd
+++ b/man/tab_source_note.Rd
@@ -11,7 +11,8 @@ tab_source_note(data, source_note)
 
 \item{source_note}{Text to be used in the source note. We can optionally use
 the \code{\link[=md]{md()}} and \code{\link[=html]{html()}} functions to style the text as Markdown or to
-retain HTML elements in the text.}
+retain HTML elements in the text. Using \code{NULL} will remove all existing
+source notes.}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -420,6 +420,20 @@ test_that("a gt table contains the expected source note", {
     expect_equal(
       c("Henderson and Velleman (1981).",
         "This was in Motor Trend magazine, hence the `mt`."))
+
+  # Create a `tbl_html` object with `gt()`; this sets a
+  # source note and then removes it with `NULL`
+  tbl_html <-
+    gt(mtcars_short) %>%
+    tab_source_note(source_note = md("*Henderson and Velleman* (1981).")) %>%
+    tab_source_note(source_note = NULL) %>%
+    render_as_html() %>%
+    xml2::read_html()
+
+  # Expect no source note text will be rendered
+  tbl_html %>%
+    selection_text("[class='gt_sourcenote']") %>%
+    expect_equal(character(0))
 })
 
 test_that("row groups can be successfully generated with `tab_row_group()", {


### PR DESCRIPTION
This will allow `NULL` to be valid input in `tab_source_note()` and `tab_footnote()`. In these, `NULL` isn't already used to signify a missing option, and, this change will bring the behavior closer to that of `tab_header()`.

Fixes: https://github.com/rstudio/gt/issues/790