### PR TITLE
Add return value for `gtsave()`

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -38,19 +38,22 @@
 #' document. The LaTeX and RTF saving functions don't have any options to pass
 #' to `...`.
 #'
-#' If the output filename extension is ".docx", a docx (word) file is produced. This process is
-#' facilitated by the **rmarkdown** package, so this package needs to be installed beofre attempting
-#' to save any table as a docx.
+#' If the output filename extension is `.docx`, a Word document file is
+#' produced. This process is facilitated by the **rmarkdown** package, so this
+#' package needs to be installed before attempting to save any table as a
+#' `.docx` document.
 #'
 #' @param data A table object that is created using the [gt()] function.
 #' @param filename The file name to create on disk. Ensure that an extension
 #'   compatible with the output types is provided (`.html`, `.tex`, `.ltx`,
-#'   `.rtf`, `.docx`). If a custom save function is provided then the file extension is
-#'   disregarded.
+#'   `.rtf`, `.docx`). If a custom save function is provided then the file
+#'   extension is disregarded.
 #' @param path An optional path to which the file should be saved (combined with
 #'   filename).
 #' @param ... All other options passed to the appropriate internal saving
 #'   function.
+#'
+#' @return Invisibly returns `TRUE` if the export process is successful.
 #'
 #' @section Examples:
 #'

--- a/R/export.R
+++ b/R/export.R
@@ -165,6 +165,8 @@ gtsave <- function(
       ))
     }
   )
+
+  invisible(TRUE)
 }
 
 #' Saving function for an HTML file

--- a/man/gtsave.Rd
+++ b/man/gtsave.Rd
@@ -11,14 +11,17 @@ gtsave(data, filename, path = NULL, ...)
 
 \item{filename}{The file name to create on disk. Ensure that an extension
 compatible with the output types is provided (\code{.html}, \code{.tex}, \code{.ltx},
-\code{.rtf}, \code{.docx}). If a custom save function is provided then the file extension is
-disregarded.}
+\code{.rtf}, \code{.docx}). If a custom save function is provided then the file
+extension is disregarded.}
 
 \item{path}{An optional path to which the file should be saved (combined with
 filename).}
 
 \item{...}{All other options passed to the appropriate internal saving
 function.}
+}
+\value{
+Invisibly returns \code{TRUE} if the export process is successful.
 }
 \description{
 The \code{gtsave()} function makes it easy to save a \strong{gt} table to a file. The
@@ -57,9 +60,10 @@ LaTeX document is produced. An output filename of \code{.rtf} will generate an R
 document. The LaTeX and RTF saving functions don't have any options to pass
 to \code{...}.
 
-If the output filename extension is ".docx", a docx (word) file is produced. This process is
-facilitated by the \strong{rmarkdown} package, so this package needs to be installed beofre attempting
-to save any table as a docx.
+If the output filename extension is \code{.docx}, a Word document file is
+produced. This process is facilitated by the \strong{rmarkdown} package, so this
+package needs to be installed before attempting to save any table as a
+\code{.docx} document.
 }
 \section{Examples}{
 


### PR DESCRIPTION
This adds a return value (`invisible(TRUE)`) to the bottom of the `gtsave()` function body. This clears up the issue of unwanted printing in R Markdown / Quarto documents and usefully returns `TRUE` in case the user needs to log the outcome of a `gtsave()` call. This also adds to and cleans up documentation in `gtsave()`.

Fixes https://github.com/rstudio/gt/issues/974

 