### PR TITLE
Remove dependency on checkmate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Depends:
 Imports:
     base64enc (>= 0.1-3),
     bitops (>= 1.0-7),
-    checkmate (>= 2.0.0),
     cli (>= 3.3.0),
     commonmark (>= 1.8),
     dplyr (>= 1.0.8),

--- a/R/build_data.R
+++ b/R/build_data.R
@@ -3,7 +3,8 @@
 #' @noRd
 build_data <- function(data, context) {
 
-  checkmate::assert_class(data, "gt_tbl")
+  # Perform input object validation
+  stop_if_not_gt(data = data)
 
   # Create `body` with rendered values; move
   # input data cells to `body` that didn't have

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -2242,20 +2242,14 @@ preprocess_tab_option <- function(option, var_name, type) {
       option
     )
 
-  # Perform checkmate assertions by `type`
+  # Perform `stopifnot()` checks by `type`
   switch(
     type,
-    logical = checkmate::assert_logical(
-      option, len = 1, any.missing = FALSE, .var.name = var_name
-    ),
-    overflow =,
-    px =,
-    value = checkmate::assert_character(
-      option, len = 1, any.missing = FALSE, .var.name = var_name
-    ),
-    values = checkmate::assert_character(
-      option, min.len = 1, any.missing = FALSE, .var.name = var_name
-    )
+    logical = stopifnot(rlang::is_scalar_logical(option), !any(is.na(option))),
+    overflow = ,
+    px = ,
+    value = stopifnot(rlang::is_scalar_character(option), !any(is.na(option))),
+    values = stopifnot(rlang::is_character(option), length(option) >= 1, !any(is.na(option)))
   )
 
   option

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -226,12 +226,6 @@ get_currency_decimals <- function(
 #' @noRd
 scale_x_values <- function(x, scale_by) {
 
-  checkmate::assert_numeric(
-    scale_by,
-    finite = TRUE,
-    any.missing = FALSE
-  )
-
   len <- length(scale_by)
 
   # Stop function if the length of `scale_by`


### PR DESCRIPTION
The `checkmate` package's assertion functions were not really used comprehensively in gt and we have robust checking throughout anyway. So, it seemed prudent to remove the dependency on that package and provide suitable assertion replacements where needed, and that's what this PR delivers. 
