### PR TITLE
Ensure that unique IDs are maintained across columns spanners and column headers

### DIFF
--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -200,7 +200,8 @@ tab_spanner <- function(
     return(data)
   }
 
-  # Check new `id` against existing `id` values and stop if necessary
+  # Check new `id` against existing `id` values across column labels
+  # and spanner column labels and stop if necessary
   check_spanner_id_unique(data = data, spanner_id = id)
 
   # Resolve the `column_names` that new spanner will span over

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -486,11 +486,14 @@ tab_spanner_delim <- function(
 
       if (!is.na(spanners_i_values[j])) {
 
-        # Obtain the ID for the spanner
+        # Construct the ID for the spanner from the spanner matrix
         spanner_id <-
-          paste(
-            spanner_matrix[seq(i, nrow(spanner_matrix)), spanners_i_col_i[j]],
-            collapse = delim
+          paste0(
+            "spanner-",
+            paste(
+              spanner_matrix[seq(i, nrow(spanner_matrix)), spanners_i_col_i[j]],
+              collapse = delim
+            )
           )
 
         spanner_columns <-

--- a/R/utils.R
+++ b/R/utils.R
@@ -1767,13 +1767,16 @@ validate_style_in <- function(
 
 check_spanner_id_unique <- function(data, spanner_id) {
 
-  existing_ids <- dt_spanners_get_ids(data = data)
+  existing_column_ids <- dt_boxhead_get_vars(data = data)
+  existing_spanner_ids <- dt_spanners_get_ids(data = data)
 
-  if (spanner_id %in% existing_ids) {
+  all_existing_ids <- c(existing_column_ids, existing_spanner_ids)
+
+  if (spanner_id %in% all_existing_ids) {
 
     cli::cli_abort(c(
       "The spanner `id` provided (\"{spanner_id}\") is not unique.",
-      "*" = "The `id` must be unique across existing spanners.",
+      "*" = "The `id` must be unique across existing spanner and column IDs.",
       "*" = "Provide a unique ID value for this spanner."
     ))
   }

--- a/tests/testthat/test-util_functions.R
+++ b/tests/testthat/test-util_functions.R
@@ -617,6 +617,10 @@ test_that("The `check_spanner_id_unique()` function works properly", {
     gt(exibble) %>%
     tab_spanner(label = "a", columns = num)
 
+  gt_tbl_3 <-
+    gt(exibble, rowname_col = "row", groupname_col = "group") %>%
+    tab_spanner(label = "a", columns = c(num, char))
+
   # Don't expect an error when checking for unique spanner IDs
   # in a gt table with no spanner column labels
   expect_error(
@@ -628,6 +632,24 @@ test_that("The `check_spanner_id_unique()` function works properly", {
   # is used as the `id` value)
   expect_error(
     check_spanner_id_unique(data = gt_tbl_2, spanner_id = "a")
+  )
+
+  # Expect an error if creating a spanner ID that is the same as
+  # a column name
+  expect_error(
+    check_spanner_id_unique(data = gt_tbl_1, spanner_id = "num")
+  )
+  expect_error(
+    check_spanner_id_unique(data = gt_tbl_2, spanner_id = "num")
+  )
+  expect_error(
+    check_spanner_id_unique(data = gt_tbl_2, spanner_id = "num")
+  )
+  expect_error(
+    check_spanner_id_unique(data = gt_tbl_3, spanner_id = "row")
+  )
+  expect_error(
+    check_spanner_id_unique(data = gt_tbl_3, spanner_id = "group")
   )
 })
 


### PR DESCRIPTION
Currently, we use `check_spanner_id_unique()` to validate whether an ID value for a new column spanner is unique. The uniqueness check only considers the closed set of existing column spanner ID values. The changes here ensure that the column spanner IDs are unique across all cells that use the `<th>` tag (this includes column names and spanner column names).

Fixes: #991 