### PR TITLE
Adjust family names to fit with .Rd templating

### DIFF
--- a/R/data_color.R
+++ b/R/data_color.R
@@ -126,7 +126,7 @@
 #' `r man_get_image_tag(file = "man_data_color_2.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-21
 #'

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -27,7 +27,7 @@
 #' dplyr::glimpse(countrypops)
 #' ```
 #'
-#' @family Datasets
+#' @family datasets
 #' @section Function ID:
 #' 11-1
 #'
@@ -78,7 +78,7 @@
 #' dplyr::glimpse(sza)
 #' ```
 #'
-#' @family Datasets
+#' @family datasets
 #' @section Function ID:
 #' 11-2
 #'
@@ -133,7 +133,7 @@
 #' dplyr::glimpse(gtcars)
 #' ```
 #'
-#' @family Datasets
+#' @family datasets
 #' @section Function ID:
 #' 11-3
 #'
@@ -163,7 +163,7 @@
 #' dplyr::glimpse(sp500)
 #' ```
 #'
-#' @family Datasets
+#' @family datasets
 #' @section Function ID:
 #' 11-4
 #'
@@ -294,7 +294,7 @@
 #' dplyr::glimpse(pizzaplace)
 #' ```
 #'
-#' @family Datasets
+#' @family datasets
 #' @section Function ID:
 #' 11-5
 #'
@@ -338,7 +338,7 @@
 #' exibble
 #' ```
 #'
-#' @family Datasets
+#' @family datasets
 #' @section Function ID:
 #' 11-6
 #'

--- a/R/export.R
+++ b/R/export.R
@@ -107,7 +107,7 @@
 #' tab_1 %>% gtsave("tab_1.docx")
 #' ```
 #'
-#' @family Export Functions
+#' @family table export functions
 #' @section Function ID:
 #' 13-1
 #'
