### PR TITLE
Use `&` instead of `&&` in `filter()` stmt

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -257,7 +257,7 @@ get_alignment_at_body_cell <- function(
   styles_filtered_tbl <-
     dplyr::filter(
       styles_tbl,
-      locname == "data" && colname == .env$colname && rownum == .env$rownum
+      locname == "data" & colname == .env$colname & rownum == .env$rownum
     )
 
   if (nrow(styles_tbl) < 1) {


### PR DESCRIPTION
This PR fixes an error in a `filter()` statement. The `&&`s should rightly be `&`s. This clears a warning with newer versions of R and correctly filters the table that this statement operates on.

Fixes: https://github.com/rstudio/gt/issues/1004
