### PR TITLE
Update `escape_latex()` for better rendering

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -2480,7 +2480,8 @@ latex_special_chars <- c(
 #' @export
 escape_latex <- function(text) {
 
-  m <- gregexec("[\\\\&%$#_{}~^]", text)
+  m <- gregexpr("[\\\\&%$#_{}~^]", text, perl = TRUE)
+
   special_chars <- regmatches(text, m)
   escaped_chars <- lapply(special_chars, function(x) {
     latex_special_chars[x]

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -2468,10 +2468,11 @@ random_id <- function(n = 10) {
 escape_latex <- function(text) {
 
   text %>%
-    tidy_gsub("\\\\", "\\\\textbackslash ") %>%
+    tidy_gsub("\\\\", "\\\\textbackslash") %>%
     tidy_gsub("([&%$#_{}])", "\\\\\\1") %>%
-    tidy_gsub("~", "\\\\textasciitilde ") %>%
-    tidy_gsub("\\^", "\\\\textasciicircum ")
+    tidy_gsub("~", "\\\\textasciitilde{}") %>%
+    tidy_gsub("\\^", "\\\\textasciicircum{}") %>%
+    tidy_gsub("\\\\textbackslash", "\\\\textbackslash{}")
 }
 
 #' Get the LaTeX dependencies required for a **gt** table

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -2455,7 +2455,7 @@ random_id <- function(n = 10) {
 #' function will transform a character vector so that it is safe to use within
 #' LaTeX tables.
 #'
-#' @param text a character vector containing the text that is to be
+#' @param text A character vector containing the text that is to be
 #'   LaTeX-escaped.
 #'
 #' @return A character vector.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -2448,6 +2448,19 @@ random_id <- function(n = 10) {
   paste(sample(letters, n, replace = TRUE), collapse = "")
 }
 
+latex_special_chars <- c(
+  "\\" = "\\textbackslash{}",
+  "~" = "\\textasciitilde{}",
+  "^" = "\\textasciicircum{}",
+  "&" = "\\&",
+  "%" = "\\%",
+  "$" = "\\$",
+  "#" = "\\#",
+  "_" = "\\_",
+  "{" = "\\{",
+  "}" = "\\}"
+)
+
 #' Perform LaTeX escaping
 #'
 #' @description
@@ -2467,12 +2480,13 @@ random_id <- function(n = 10) {
 #' @export
 escape_latex <- function(text) {
 
-  text %>%
-    tidy_gsub("\\\\", "\\\\textbackslash") %>%
-    tidy_gsub("([&%$#_{}])", "\\\\\\1") %>%
-    tidy_gsub("~", "\\\\textasciitilde{}") %>%
-    tidy_gsub("\\^", "\\\\textasciicircum{}") %>%
-    tidy_gsub("\\\\textbackslash", "\\\\textbackslash{}")
+  m <- gregexec("[\\\\&%$#_{}~^]", text)
+  special_chars <- regmatches(text, m)
+  escaped_chars <- lapply(special_chars, function(x) {
+    latex_special_chars[x]
+  })
+  regmatches(text, m) <- escaped_chars
+  text
 }
 
 #' Get the LaTeX dependencies required for a **gt** table

--- a/man/escape_latex.Rd
+++ b/man/escape_latex.Rd
@@ -7,7 +7,7 @@
 escape_latex(text)
 }
 \arguments{
-\item{text}{a character vector containing the text that is to be
+\item{text}{A character vector containing the text that is to be
 LaTeX-escaped.}
 }
 \value{

--- a/tests/testthat/test-escaping.R
+++ b/tests/testthat/test-escaping.R
@@ -1,0 +1,34 @@
+test_that("LaTeX escaping with `escape_latex()` works well", {
+
+  expect_equal(escape_latex("\\"), "\\textbackslash{}")
+  expect_equal(escape_latex("^"), "\\textasciicircum{}")
+  expect_equal(escape_latex("~"), "\\textasciitilde{}")
+  expect_equal(escape_latex("&"), "\\&")
+  expect_equal(escape_latex("%"), "\\%")
+  expect_equal(escape_latex("$"), "\\$")
+  expect_equal(escape_latex("#"), "\\#")
+  expect_equal(escape_latex("_"), "\\_")
+  expect_equal(escape_latex("{"), "\\{")
+  expect_equal(escape_latex("}"), "\\}")
+
+  expect_equal(
+    escape_latex("\\^~&%$#_{}"),
+    "\\textbackslash{}\\textasciicircum{}\\textasciitilde{}\\&\\%\\$\\#\\_\\{\\}"
+  )
+  expect_equal(
+    escape_latex(" \\ ^ ~ & % $ # _ { } "),
+    " \\textbackslash{} \\textasciicircum{} \\textasciitilde{} \\& \\% \\$ \\# \\_ \\{ \\} "
+  )
+  expect_equal(
+    escape_latex("A\\B^C~D&E%F$G#H_I{J}K"),
+    "A\\textbackslash{}B\\textasciicircum{}C\\textasciitilde{}D\\&E\\%F\\$G\\#H\\_I\\{J\\}K"
+  )
+
+  expect_equal(
+    escape_latex(c("\\", "^", "~", "&", "%", "$", "#", "_", "{", "}")),
+    c(
+      "\\textbackslash{}", "\\textasciicircum{}", "\\textasciitilde{}",
+      "\\&", "\\%", "\\$", "\\#", "\\_", "\\{", "\\}"
+    )
+  )
+})


### PR DESCRIPTION
Certain replacements for LaTeX escapes that supply a command will render better (i.e., not include unwanted space characters) if they use `{}` (e.g., `\textasciitilde{}` instead of `\textasciitilde `). To that end, this PR enhances the `escape_latex()` function to make the replacements render LaTeX text more accurately. 