### PR TITLE
Better integrate footnote marks with table cell text rendered with `fmt_markdown()`

### DIFF
--- a/R/z_utils_render_footnotes.R
+++ b/R/z_utils_render_footnotes.R
@@ -534,8 +534,7 @@ set_footnote_marks_stubhead <- function(data,
 #' Apply footnotes to the data rows
 #'
 #' @noRd
-apply_footnotes_to_output <- function(data,
-                                      context = "html") {
+apply_footnotes_to_output <- function(data, context = "html") {
 
   body <- dt_body_get(data = data)
   footnotes_tbl <- dt_footnotes_get(data = data)
@@ -585,9 +584,38 @@ apply_footnotes_to_output <- function(data,
       mark <- footnotes_dispatch[[context]](footnotes_data_marks$fs_id_coalesced[i])
 
       if (footnote_placement == "right") {
-        text <- paste0(text, mark)
+
+        # Footnote placement on the right of the cell text
+
+        if (context == "html" && grepl("</p>\n</div>$", text)) {
+
+          text <-
+            paste0(
+              gsub("</p>\n</div>", "", text, fixed = TRUE),
+              mark,
+              "</p></div>"
+            )
+
+        } else {
+          text <- paste0(text, mark)
+        }
+
       } else {
-        text <- paste0(mark, " ", text)
+
+        # Footnote placement on the left of the cell text
+
+        if (context == "html" && grepl("^<div class='gt_from_md'><p>", text)) {
+
+          text <-
+            paste0(
+              "<div class='gt_from_md'><p>",
+              mark, " ",
+              gsub("<div class='gt_from_md'><p>", "", text, fixed = TRUE)
+            )
+
+        } else {
+          text <- paste0(mark, " ", text)
+        }
       }
 
       body[footnotes_data_marks$rownum[i], footnotes_data_marks$colname[i]] <- text

--- a/tests/testthat/_snaps/tab_footnote.md
+++ b/tests/testthat/_snaps/tab_footnote.md
@@ -386,3 +386,17 @@
       
       }
 
+# Footnotes are correctly placed with text produced by `fmt_markdown()`
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\">char</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><td class=\"gt_row gt_left\"><div class='gt_from_md'><p>apricot<sup class=\"gt_footnote_marks\">1</sup></p></div></td></tr>\n  </tbody>\n  \n  <tfoot class=\"gt_footnotes\">\n    <tr>\n      <td class=\"gt_footnote\" colspan=\"1\"><sup class=\"gt_footnote_marks\">1</sup> note</td>\n    </tr>\n  </tfoot>\n</table>"
+
+---
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\">char</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><td class=\"gt_row gt_left\"><div class='gt_from_md'><p><sup class=\"gt_footnote_marks\">1</sup> apricot</p>\n</div></td></tr>\n  </tbody>\n  \n  <tfoot class=\"gt_footnotes\">\n    <tr>\n      <td class=\"gt_footnote\" colspan=\"1\"><sup class=\"gt_footnote_marks\">1</sup> note</td>\n    </tr>\n  </tfoot>\n</table>"
+

--- a/tests/testthat/test-tab_footnote.R
+++ b/tests/testthat/test-tab_footnote.R
@@ -1078,3 +1078,38 @@ test_that("The final placement of footnotes is correct with the 'auto' mode", {
     selection_text("[class='gt_row gt_center']") %>%
     expect_equal("0.11mark_1")
 })
+
+test_that("Footnotes are correctly placed with text produced by `fmt_markdown()`", {
+
+  exibble[1, 2] %>%
+    gt() %>%
+    fmt_markdown(columns = char) %>%
+    tab_footnote(footnote = "note", locations = cells_body(char, 1)) %>%
+    render_as_html() %>%
+    xml2::read_html() %>%
+    selection_text("[class='gt_row gt_left']") %>%
+    expect_equal("apricot1")
+
+  exibble[1, 2] %>%
+    gt() %>%
+    fmt_markdown(columns = char) %>%
+    tab_footnote(footnote = "note", locations = cells_body(char, 1)) %>%
+    render_as_html() %>%
+    expect_snapshot()
+
+  exibble[1, 2] %>%
+    gt() %>%
+    fmt_markdown(columns = char) %>%
+    tab_footnote(footnote = "note", locations = cells_body(char, 1), placement = "left") %>%
+    render_as_html() %>%
+    xml2::read_html() %>%
+    selection_text("[class='gt_row gt_left']") %>%
+    expect_equal("1 apricot\n")
+
+  exibble[1, 2] %>%
+    gt() %>%
+    fmt_markdown(columns = char) %>%
+    tab_footnote(footnote = "note", locations = cells_body(char, 1), placement = "left") %>%
+    render_as_html() %>%
+    expect_snapshot()
+})


### PR DESCRIPTION
This PR ensures that table body cell text generated from `fmt_markdown()` can have footnote marks inline with the produced text. This fix works both for right and left placement of the footnote marks. New testthat tests were added to address these changes.

Fixes: https://github.com/rstudio/gt/issues/993
Fixes: https://github.com/rstudio/gt/issues/893