@@ -378,7 +378,7 @@ gtsave_filename <- function(path, filename) {
 #' It has only the `<table>...</table>` part so it's not a complete HTML
 #' document but rather an HTML fragment.
 #'
-#' @family Export Functions
+#' @family table export functions
 #' @section Function ID:
 #' 13-2
 #'
@@ -443,7 +443,7 @@ as_raw_html <- function(
 #' Markdown documents that are knit to PDF. We can use `as.character()` to get
 #' just the LaTeX code as a single-element vector.
 #'
-#' @family Export Functions
+#' @family table export functions
 #' @section Function ID:
 #' 13-3
 #'
@@ -527,7 +527,7 @@ as_latex <- function(data) {
 #'   as_rtf()
 #' ```
 #'
-#' @family Export Functions
+#' @family table export functions
 #' @section Function ID:
 #' 13-4
 #'
@@ -631,7 +631,7 @@ as_rtf <- function(data) {
 #'   ) %>%
 #'   as_word()
 #'
-#' @family Export Functions
+#' @family table export functions
 #' @section Function ID:
 #' 13-5
 #'
@@ -832,7 +832,7 @@ as_word_tbl_body <- function(
 #' `r man_get_image_tag(file = "man_extract_summary_1.png")`
 #' }}
 #'
-#' @family Export Functions
+#' @family table export functions
 #' @section Function ID:
 #' 13-6
 #'

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -154,7 +154,7 @@
 #' `r man_get_image_tag(file = "man_fmt_number_2.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-1
 #'
@@ -349,7 +349,7 @@ fmt_number <- function(
 #' `r man_get_image_tag(file = "man_fmt_integer_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-2
 #'
@@ -449,7 +449,7 @@ fmt_integer <- function(
 #' `r man_get_image_tag(file = "man_fmt_scientific_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-3
 #'
@@ -633,7 +633,7 @@ fmt_scientific <- function(
 #' `r man_get_image_tag(file = "man_fmt_engineering_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-4
 #'
@@ -992,7 +992,7 @@ fmt_symbol <- function(
 #' `r man_get_image_tag(file = "man_fmt_percent_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-5
 #'
@@ -1150,7 +1150,7 @@ fmt_percent <- function(
 #' `r man_get_image_tag(file = "man_fmt_partsper_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-6
 #'
@@ -1387,7 +1387,7 @@ fmt_partsper <- function(
 #' `r man_get_image_tag(file = "man_fmt_fraction_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-7
 #'
@@ -1823,7 +1823,7 @@ round_gt <- function(x, digits = 0) {
 #' `r man_get_image_tag(file = "man_fmt_currency_2.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-8
 #'
@@ -1985,7 +1985,7 @@ fmt_currency <- function(
 #' `r man_get_image_tag(file = "man_fmt_bytes_2.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-9
 #'
@@ -2182,7 +2182,7 @@ fmt_bytes <- function(
 #' `r man_get_image_tag(file = "man_fmt_date_2.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-10
 #'
@@ -2338,7 +2338,7 @@ fmt_date <- function(
 #' `r man_get_image_tag(file = "man_fmt_time_2.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-11
 #'
@@ -2559,7 +2559,7 @@ fmt_time <- function(
 #' `r man_get_image_tag(file = "man_fmt_datetime_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-12
 #'
@@ -2795,7 +2795,7 @@ fmt_datetime <- function(
 #' `r man_get_image_tag(file = "man_fmt_duration_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-13
 #'
@@ -3513,7 +3513,7 @@ extract_duration_pattern <- function(
 #' `r man_get_image_tag(file = "man_fmt_markdown_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-14
 #'
@@ -3607,7 +3607,7 @@ fmt_markdown <- function(
 #' `r man_get_image_tag(file = "man_fmt_passthrough_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-15
 #'
@@ -3763,7 +3763,7 @@ fmt_passthrough <- function(
 #' `r man_get_image_tag(file = "man_fmt_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-16
 #'

--- a/R/gt.R
+++ b/R/gt.R
@@ -93,7 +93,7 @@
 #' `r man_get_image_tag(file = "man_gt_2.png")`
 #' }}
 #'
-#' @family Create Table
+#' @family table creation functions
 #' @section Function ID:
 #' 1-1
 #'

--- a/R/gt_preview.R
+++ b/R/gt_preview.R
@@ -42,7 +42,7 @@
 #' `r man_get_image_tag(file = "man_gt_preview_1.png")`
 #' }}
 #'
-#' @family Create Table
+#' @family table creation functions
 #' @section Function ID:
 #' 1-2
 #'

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -28,7 +28,7 @@
 #' `r man_get_image_tag(file = "man_md_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-1
 #'
@@ -75,7 +75,7 @@ md <- function(text) {
 #' `r man_get_image_tag(file = "man_html_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-2
 #'
@@ -132,7 +132,7 @@ is_rtf <- function(x) {
 #' `r man_get_image_tag(file = "man_px_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-3
 #'
@@ -182,7 +182,7 @@ px <- function(x) {
 #' `r man_get_image_tag(file = "man_pct_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-4
 #'
@@ -272,7 +272,7 @@ pct <- function(x) {
 #' `r man_get_image_tag(file = "man_cells_title_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-5
 #'
@@ -378,7 +378,7 @@ cells_title <- function(groups = c("title", "subtitle")) {
 #' `r man_get_image_tag(file = "man_cells_stubhead_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-6
 #'
@@ -473,7 +473,7 @@ cells_stubhead <- function() {
 #' `r man_get_image_tag(file = "man_cells_column_spanners_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-7
 #'
@@ -577,7 +577,7 @@ cells_column_spanners <- function(spanners = everything()) {
 #' `r man_get_image_tag(file = "man_cells_column_labels_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-8
 #'
@@ -683,7 +683,7 @@ cells_column_labels <- function(columns = everything()) {
 #' `r man_get_image_tag(file = "man_cells_row_groups_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-9
 #'
@@ -801,7 +801,7 @@ cells_group <- function(groups = TRUE) {
 #' `r man_get_image_tag(file = "man_cells_stub_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-10
 #'
@@ -900,7 +900,7 @@ cells_stub <- function(rows = everything()) {
 #' `r man_get_image_tag(file = "man_cells_body_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-11
 #'
@@ -1035,7 +1035,7 @@ cells_body <- function(
 #' `r man_get_image_tag(file = "man_cells_summary_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-12
 #'
@@ -1158,7 +1158,7 @@ cells_summary <- function(
 #' `r man_get_image_tag(file = "man_cells_grand_summary_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-13
 #'
@@ -1286,7 +1286,7 @@ cells_grand_summary <- function(
 #' `r man_get_image_tag(file = "man_cells_stub_summary_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-14
 #'
@@ -1399,7 +1399,7 @@ cells_stub_summary <- function(
 #' `r man_get_image_tag(file = "man_cells_stub_grand_summary_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-15
 #'
@@ -1511,7 +1511,7 @@ cells_stub_grand_summary <- function(rows = everything()) {
 #' `r man_get_image_tag(file = "man_cells_footnotes_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-16
 #'
@@ -1605,7 +1605,7 @@ cells_footnotes <- function() {
 #' `r man_get_image_tag(file = "man_cells_source_notes_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-17
 #'
@@ -1673,7 +1673,7 @@ cells_source_notes <- function() {
 #' `r man_get_image_tag(file = "man_currency_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-18
 #'
@@ -1798,7 +1798,7 @@ currency <- function(
 #' `r man_get_image_tag(file = "man_cell_text_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-19
 #'
@@ -1973,7 +1973,7 @@ cell_style_to_html.cell_text <- function(style) {
 #' `r man_get_image_tag(file = "man_cell_fill_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-20
 #'
@@ -2097,7 +2097,7 @@ cell_style_to_html.cell_fill <- function(style) {
 #' `r man_get_image_tag(file = "man_cell_borders_2.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-21
 #'
@@ -2286,7 +2286,7 @@ cell_style_structure <- function(name, obj, subclass = name) {
 #' `r man_get_image_tag(file = "man_google_font_2.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-27
 #'
@@ -2352,7 +2352,7 @@ google_font <- function(name) {
 #' `r man_get_image_tag(file = "man_default_fonts_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #'
 #' @section Function ID:
 #' 7-26
@@ -2439,7 +2439,7 @@ default_fonts <- function() {
 #' `r man_get_image_tag(file = "man_adjust_luminance_1.png")`
 #' }}
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-22
 #'
@@ -2496,7 +2496,7 @@ adjust_luminance <- function(
 #'
 #' @return A character vector containing a single, random ID.
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-23
 #'
@@ -2531,7 +2531,7 @@ latex_special_chars <- c(
 #'
 #' @return A character vector.
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-24
 #'
@@ -2588,7 +2588,7 @@ escape_latex <- function(text) {
 #'
 #' @return An object of class `knit_asis`.
 #'
-#' @family Helper Functions
+#' @family helper functions
 #' @section Function ID:
 #' 7-25
 #'

--- a/R/image.R
+++ b/R/image.R
@@ -98,7 +98,7 @@
 #' `r man_get_image_tag(file = "man_web_image_2.png")`
 #' }}
 #'
-#' @family Image Addition Functions
+#' @family image addition functions
 #' @section Function ID:
 #' 8-1
 #'
@@ -172,7 +172,7 @@ web_image <- function(
 #' `r man_get_image_tag(file = "man_local_image_1.png")`
 #' }}
 #'
-#' @family Image Addition Functions
+#' @family image addition functions
 #' @section Function ID:
 #' 8-2
 #'
@@ -272,7 +272,7 @@ local_image <- function(
 #' `r man_get_image_tag(file = "man_ggplot_image_1.png")`
 #' }}
 #'
-#' @family Image Addition Functions
+#' @family image addition functions
 #' @section Function ID:
 #' 8-3
 #'
@@ -331,7 +331,7 @@ ggplot_image <- function(
 #'
 #' @return A character vector with a single path to an image file.
 #'
-#' @family Image Addition Functions
+#' @family image addition functions
 #' @section Function ID:
 #' 8-4
 #'

--- a/R/info_tables.R
+++ b/R/info_tables.R
@@ -22,7 +22,7 @@
 #' `r man_get_image_tag(file = "man_info_date_style_1.png")`
 #' }}
 #'
-#' @family Information Functions
+#' @family information functions
 #' @section Function ID:
 #' 10-1
 #'
@@ -90,7 +90,7 @@ info_date_style <- function() {
 #' `r man_get_image_tag(file = "man_info_time_style_1.png")`
 #' }}
 #'
-#' @family Information Functions
+#' @family information functions
 #' @section Function ID:
 #' 10-2
 #'
@@ -175,7 +175,7 @@ info_time_style <- function() {
 #' `r man_get_image_tag(file = "man_info_currencies_2.png")`
 #' }}
 #'
-#' @family Information Functions
+#' @family information functions
 #' @section Function ID:
 #' 10-3
 #'
@@ -327,7 +327,7 @@ info_currencies <- function(
 #' `r man_get_image_tag(file = "man_info_locales_1.png")`
 #' }}
 #'
-#' @family Information Functions
+#' @family information functions
 #' @section Function ID:
 #' 10-4
 #'
@@ -471,7 +471,7 @@ info_locales <- function(begins_with = NULL) {
 #' `r man_get_image_tag(file = "man_info_paletteer_1.png")`
 #' }}
 #'
-#' @family Information Functions
+#' @family information functions
 #' @section Function ID:
 #' 10-5
 #'
@@ -578,7 +578,7 @@ info_paletteer <- function(color_pkgs = NULL) {
 #' `r man_get_image_tag(file = "man_info_google_fonts_1.png")`
 #' }}
 #'
-#' @family Information Functions
+#' @family information functions
 #' @section Function ID:
 #' 10-6
 #'

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -47,7 +47,7 @@
 #' `r man_get_image_tag(file = "man_cols_align_1.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-1
 #'
@@ -183,7 +183,7 @@ cols_align <- function(
 #' `r man_get_image_tag(file = "man_cols_width_1.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-2
 #'
@@ -357,7 +357,7 @@ cols_width <- function(
 #' `r man_get_image_tag(file = "man_cols_label_2.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-3
 #'
@@ -485,7 +485,7 @@ cols_label <- function(
 #' `r man_get_image_tag(file = "man_cols_move_to_start_2.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-4
 #'
@@ -589,7 +589,7 @@ cols_move_to_start <- function(
 #' `r man_get_image_tag(file = "man_cols_move_to_end_2.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-5
 #'
@@ -684,7 +684,7 @@ cols_move_to_end <- function(
 #' `r man_get_image_tag(file = "man_cols_move_1.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-6
 #'
@@ -823,7 +823,7 @@ cols_move <- function(
 #' `r man_get_image_tag(file = "man_cols_hide_2.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-7
 #'
@@ -920,7 +920,7 @@ cols_hide <- function(
 #' `r man_get_image_tag(file = "man_cols_unhide_2.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-8
 #'
@@ -1045,7 +1045,7 @@ cols_unhide <- function(
 #' `r man_get_image_tag(file = "man_cols_merge_uncert_1.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-9
 #'
@@ -1171,7 +1171,7 @@ cols_merge_uncert <- function(
 #' `r man_get_image_tag(file = "man_cols_merge_range_1.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-10
 #'
@@ -1345,7 +1345,7 @@ cols_merge_resolver <- function(data, col_begin, col_end, sep) {
 #' `r man_get_image_tag(file = "man_cols_merge_n_pct_1.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-11
 #'
@@ -1464,7 +1464,7 @@ cols_merge_n_pct <- function(
 #' `r man_get_image_tag(file = "man_cols_merge_1.png")`
 #' }}
 #'
-#' @family Modify Columns
+#' @family column modification functions
 #' @section Function ID:
 #' 4-12
 #'

--- a/R/modify_rows.R
+++ b/R/modify_rows.R
@@ -37,7 +37,7 @@
 #' `r man_get_image_tag(file = "man_row_group_order_1.png")`
 #' }}
 #'
-#' @family Modify Rows
+#' @family row modification functions
 #' @section Function ID:
 #' 5-1
 #'

--- a/R/substitution.R
+++ b/R/substitution.R
@@ -41,7 +41,7 @@
 #' `r man_get_image_tag(file = "man_sub_missing_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-16
 #'
@@ -176,7 +176,7 @@ fmt_missing <- function(
 #' `r man_get_image_tag(file = "man_sub_zero_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-17
 #'
@@ -308,7 +308,7 @@ sub_zero <- function(
 #' `r man_get_image_tag(file = "man_sub_small_vals_3.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-18
 #'
@@ -508,7 +508,7 @@ sub_small_vals <- function(
 #' `r man_get_image_tag(file = "man_sub_large_vals_3.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-19
 #'

--- a/R/summary_rows.R
+++ b/R/summary_rows.R
@@ -75,7 +75,7 @@
 #' `r man_get_image_tag(file = "man_summary_rows_1.png")`
 #' }}
 #'
-#' @family Add Rows
+#' @family row addition functions
 #' @section Function ID:
 #' 6-1
 #'
@@ -233,7 +233,7 @@ summary_rows <- function(
 #' `r man_get_image_tag(file = "man_grand_summary_rows_1.png")`
 #' }}
 #'
-#' @family Add Rows
+#' @family row addition functions
 #' @section Function ID:
 #' 6-2
 #'

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -37,7 +37,7 @@
 #' `r man_get_image_tag(file = "man_tab_header_1.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-1
 #'
@@ -123,7 +123,7 @@ tab_header <- function(
 #' `r man_get_image_tag(file = "man_tab_spanner_1.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-2
 #'
@@ -364,7 +364,7 @@ resolve_spanned_column_names <- function(
 #' `r man_get_image_tag(file = "man_tab_spanner_delim_1.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-3
 #'
@@ -609,7 +609,7 @@ tab_spanner_delim <- function(
 #' `r man_get_image_tag(file = "man_tab_row_group_2.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-4
 #'
@@ -740,7 +740,7 @@ tab_row_group <- function(
 #' `r man_get_image_tag(file = "man_tab_stubhead_1.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-5
 #'
@@ -837,7 +837,7 @@ tab_stubhead <- function(
 #' `r man_get_image_tag(file = "man_tab_footnote_1.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-6
 #'
@@ -1160,7 +1160,7 @@ set_footnote.cells_footnotes <- function(loc, data, footnote, placement) {
 #' `r man_get_image_tag(file = "man_tab_source_note_1.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-7
 #'
@@ -1309,7 +1309,7 @@ tab_source_note <- function(
 #' `r man_get_image_tag(file = "man_tab_style_3.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-8
 #'
@@ -1996,7 +1996,7 @@ set_style.cells_source_notes <- function(loc, data, style) {
 #' `r man_get_image_tag(file = "man_tab_options_6.png")`
 #' }}
 #'
-#' @family Create or Modify Parts
+#' @family part creation/modification functions
 #' @section Function ID:
 #' 2-9
 #'

--- a/R/text_transform.R
+++ b/R/text_transform.R
@@ -41,7 +41,7 @@
 #' `r man_get_image_tag(file = "man_text_transform_1.png")`
 #' }}
 #'
-#' @family Format Data
+#' @family data formatting functions
 #' @section Function ID:
 #' 3-20
 #'

--- a/man/adjust_luminance.Rd
+++ b/man/adjust_luminance.Rd
@@ -85,7 +85,7 @@ of increasingly darker palettes (with \code{\link[=data_color]{data_color()}}).
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
 \code{\link{cell_text}()},
@@ -113,4 +113,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/as_latex.Rd
+++ b/man/as_latex.Rd
@@ -45,11 +45,11 @@ just the LaTeX code as a single-element vector.
 }
 
 \seealso{
-Other Export Functions: 
+Other table export functions: 
 \code{\link{as_raw_html}()},
 \code{\link{as_rtf}()},
 \code{\link{as_word}()},
 \code{\link{extract_summary}()},
 \code{\link{gtsave}()}
 }
-\concept{Export Functions}
+\concept{table export functions}

--- a/man/as_raw_html.Rd
+++ b/man/as_raw_html.Rd
@@ -51,11 +51,11 @@ document but rather an HTML fragment.
 }
 
 \seealso{
-Other Export Functions: 
+Other table export functions: 
 \code{\link{as_latex}()},
 \code{\link{as_rtf}()},
 \code{\link{as_word}()},
 \code{\link{extract_summary}()},
 \code{\link{gtsave}()}
 }
-\concept{Export Functions}
+\concept{table export functions}

--- a/man/as_rtf.Rd
+++ b/man/as_rtf.Rd
@@ -39,11 +39,11 @@ code.
 }
 
 \seealso{
-Other Export Functions: 
+Other table export functions: 
 \code{\link{as_latex}()},
 \code{\link{as_raw_html}()},
 \code{\link{as_word}()},
 \code{\link{extract_summary}()},
 \code{\link{gtsave}()}
 }
-\concept{Export Functions}
+\concept{table export functions}

--- a/man/as_word.Rd
+++ b/man/as_word.Rd
@@ -57,11 +57,11 @@ tab_rtf <-
 
 }
 \seealso{
-Other Export Functions: 
+Other table export functions: 
 \code{\link{as_latex}()},
 \code{\link{as_raw_html}()},
 \code{\link{as_rtf}()},
 \code{\link{extract_summary}()},
 \code{\link{gtsave}()}
 }
-\concept{Export Functions}
+\concept{table export functions}

--- a/man/cell_borders.Rd
+++ b/man/cell_borders.Rd
@@ -102,7 +102,7 @@ This uses multiple \code{cell_borders()} and \code{\link[=cells_body]{cells_body
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_fill}()},
 \code{\link{cell_text}()},
@@ -130,4 +130,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cell_fill.Rd
+++ b/man/cell_fill.Rd
@@ -64,7 +64,7 @@ the \code{cell_fill()} helper function.
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_text}()},
@@ -92,4 +92,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cell_text.Rd
+++ b/man/cell_text.Rd
@@ -119,7 +119,7 @@ the \code{cell_text()} helper function.
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -147,4 +147,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_body.Rd
+++ b/man/cells_body.Rd
@@ -96,7 +96,7 @@ data cell with \code{\link[=tab_footnote]{tab_footnote()}}, using \code{cells_bo
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -124,4 +124,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_column_labels.Rd
+++ b/man/cells_column_labels.Rd
@@ -100,7 +100,7 @@ Use \code{\link{sza}} to create a \strong{gt} table. Add footnotes to the column
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -128,4 +128,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_column_spanners.Rd
+++ b/man/cells_column_spanners.Rd
@@ -95,7 +95,7 @@ three column labels with \code{\link[=tab_spanner]{tab_spanner()}} and then use 
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -123,4 +123,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_footnotes.Rd
+++ b/man/cells_footnotes.Rd
@@ -107,7 +107,7 @@ Use \code{\link{sza}} to create a \strong{gt} table. Color the \code{sza} column
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -135,4 +135,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_grand_summary.Rd
+++ b/man/cells_grand_summary.Rd
@@ -108,7 +108,7 @@ summary cell with with \code{\link[=tab_style]{tab_style()}} and \code{cells_gra
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -136,4 +136,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_row_groups.Rd
+++ b/man/cells_row_groups.Rd
@@ -102,7 +102,7 @@ with the \code{\link[=summary_rows]{summary_rows()}} function and then add a foo
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -130,4 +130,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_source_notes.Rd
+++ b/man/cells_source_notes.Rd
@@ -92,7 +92,7 @@ source notes section.
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -120,4 +120,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_stub.Rd
+++ b/man/cells_stub.Rd
@@ -98,7 +98,7 @@ table stub with \code{\link[=tab_style]{tab_style()}}, using \code{cells_stub()}
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -126,4 +126,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_stub_grand_summary.Rd
+++ b/man/cells_stub_grand_summary.Rd
@@ -101,7 +101,7 @@ summary stub cell with with the \code{\link[=tab_style]{tab_style()}} and
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -129,4 +129,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_stub_summary.Rd
+++ b/man/cells_stub_summary.Rd
@@ -117,7 +117,7 @@ data stub cells with \code{\link[=tab_style]{tab_style()}} and \code{cells_stub_
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -145,4 +145,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_stubhead.Rd
+++ b/man/cells_stubhead.Rd
@@ -88,7 +88,7 @@ Use \code{\link{pizzaplace}} to create a \strong{gt} table. Add a stubhead label
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -116,4 +116,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_summary.Rd
+++ b/man/cells_summary.Rd
@@ -129,7 +129,7 @@ data cells with with \code{\link[=tab_style]{tab_style()}}, using \code{cells_su
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -157,4 +157,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cells_title.Rd
+++ b/man/cells_title.Rd
@@ -92,7 +92,7 @@ add a footnote to the title with \code{\link[=tab_footnote]{tab_footnote()}} and
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -120,4 +120,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/cols_align.Rd
+++ b/man/cols_align.Rd
@@ -68,7 +68,7 @@ data to the left.
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
 \code{\link{cols_merge_n_pct}()},
@@ -81,4 +81,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_hide.Rd
+++ b/man/cols_hide.Rd
@@ -83,7 +83,7 @@ statements has no effect.
 \seealso{
 \code{\link[=cols_unhide]{cols_unhide()}} to perform the inverse operation.
 
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_label}()},
 \code{\link{cols_merge_n_pct}()},
@@ -96,4 +96,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_label.Rd
+++ b/man/cols_label.Rd
@@ -89,7 +89,7 @@ formatting.
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_merge_n_pct}()},
@@ -102,4 +102,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_merge.Rd
+++ b/man/cols_merge.Rd
@@ -86,7 +86,7 @@ merge the \code{open} & \code{close} columns together, and, the \code{low} & \co
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -99,4 +99,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_merge_n_pct.Rd
+++ b/man/cols_merge_n_pct.Rd
@@ -112,7 +112,7 @@ percentages of the top 3 pizzas sold by pizza category in 2015. The
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -125,4 +125,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_merge_range.Rd
+++ b/man/cols_merge_range.Rd
@@ -88,7 +88,7 @@ function.
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -101,4 +101,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_merge_uncert.Rd
+++ b/man/cols_merge_uncert.Rd
@@ -101,7 +101,7 @@ Use \code{\link{exibble}} to create a \strong{gt} table, keeping only the \code{
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -114,4 +114,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_move.Rd
+++ b/man/cols_move.Rd
@@ -64,7 +64,7 @@ position \code{population} after \code{country_name} with the \code{cols_move()}
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -77,4 +77,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_move_to_end.Rd
+++ b/man/cols_move_to_end.Rd
@@ -71,7 +71,7 @@ move \code{year} and \code{country_name} to the end of the column series.
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -84,4 +84,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_move_to_start.Rd
+++ b/man/cols_move_to_start.Rd
@@ -72,7 +72,7 @@ move \code{year} and \code{population} to the start.
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -85,4 +85,4 @@ Other Modify Columns:
 \code{\link{cols_unhide}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_unhide.Rd
+++ b/man/cols_unhide.Rd
@@ -70,7 +70,7 @@ the \code{cols_unhide()} function becomes useful.
 \seealso{
 \code{\link[=cols_hide]{cols_hide()}} to perform the inverse operation.
 
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -83,4 +83,4 @@ Other Modify Columns:
 \code{\link{cols_move}()},
 \code{\link{cols_width}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/cols_width.Rd
+++ b/man/cols_width.Rd
@@ -79,7 +79,7 @@ end will capture all remaining columns).
 }
 
 \seealso{
-Other Modify Columns: 
+Other column modification functions: 
 \code{\link{cols_align}()},
 \code{\link{cols_hide}()},
 \code{\link{cols_label}()},
@@ -92,4 +92,4 @@ Other Modify Columns:
 \code{\link{cols_move}()},
 \code{\link{cols_unhide}()}
 }
-\concept{Modify Columns}
+\concept{column modification functions}

--- a/man/countrypops.Rd
+++ b/man/countrypops.Rd
@@ -50,12 +50,12 @@ Here is a glimpse at the data available in \code{countrypops}.
 }
 
 \seealso{
-Other Datasets: 
+Other datasets: 
 \code{\link{exibble}},
 \code{\link{gtcars}},
 \code{\link{pizzaplace}},
 \code{\link{sp500}},
 \code{\link{sza}}
 }
-\concept{Datasets}
+\concept{datasets}
 \keyword{datasets}

--- a/man/currency.Rd
+++ b/man/currency.Rd
@@ -65,7 +65,7 @@ have currency values in guilder (a defunct Dutch currency).
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -93,4 +93,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/data_color.Rd
+++ b/man/data_color.Rd
@@ -154,7 +154,7 @@ as the domain.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
 \code{\link{fmt_datetime}()},
@@ -177,4 +177,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/default_fonts.Rd
+++ b/man/default_fonts.Rd
@@ -52,7 +52,7 @@ the \code{default_fonts()} set).
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -80,4 +80,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/escape_latex.Rd
+++ b/man/escape_latex.Rd
@@ -24,7 +24,7 @@ LaTeX tables.
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -52,4 +52,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/exibble.Rd
+++ b/man/exibble.Rd
@@ -62,12 +62,12 @@ Here is the \code{exibble}.
 }
 
 \seealso{
-Other Datasets: 
+Other datasets: 
 \code{\link{countrypops}},
 \code{\link{gtcars}},
 \code{\link{pizzaplace}},
 \code{\link{sp500}},
 \code{\link{sza}}
 }
-\concept{Datasets}
+\concept{datasets}
 \keyword{datasets}

--- a/man/extract_summary.Rd
+++ b/man/extract_summary.Rd
@@ -103,11 +103,11 @@ Use the summary list to make a new \strong{gt} table. The key thing is to use
 }
 
 \seealso{
-Other Export Functions: 
+Other table export functions: 
 \code{\link{as_latex}()},
 \code{\link{as_raw_html}()},
 \code{\link{as_rtf}()},
 \code{\link{as_word}()},
 \code{\link{gtsave}()}
 }
-\concept{Export Functions}
+\concept{table export functions}

--- a/man/fmt.Rd
+++ b/man/fmt.Rd
@@ -88,7 +88,7 @@ Use \code{\link{exibble}} to create a \strong{gt} table. Format the numeric valu
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -111,4 +111,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_bytes.Rd
+++ b/man/fmt_bytes.Rd
@@ -162,7 +162,7 @@ byte sizes as binary values.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_currency}()},
 \code{\link{fmt_datetime}()},
@@ -185,4 +185,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_currency.Rd
+++ b/man/fmt_currency.Rd
@@ -233,7 +233,7 @@ columns, then, format those columns using the \code{"CNY"} and \code{"GBP"} curr
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_datetime}()},
@@ -256,4 +256,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_date.Rd
+++ b/man/fmt_date.Rd
@@ -123,7 +123,7 @@ in the \code{rows} argument).
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -146,4 +146,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_datetime.Rd
+++ b/man/fmt_datetime.Rd
@@ -199,7 +199,7 @@ Format the column to have dates formatted as \code{month_day_year} and times to 
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -222,4 +222,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_duration.Rd
+++ b/man/fmt_duration.Rd
@@ -184,7 +184,7 @@ number of days since March 30, 2020.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -207,4 +207,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -118,7 +118,7 @@ engineering notation.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -141,4 +141,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_fraction.Rd
+++ b/man/fmt_fraction.Rd
@@ -185,7 +185,7 @@ Use \code{\link{pizzaplace}} to create a \strong{gt} table. Format the \code{f_s
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -208,4 +208,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_integer.Rd
+++ b/man/fmt_integer.Rd
@@ -147,7 +147,7 @@ values having no digit separators (with the \code{use_seps = FALSE} option).
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -170,4 +170,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_markdown.Rd
+++ b/man/fmt_markdown.Rd
@@ -97,7 +97,7 @@ then, create a \strong{gt} table and format all columns with \code{fmt_markdown(
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -120,4 +120,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -200,7 +200,7 @@ use large-number suffixing with the \code{suffixing = TRUE} option.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -223,4 +223,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_partsper.Rd
+++ b/man/fmt_partsper.Rd
@@ -177,7 +177,7 @@ format the \code{b} column as \emph{per mille} values with \code{fmt_partsper()}
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -200,4 +200,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_passthrough.Rd
+++ b/man/fmt_passthrough.Rd
@@ -86,7 +86,7 @@ to the non-\code{NA} values.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -109,4 +109,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_percent.Rd
+++ b/man/fmt_percent.Rd
@@ -166,7 +166,7 @@ column to display values as percentages.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -189,4 +189,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -126,7 +126,7 @@ partially numeric  and partially in scientific notation (using the
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -149,4 +149,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/fmt_time.Rd
+++ b/man/fmt_time.Rd
@@ -114,7 +114,7 @@ in the \code{rows} argument).
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -137,4 +137,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/ggplot_image.Rd
+++ b/man/ggplot_image.Rd
@@ -92,9 +92,9 @@ function.
 }
 
 \seealso{
-Other Image Addition Functions: 
+Other image addition functions: 
 \code{\link{local_image}()},
 \code{\link{test_image}()},
 \code{\link{web_image}()}
 }
-\concept{Image Addition Functions}
+\concept{image addition functions}

--- a/man/google_font.Rd
+++ b/man/google_font.Rd
@@ -82,7 +82,7 @@ catchall \code{"Serif"} group).
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -110,4 +110,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/grand_summary_rows.Rd
+++ b/man/grand_summary_rows.Rd
@@ -95,7 +95,7 @@ summary rows \code{min}, \code{max}, and \code{avg} for the table with the
 }
 
 \seealso{
-Other Add Rows: 
+Other row addition functions: 
 \code{\link{summary_rows}()}
 }
-\concept{Add Rows}
+\concept{row addition functions}

--- a/man/gt.Rd
+++ b/man/gt.Rd
@@ -125,7 +125,7 @@ available in the package.
 }
 
 \seealso{
-Other Create Table: 
+Other table creation functions: 
 \code{\link{gt_preview}()}
 }
-\concept{Create Table}
+\concept{table creation functions}

--- a/man/gt_latex_dependencies.Rd
+++ b/man/gt_latex_dependencies.Rd
@@ -51,7 +51,7 @@ exibble %>% gt()
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -79,4 +79,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/gt_preview.Rd
+++ b/man/gt_preview.Rd
@@ -60,7 +60,7 @@ columns). You'll see the first five rows and the last row.
 }
 
 \seealso{
-Other Create Table: 
+Other table creation functions: 
 \code{\link{gt}()}
 }
-\concept{Create Table}
+\concept{table creation functions}

--- a/man/gtcars.Rd
+++ b/man/gtcars.Rd
@@ -79,12 +79,12 @@ Here is a glimpse at the data available in \code{gtcars}.
 }
 
 \seealso{
-Other Datasets: 
+Other datasets: 
 \code{\link{countrypops}},
 \code{\link{exibble}},
 \code{\link{pizzaplace}},
 \code{\link{sp500}},
 \code{\link{sza}}
 }
-\concept{Datasets}
+\concept{datasets}
 \keyword{datasets}

--- a/man/gtsave.Rd
+++ b/man/gtsave.Rd
@@ -118,11 +118,11 @@ With the \code{.docx} extension, we'll get a word/docx document.
 }
 
 \seealso{
-Other Export Functions: 
+Other table export functions: 
 \code{\link{as_latex}()},
 \code{\link{as_raw_html}()},
 \code{\link{as_rtf}()},
 \code{\link{as_word}()},
 \code{\link{extract_summary}()}
 }
-\concept{Export Functions}
+\concept{table export functions}

--- a/man/html.Rd
+++ b/man/html.Rd
@@ -44,7 +44,7 @@ Use \code{\link{exibble}} to create a \strong{gt} table. When adding a title, us
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -72,4 +72,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/info_currencies.Rd
+++ b/man/info_currencies.Rd
@@ -66,11 +66,11 @@ used with \code{\link[=fmt_currency]{fmt_currency()}}.
 }
 
 \seealso{
-Other Information Functions: 
+Other information functions: 
 \code{\link{info_date_style}()},
 \code{\link{info_google_fonts}()},
 \code{\link{info_locales}()},
 \code{\link{info_paletteer}()},
 \code{\link{info_time_style}()}
 }
-\concept{Information Functions}
+\concept{information functions}

--- a/man/info_date_style.Rd
+++ b/man/info_date_style.Rd
@@ -36,11 +36,11 @@ by supplying a number code to the \code{\link[=fmt_date]{fmt_date()}} function).
 }
 
 \seealso{
-Other Information Functions: 
+Other information functions: 
 \code{\link{info_currencies}()},
 \code{\link{info_google_fonts}()},
 \code{\link{info_locales}()},
 \code{\link{info_paletteer}()},
 \code{\link{info_time_style}()}
 }
-\concept{Information Functions}
+\concept{information functions}

--- a/man/info_google_fonts.Rd
+++ b/man/info_google_fonts.Rd
@@ -40,11 +40,11 @@ Get a table of info on some of the recommended \emph{Google Fonts} for tables.
 }
 
 \seealso{
-Other Information Functions: 
+Other information functions: 
 \code{\link{info_currencies}()},
 \code{\link{info_date_style}()},
 \code{\link{info_locales}()},
 \code{\link{info_paletteer}()},
 \code{\link{info_time_style}()}
 }
-\concept{Information Functions}
+\concept{information functions}

--- a/man/info_locales.Rd
+++ b/man/info_locales.Rd
@@ -50,11 +50,11 @@ with a \code{"v"}.
 }
 
 \seealso{
-Other Information Functions: 
+Other information functions: 
 \code{\link{info_currencies}()},
 \code{\link{info_date_style}()},
 \code{\link{info_google_fonts}()},
 \code{\link{info_paletteer}()},
 \code{\link{info_time_style}()}
 }
-\concept{Information Functions}
+\concept{information functions}

--- a/man/info_paletteer.Rd
+++ b/man/info_paletteer.Rd
@@ -81,11 +81,11 @@ from the \strong{paletteer} package).
 }
 
 \seealso{
-Other Information Functions: 
+Other information functions: 
 \code{\link{info_currencies}()},
 \code{\link{info_date_style}()},
 \code{\link{info_google_fonts}()},
 \code{\link{info_locales}()},
 \code{\link{info_time_style}()}
 }
-\concept{Information Functions}
+\concept{information functions}

--- a/man/info_time_style.Rd
+++ b/man/info_time_style.Rd
@@ -36,11 +36,11 @@ by supplying a number code to the \code{\link[=fmt_time]{fmt_time()}} function).
 }
 
 \seealso{
-Other Information Functions: 
+Other information functions: 
 \code{\link{info_currencies}()},
 \code{\link{info_date_style}()},
 \code{\link{info_google_fonts}()},
 \code{\link{info_locales}()},
 \code{\link{info_paletteer}()}
 }
-\concept{Information Functions}
+\concept{information functions}

--- a/man/local_image.Rd
+++ b/man/local_image.Rd
@@ -73,9 +73,9 @@ various sizes.
 }
 
 \seealso{
-Other Image Addition Functions: 
+Other image addition functions: 
 \code{\link{ggplot_image}()},
 \code{\link{test_image}()},
 \code{\link{web_image}()}
 }
-\concept{Image Addition Functions}
+\concept{image addition functions}

--- a/man/md.Rd
+++ b/man/md.Rd
@@ -43,7 +43,7 @@ helper to use Markdown formatting.
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -71,4 +71,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/pct.Rd
+++ b/man/pct.Rd
@@ -49,7 +49,7 @@ the font size for the column labels.
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -77,4 +77,4 @@ Other Helper Functions:
 \code{\link{px}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/pizzaplace.Rd
+++ b/man/pizzaplace.Rd
@@ -147,12 +147,12 @@ Here is a glimpse at the pizza data available in \code{pizzaplace}.
 }
 
 \seealso{
-Other Datasets: 
+Other datasets: 
 \code{\link{countrypops}},
 \code{\link{exibble}},
 \code{\link{gtcars}},
 \code{\link{sp500}},
 \code{\link{sza}}
 }
-\concept{Datasets}
+\concept{datasets}
 \keyword{datasets}

--- a/man/px.Rd
+++ b/man/px.Rd
@@ -46,7 +46,7 @@ font size for the column labels.
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -74,4 +74,4 @@ Other Helper Functions:
 \code{\link{pct}()},
 \code{\link{random_id}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/random_id.Rd
+++ b/man/random_id.Rd
@@ -22,7 +22,7 @@ value argument of variable length (the default is 10 letters).
 }
 
 \seealso{
-Other Helper Functions: 
+Other helper functions: 
 \code{\link{adjust_luminance}()},
 \code{\link{cell_borders}()},
 \code{\link{cell_fill}()},
@@ -50,4 +50,4 @@ Other Helper Functions:
 \code{\link{pct}()},
 \code{\link{px}()}
 }
-\concept{Helper Functions}
+\concept{helper functions}

--- a/man/row_group_order.Rd
+++ b/man/row_group_order.Rd
@@ -52,4 +52,4 @@ new ordering in \code{groups}.
 5-1
 }
 
-\concept{Modify Rows}
+\concept{row modification functions}

--- a/man/sp500.Rd
+++ b/man/sp500.Rd
@@ -46,12 +46,12 @@ Here is a glimpse at the data available in \code{sp500}.
 }
 
 \seealso{
-Other Datasets: 
+Other datasets: 
 \code{\link{countrypops}},
 \code{\link{exibble}},
 \code{\link{gtcars}},
 \code{\link{pizzaplace}},
 \code{\link{sza}}
 }
-\concept{Datasets}
+\concept{datasets}
 \keyword{datasets}

--- a/man/sub_large_vals.Rd
+++ b/man/sub_large_vals.Rd
@@ -134,7 +134,7 @@ omitted.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -157,4 +157,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/sub_missing.Rd
+++ b/man/sub_missing.Rd
@@ -77,7 +77,7 @@ columns will be given replacement text with two calls of \code{sub_missing()}.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -100,4 +100,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/sub_small_vals.Rd
+++ b/man/sub_small_vals.Rd
@@ -133,7 +133,7 @@ omitted.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -156,4 +156,4 @@ Other Format Data:
 \code{\link{sub_zero}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/sub_zero.Rd
+++ b/man/sub_zero.Rd
@@ -84,7 +84,7 @@ single call of \code{sub_zero()}.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -107,4 +107,4 @@ Other Format Data:
 \code{\link{sub_small_vals}()},
 \code{\link{text_transform}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/summary_rows.Rd
+++ b/man/summary_rows.Rd
@@ -103,7 +103,7 @@ is a week number) with the \code{summary_rows()} function.
 }
 
 \seealso{
-Other Add Rows: 
+Other row addition functions: 
 \code{\link{grand_summary_rows}()}
 }
-\concept{Add Rows}
+\concept{row addition functions}

--- a/man/sza.Rd
+++ b/man/sza.Rd
@@ -65,12 +65,12 @@ Here is a glimpse at the data available in \code{sza}.
 }
 
 \seealso{
-Other Datasets: 
+Other datasets: 
 \code{\link{countrypops}},
 \code{\link{exibble}},
 \code{\link{gtcars}},
 \code{\link{pizzaplace}},
 \code{\link{sp500}}
 }
-\concept{Datasets}
+\concept{datasets}
 \keyword{datasets}

--- a/man/tab_footnote.Rd
+++ b/man/tab_footnote.Rd
@@ -104,7 +104,7 @@ Use \code{\link{sza}} to create a \strong{gt} table. Color the \code{sza} column
 }
 
 \seealso{
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_header}()},
 \code{\link{tab_options}()},
 \code{\link{tab_row_group}()},
@@ -114,4 +114,4 @@ Other Create or Modify Parts:
 \code{\link{tab_stubhead}()},
 \code{\link{tab_style}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/tab_header.Rd
+++ b/man/tab_header.Rd
@@ -54,7 +54,7 @@ Use \code{\link{gtcars}} to create a \strong{gt} table. Add a header part with t
 }
 
 \seealso{
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_footnote}()},
 \code{\link{tab_options}()},
 \code{\link{tab_row_group}()},
@@ -64,4 +64,4 @@ Other Create or Modify Parts:
 \code{\link{tab_stubhead}()},
 \code{\link{tab_style}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -524,7 +524,7 @@ Reduce the size of the title and the subtitle text.
 }
 
 \seealso{
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_footnote}()},
 \code{\link{tab_header}()},
 \code{\link{tab_row_group}()},
@@ -534,4 +534,4 @@ Other Create or Modify Parts:
 \code{\link{tab_stubhead}()},
 \code{\link{tab_style}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/tab_row_group.Rd
+++ b/man/tab_row_group.Rd
@@ -99,7 +99,7 @@ provided to the \code{rows} argument).
 }
 
 \seealso{
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_footnote}()},
 \code{\link{tab_header}()},
 \code{\link{tab_options}()},
@@ -109,4 +109,4 @@ Other Create or Modify Parts:
 \code{\link{tab_stubhead}()},
 \code{\link{tab_style}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/tab_source_note.Rd
+++ b/man/tab_source_note.Rd
@@ -47,7 +47,7 @@ source note to the table footer that cites the data source.
 }
 
 \seealso{
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_footnote}()},
 \code{\link{tab_header}()},
 \code{\link{tab_options}()},
@@ -57,4 +57,4 @@ Other Create or Modify Parts:
 \code{\link{tab_stubhead}()},
 \code{\link{tab_style}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/tab_spanner.Rd
+++ b/man/tab_spanner.Rd
@@ -92,7 +92,7 @@ column with the label \code{"performance"}.
 }
 
 \seealso{
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_footnote}()},
 \code{\link{tab_header}()},
 \code{\link{tab_options}()},
@@ -102,4 +102,4 @@ Other Create or Modify Parts:
 \code{\link{tab_stubhead}()},
 \code{\link{tab_style}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/tab_spanner_delim.Rd
+++ b/man/tab_spanner_delim.Rd
@@ -75,7 +75,7 @@ column labels (second part).
 }
 
 \seealso{
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_footnote}()},
 \code{\link{tab_header}()},
 \code{\link{tab_options}()},
@@ -85,4 +85,4 @@ Other Create or Modify Parts:
 \code{\link{tab_stubhead}()},
 \code{\link{tab_style}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/tab_stubhead.Rd
+++ b/man/tab_stubhead.Rd
@@ -49,7 +49,7 @@ is in the stub.
 }
 
 \seealso{
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_footnote}()},
 \code{\link{tab_header}()},
 \code{\link{tab_options}()},
@@ -59,4 +59,4 @@ Other Create or Modify Parts:
 \code{\link{tab_spanner}()},
 \code{\link{tab_style}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/tab_style.Rd
+++ b/man/tab_style.Rd
@@ -148,7 +148,7 @@ Use \code{\link{exibble}} to create a \strong{gt} table. Replace missing values 
 defining custom styles and \code{\link[=cells_body]{cells_body()}} as one of many useful helper
 functions for targeting the locations to be styled.
 
-Other Create or Modify Parts: 
+Other part creation/modification functions: 
 \code{\link{tab_footnote}()},
 \code{\link{tab_header}()},
 \code{\link{tab_options}()},
@@ -158,4 +158,4 @@ Other Create or Modify Parts:
 \code{\link{tab_spanner}()},
 \code{\link{tab_stubhead}()}
 }
-\concept{Create or Modify Parts}
+\concept{part creation/modification functions}

--- a/man/test_image.Rd
+++ b/man/test_image.Rd
@@ -25,9 +25,9 @@ since we test various sizes of the test image within that function.
 }
 
 \seealso{
-Other Image Addition Functions: 
+Other image addition functions: 
 \code{\link{ggplot_image}()},
 \code{\link{local_image}()},
 \code{\link{web_image}()}
 }
-\concept{Image Addition Functions}
+\concept{image addition functions}

--- a/man/text_transform.Rd
+++ b/man/text_transform.Rd
@@ -61,7 +61,7 @@ vector of column values from the \code{num} column.
 }
 
 \seealso{
-Other Format Data: 
+Other data formatting functions: 
 \code{\link{data_color}()},
 \code{\link{fmt_bytes}()},
 \code{\link{fmt_currency}()},
@@ -84,4 +84,4 @@ Other Format Data:
 \code{\link{sub_small_vals}()},
 \code{\link{sub_zero}()}
 }
-\concept{Format Data}
+\concept{data formatting functions}

--- a/man/web_image.Rd
+++ b/man/web_image.Rd
@@ -113,9 +113,9 @@ and five times in the subtitle.
 }
 
 \seealso{
-Other Image Addition Functions: 
+Other image addition functions: 
 \code{\link{ggplot_image}()},
 \code{\link{local_image}()},
 \code{\link{test_image}()}
 }
-\concept{Image Addition Functions}
+\concept{image addition functions}


### PR DESCRIPTION
Each exported function in gt is part of a family and given a family name (with the `@family` roxygen tag). When generated as .Rd files the family names are incorporated like this in the `See Also` help section:

`Other <family_name>: ...[.Rd links to other functions in the family]...`

Previously, the family names were written as standalone titles but they really need to be written to fit within this structure (lower case, preferably ending with 'functions'). This PR doesn't change familiar membership, it just modifies all of the family names in the source .R files (and the .Rd files were rebuilt). 