### PR TITLE
[Accessibility] Closing #679: Use <td> instead of <th> for title and subtitle

### DIFF
--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -287,7 +287,7 @@ create_heading_component_h <- function(data) {
 
   title_row <-
     htmltools::tags$tr(
-      htmltools::tags$th(
+      htmltools::tags$td(
         colspan = n_cols_total,
         class = paste(title_classes, collapse = " "),
         style = title_styles,
@@ -301,7 +301,7 @@ create_heading_component_h <- function(data) {
 
     subtitle_row <-
       htmltools::tags$tr(
-        htmltools::tags$th(
+        htmltools::tags$td(
           colspan = n_cols_total,
           class = paste(subtitle_classes, collapse = " "),
           style = subtitle_styles,


### PR DESCRIPTION
This PR addresses #679: now screen readers don't get confused when using title and subtitle element.

## Reprex

``` r
library(gt)

# Create gt table with title and subtitle
airquality[1:10, ] %>%
  gt::gt() %>%
  gt::tab_header(
    title = "Title",
    subtitle = "Subtitle"
  )
```

## Results

`title` and `subtitle` now get treated as `<td>`. This is good for screen reader a11y.

@rich-iannone, I still need your help to verify whether there are any CSS tweaks that we need to consider. I don't want to introduce any visual breaks.
