### PR TITLE
Ensure that the row group labels in a two-column stub can render footnote marks

### DIFF
--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -804,11 +804,15 @@ create_body_component_h <- function(data) {
 
     cell_matrix <- cell_matrix[i, ]
 
-    if (
-      "group_label" %in% stub_layout &&
-      !(i %in% groups_rows_df$row_start)
-      ) {
+    if ("group_label" %in% stub_layout) {
+
+      if (!(i %in% groups_rows_df$row_start)) {
         cell_matrix <- cell_matrix[-1]
+      }
+      if (i %in% groups_rows_df$row_start) {
+        cell_matrix[1] <-
+          groups_rows_df[groups_rows_df$row_start == i, ][["group_label"]]
+      }
     }
 
     cell_matrix

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -810,8 +810,7 @@ create_body_component_h <- function(data) {
         cell_matrix <- cell_matrix[-1]
       }
       if (i %in% groups_rows_df$row_start) {
-        cell_matrix[1] <-
-          groups_rows_df[groups_rows_df$row_start == i, ][["group_label"]]
+        cell_matrix[1] <- groups_rows_df$group_label[groups_rows_df$row_start == i]
       }
     }
 

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -306,6 +306,14 @@ create_body_component_l <- function(data) {
   cell_matrix <- get_body_component_cell_matrix(data = data)
   row_splits_body <- split_row_content(cell_matrix)
 
+  if ("group_label" %in% stub_layout) {
+
+    for (i in seq_len(nrow(groups_rows_df))) {
+      row_splits_body[[groups_rows_df$row_start[i]]][1] <-
+        groups_rows_df$group_label[i]
+    }
+  }
+
   # Insert indentation where necessary
   if (has_stub_column && any(!is.na(stub_df$indent))) {
 

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -1384,9 +1384,11 @@ create_body_component_rtf <- function(data) {
   for (i in seq_len(n_rows)) {
 
     group_info <- groups_rows_df[groups_rows_df$row_start == i, c("group_id", "group_label")]
+
     if (nrow(group_info) == 0) {
       group_info <- NULL
     }
+
     group_id <- group_info[["group_id"]]
     group_label <- group_info[["group_label"]]
 
@@ -1437,9 +1439,11 @@ create_body_component_rtf <- function(data) {
               rtf_border("top", color = table_body_hlines_color, width = 10),
               rtf_border("bottom", color = table_body_hlines_color, width = 10)
             )
+
           if ("group_label" %in% stub_layout && x == 1) {
 
             if (i %in% groups_rows_df$row_start) {
+              cell_matrix[[i, x]] <- group_label
               top_bottom_borders[[2]] <- NULL
             } else if (i %in% groups_rows_df$row_end) {
               top_bottom_borders[[1]] <- NULL
@@ -1495,6 +1499,7 @@ create_body_component_rtf <- function(data) {
           widths = col_widths,
           height = 0
         )
+
     } else {
 
       body_row <-

--- a/R/z_utils_render_footnotes.R
+++ b/R/z_utils_render_footnotes.R
@@ -653,10 +653,11 @@ set_footnote_marks_row_groups <- function(data,
       row_index <-
         which(groups_rows_df[, "group_id"] == footnotes_row_groups_marks$grpname[i])
 
-      groups_rows_df[row_index, "group_label"] <- paste0(
-        groups_rows_df[row_index, "group_label"],
-        fn(footnotes_row_groups_marks$fs_id_coalesced[i])
-      )
+      groups_rows_df[row_index, "group_label"] <-
+        paste0(
+          groups_rows_df[row_index, "group_label"],
+          fn(footnotes_row_groups_marks$fs_id_coalesced[i])
+        )
     }
   }
 

--- a/tests/testthat/_snaps/tab_footnote.md
+++ b/tests/testthat/_snaps/tab_footnote.md
@@ -400,3 +400,155 @@
     Output
       [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\">char</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><td class=\"gt_row gt_left\"><div class='gt_from_md'><p><sup class=\"gt_footnote_marks\">1</sup> apricot</p>\n</div></td></tr>\n  </tbody>\n  \n  <tfoot class=\"gt_footnotes\">\n    <tr>\n      <td class=\"gt_footnote\" colspan=\"1\"><sup class=\"gt_footnote_marks\">1</sup> note</td>\n    </tr>\n  </tfoot>\n</table>"
 
+# Footnotes work with group labels in 2-column stub arrangements
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"2\" scope=\"colgroup\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_right\" rowspan=\"1\" colspan=\"1\" scope=\"col\">Pizzas Sold</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr class=\"gt_row_group_first\"><td rowspan=\"4\" class=\"gt_row gt_left gt_stub_row_group\">peppr_salami<sup class=\"gt_footnote_marks\">1</sup></td>\n<th scope=\"row\" class=\"gt_row gt_left gt_stub\">L</th>\n<td class=\"gt_row gt_right\">696</td></tr>\n    <tr><th scope=\"row\" class=\"gt_row gt_left gt_stub\">M</th>\n<td class=\"gt_row gt_right\">428</td></tr>\n    <tr><th scope=\"row\" class=\"gt_row gt_left gt_stub\">S</th>\n<td class=\"gt_row gt_right\">322</td></tr>\n    <tr><td class=\"gt_row gt_left gt_stub gt_summary_row gt_first_summary_row thick gt_last_summary_row\">TOTAL</td>\n<td class=\"gt_row gt_right gt_summary_row gt_first_summary_row thick gt_last_summary_row\">1,446</td></tr>\n    <tr class=\"gt_row_group_first\"><td rowspan=\"4\" class=\"gt_row gt_left gt_stub_row_group\">soppressata</td>\n<th scope=\"row\" class=\"gt_row gt_left gt_stub\">L</th>\n<td class=\"gt_row gt_right\">405</td></tr>\n    <tr><th scope=\"row\" class=\"gt_row gt_left gt_stub\">M</th>\n<td class=\"gt_row gt_right\">268</td></tr>\n    <tr><th scope=\"row\" class=\"gt_row gt_left gt_stub\">S</th>\n<td class=\"gt_row gt_right\">288</td></tr>\n    <tr><td class=\"gt_row gt_left gt_stub gt_summary_row gt_first_summary_row thick gt_last_summary_row\">TOTAL</td>\n<td class=\"gt_row gt_right gt_summary_row gt_first_summary_row thick gt_last_summary_row\">961</td></tr>\n  </tbody>\n  \n  <tfoot class=\"gt_footnotes\">\n    <tr>\n      <td class=\"gt_footnote\" colspan=\"3\"><sup class=\"gt_footnote_marks\">1</sup> The Pepper-Salami.</td>\n    </tr>\n  </tfoot>\n</table>"
+
+---
+
+    Code
+      .
+    Output
+      [1] "\\setlength{\\LTpost}{0mm}\n\\begin{longtable}{l|l|r}\n\\toprule\n\\multicolumn{2}{l}{} & Pizzas Sold \\\\ \n\\midrule\npeppr\\_salami\\textsuperscript{1} & L & 696 \\\\ \n & M & 428 \\\\ \n & S & 322 \\\\ \n\\cmidrule(l{-0.05em}r){2-3}\\multicolumn{1}{l|}{} & \\multicolumn{1}{l|}{TOTAL} & $1,446$ \\\\ \n\\midrule\nsoppressata & L & 405 \\\\ \n & M & 268 \\\\ \n & S & 288 \\\\ \n\\cmidrule(l{-0.05em}r){2-3}\\multicolumn{1}{l|}{} & \\multicolumn{1}{l|}{TOTAL} & $961$ \\\\ \n\\bottomrule\n\\end{longtable}\n\\begin{minipage}{\\linewidth}\n\\textsuperscript{1}The Pepper-Salami.\\\\\n\\end{minipage}\n"
+
+---
+
+    Code
+      .
+    Output
+      {\rtf\ansi\ansicpg1252{\fonttbl{\f0\froman\fcharset0\fprq0 Courier New;}{\f1\froman\fcharset0\fprq0 Times;}}{\colortbl;\red211\green211\blue211;}
+      
+      \paperw12240\paperh15840\widowctrl\ftnbj\fet0\sectd\linex0
+      \lndscpsxn
+      \margl1440\margr1440\margt1440\margb1440
+      \headery720\footery720\fs20
+      
+      \trowd\trrh0\trhdr
+      
+      \pard\plain\uc0\ql\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85\clbrdrb\brdrs\brdrw20\brdrcf1\clmgf \cellx3120
+      \intbl {\f0 {\f0\fs20 }}\cell
+      
+      \pard\plain\uc0\ql\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85\clbrdrb\brdrs\brdrw20\brdrcf1\clmrg \cellx6240
+      \intbl {\f0 {\f0\fs20 }}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85\clbrdrb\brdrs\brdrw20\brdrcf1 \cellx9360
+      \intbl {\f0 {\f0\fs20 Pizzas Sold}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+      \intbl {\f0 {\f0\fs20 peppr_salami{\super \i 1}}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+      \intbl {\f0 {\f0\fs20 L}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 696}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+      \intbl {\f0 {\f0\fs20 }}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+      \intbl {\f0 {\f0\fs20 M}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 428}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+      \intbl {\f0 {\f0\fs20 }}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+      \intbl {\f0 {\f0\fs20 S}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 322}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+      \intbl {\f0 {\f0\fs20 }}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+      \intbl {\f0 {\f0\fs20 TOTAL}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 1,446}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+      \intbl {\f0 {\f0\fs20 soppressata}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+      \intbl {\f0 {\f0\fs20 L}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 405}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+      \intbl {\f0 {\f0\fs20 }}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+      \intbl {\f0 {\f0\fs20 M}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 268}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+      \intbl {\f0 {\f0\fs20 }}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+      \intbl {\f0 {\f0\fs20 S}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 288}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+      \intbl {\f0 {\f0\fs20 }}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+      \intbl {\f0 {\f0\fs20 TOTAL}}\cell
+      
+      \pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 961}}\cell
+      
+      \row
+      
+      \trowd\trrh0
+      
+      \pard\plain\uc0\ql\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+      \intbl {\f0 {\f0\fs20 {\super \i 1}The Pepper-Salami.}}\cell
+      
+      \row
+      
+      }
+

--- a/tests/testthat/test-tab_footnote.R
+++ b/tests/testthat/test-tab_footnote.R
@@ -1113,3 +1113,31 @@ test_that("Footnotes are correctly placed with text produced by `fmt_markdown()`
     render_as_html() %>%
     expect_snapshot()
 })
+
+test_that("Footnotes work with group labels in 2-column stub arrangements", {
+
+  gt_tbl <-
+    pizzaplace %>%
+    dplyr::filter(name %in% c("soppressata", "peppr_salami")) %>%
+    dplyr::group_by(name, size) %>%
+    dplyr::summarize(`Pizzas Sold` = dplyr::n(), .groups = "drop") %>%
+    gt(rowname_col = "size", groupname_col = "name") %>%
+    summary_rows(
+      groups = TRUE,
+      columns = `Pizzas Sold`,
+      fns = list(TOTAL = "sum"),
+      formatter = fmt_number,
+      decimals = 0,
+      use_seps = TRUE
+    ) %>%
+    tab_options(row_group.as_column = TRUE) %>%
+    tab_footnote(
+      footnote = "The Pepper-Salami.",
+      locations = cells_row_groups(groups = "peppr_salami")
+    )
+
+  # Take snapshots of `gt_tbl`
+  gt_tbl %>% render_as_html() %>% expect_snapshot()
+  gt_tbl %>% as_latex() %>% as.character() %>% expect_snapshot()
+  gt_tbl %>% as_rtf() %>% expect_snapshot()
+})

--- a/text.rtf
+++ b/text.rtf
@@ -1,0 +1,132 @@
+{\rtf\ansi\ansicpg1252{\fonttbl{\f0\froman\fcharset0\fprq0 Courier New;}{\f1\froman\fcharset0\fprq0 Times;}}{\colortbl;\red211\green211\blue211;}
+
+\paperw12240\paperh15840\widowctrl\ftnbj\fet0\sectd\linex0
+\lndscpsxn
+\margl1440\margr1440\margt1440\margb1440
+\headery720\footery720\fs20
+
+\trowd\trrh0\trhdr
+
+\pard\plain\uc0\ql\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85\clbrdrb\brdrs\brdrw20\brdrcf1\clmgf \cellx3120
+\intbl {\f0 {\f0\fs20 }}\cell
+
+\pard\plain\uc0\ql\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85\clbrdrb\brdrs\brdrw20\brdrcf1\clmrg \cellx6240
+\intbl {\f0 {\f0\fs20 }}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85\clbrdrb\brdrs\brdrw20\brdrcf1 \cellx9360
+\intbl {\f0 {\f0\fs20 Pizzas Sold}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+\intbl {\f0 {\f0\fs20 peppr_salami{\super \i 1}}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+\intbl {\f0 {\f0\fs20 L}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 696}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+\intbl {\f0 {\f0\fs20 }}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+\intbl {\f0 {\f0\fs20 M}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 428}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+\intbl {\f0 {\f0\fs20 }}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+\intbl {\f0 {\f0\fs20 S}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 322}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+\intbl {\f0 {\f0\fs20 }}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+\intbl {\f0 {\f0\fs20 TOTAL}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 1,446}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+\intbl {\f0 {\f0\fs20 soppressata}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+\intbl {\f0 {\f0\fs20 L}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 405}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+\intbl {\f0 {\f0\fs20 }}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+\intbl {\f0 {\f0\fs20 M}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 268}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+\intbl {\f0 {\f0\fs20 }}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+\intbl {\f0 {\f0\fs20 S}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 288}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx3120
+\intbl {\f0 {\f0\fs20 }}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx6240
+\intbl {\f0 {\f0\fs20 TOTAL}}\cell
+
+\pard\plain\uc0\qr\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 961}}\cell
+
+\row
+
+\trowd\trrh0
+
+\pard\plain\uc0\ql\clvertalc \clpadfl3\clpadl25 \clpadft3\clpadt85 \clpadfb3\clpadb25 \clpadfr3\clpadr85 \cellx9360
+\intbl {\f0 {\f0\fs20 {\super \i 1}The Pepper-Salami.}}\cell
+
+\row
+
+}


### PR DESCRIPTION
When formatting a table with a two-column stub arrangement, the group label wasn't being used to generate the cell matrix (the left-most cell corresponding to a group label was taken from the table body). This is wrong as the group labels are placed in the `groups_rows_df` table, where they undergo rendering and that's where footnote marks are affixed to them.

This PR modifies the body row rendering in the separate HTML, LaTeX, and RTF implementations. Several snapshot tests have been added to capture the fix. Here is the code that illustrates the problem, with a screenshot showing that the change was successful.

```r
pizzaplace %>%
  dplyr::filter(name %in% c("soppressata", "peppr_salami")) %>%
  dplyr::group_by(name, size) %>%
  dplyr::summarize(`Pizzas Sold` = dplyr::n(), .groups = "drop") %>%
  gt(rowname_col = "size", groupname_col = "name") %>%
  summary_rows(
    groups = TRUE,
    columns = `Pizzas Sold`,
    fns = list(TOTAL = "sum"),
    formatter = fmt_number,
    decimals = 0,
    use_seps = TRUE
  ) %>%
  tab_options(row_group.as_column = TRUE) %>%
  tab_footnote(
    footnote = "The Pepper-Salami.",
    cells_row_groups(groups = "peppr_salami")
  )
```

<img width="1108" alt="group-label-footnote-fix" src="https://user-images.githubusercontent.com/5612024/185296852-8043cd4b-e3e5-435e-8b4d-2eafd2388246.png">

Fixes: https://github.com/rstudio/gt/issues/1001

