### PR TITLE
Fix spanner ID generation in `tab_spanner_delim()`

### DIFF
--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -391,6 +391,7 @@ tab_spanner_delim <- function(
       expr = {{ columns }},
       data = data
     )
+
   if (!is.null(columns)) {
     colnames_spanners <- base::intersect(all_cols, columns)
   } else {
@@ -482,6 +483,8 @@ tab_spanner_delim <- function(
     spanners_i_values <- rle_spanners_i$values
     spanners_i_col_i <- utils::head(cumsum(c(1, spanners_i_lengths)), -1)
 
+    spanner_id_vals <- c()
+
     for (j in seq_along(spanners_i_lengths)) {
 
       if (!is.na(spanners_i_values[j])) {
@@ -495,6 +498,26 @@ tab_spanner_delim <- function(
               collapse = delim
             )
           )
+
+        # Modify `spanner_id` to not collide with any other values
+        if (spanner_id %in% spanner_id_vals) {
+
+          if (grepl("^spanner-", spanner_id)) {
+
+            # Add number to spanner ID values on first duplication
+            spanner_id <- gsub("^spanner-", "spanner:1-", spanner_id)
+          }
+
+          while (spanner_id %in% spanner_id_vals) {
+
+            # Increment number to spanner ID values on subsequent duplications
+            idx_str <- gsub("^spanner:([0-9]+)-.*", "\\1", spanner_id)
+            idx_int <- as.integer(idx_str)
+            spanner_id <- gsub("^(spanner:)[0-9]+(-.*)", paste0("\\1", idx_int + 1, "\\2"), spanner_id)
+          }
+        }
+
+        spanner_id_vals <- unique(c(spanner_id_vals, spanner_id))
 
         spanner_columns <-
           seq(

--- a/tests/testthat/test-tab_spanner_delim.R
+++ b/tests/testthat/test-tab_spanner_delim.R
@@ -650,9 +650,9 @@ test_that("`tab_spanner_delim()` works with complex splits", {
     regexp = NA,
     gt_tbl %>%
       tab_spanner_delim(
-      delim = ".",
-      split = "first"
-    )
+        delim = ".",
+        split = "first"
+      )
   )
   expect_error(
     regexp = NA,

--- a/tests/testthat/test-tab_spanner_delim.R
+++ b/tests/testthat/test-tab_spanner_delim.R
@@ -623,3 +623,43 @@ test_that("`tab_spanner_delim()` works on higher-order spanning", {
   # Take snapshots of `gt_tbl_6_yzzz`
   gt_tbl_6_yzzz %>% render_as_html() %>% expect_snapshot()
 })
+
+test_that("`tab_spanner_delim()` works with complex splits", {
+
+  # Create a gt table with two levels of spanners that repeat
+  gt_tbl <-
+    dplyr::tibble(
+      a.i.x = "",
+      b.i.x = "",
+      a.j.x = "",
+      b.j.x = "",
+      a.i.y = "",
+      b.i.y = "",
+      a.j.y = "",
+      b.j.y = "",
+      a.i.z = "",
+      b.i.z = "",
+      a.j.z = "",
+      b.j.z = ""
+    ) %>%
+    gt()
+
+  # Ensure that `tab_spanner_delim()` doesn't fail with
+  # either of the `split` options
+  expect_error(
+    regexp = NA,
+    gt_tbl %>%
+      tab_spanner_delim(
+      delim = ".",
+      split = "first"
+    )
+  )
+  expect_error(
+    regexp = NA,
+    gt_tbl %>%
+      tab_spanner_delim(
+        delim = ".",
+        split = "last"
+      )
+  )
+})

--- a/tests/testthat/test-tab_spanner_delim.R
+++ b/tests/testthat/test-tab_spanner_delim.R
@@ -662,4 +662,43 @@ test_that("`tab_spanner_delim()` works with complex splits", {
         split = "last"
       )
   )
+
+  #
+  # Ensure that the generated IDs correctly increments their index
+  # values where appropriate
+  #
+
+  first_delim <-
+    gt_tbl %>%
+    tab_spanner_delim(
+      delim = ".",
+      split = "first"
+    )
+
+  expect_equal(
+    first_delim$`_spanners`$spanner_id,
+    c(
+      "spanner-i.a", "spanner-j.a", "spanner:1-i.a", "spanner:1-j.a",
+      "spanner:2-i.a", "spanner:2-j.a", "spanner-x.i.a", "spanner-y.i.a",
+      "spanner-z.i.a"
+    )
+  )
+
+  last_delim <-
+    gt_tbl %>%
+    tab_spanner_delim(
+      delim = ".",
+      split = "last"
+    )
+
+  expect_equal(
+    last_delim$`_spanners`$spanner_id,
+    c(
+      "spanner-i.x", "spanner-j.x", "spanner-i.y", "spanner-j.y",
+      "spanner-i.z", "spanner-j.z", "spanner-a.i.x", "spanner-b.i.x",
+      "spanner-a.j.x", "spanner-b.j.x", "spanner-a.i.y", "spanner-b.i.y",
+      "spanner-a.j.y", "spanner-b.j.y", "spanner-a.i.z", "spanner-b.i.z",
+      "spanner-a.j.z", "spanner-b.j.z"
+    )
+  )
 })


### PR DESCRIPTION
In more complex situations, `tab_spanner_delim()` would fail to generate unique ID values. This is now fixed by adding an index to the first-duplicated ID value and incrementing by 1 for subsequent duplications. Now this works:

```r
library(tidyverse)
library(gt)

dplyr::tibble(
      a.i.x = "",
      b.i.x = "",
      a.j.x = "",
      b.j.x = "",
      a.i.y = "",
      b.i.y = "",
      a.j.y = "",
      b.j.y = "",
      a.i.z = "",
      b.i.z = "",
      a.j.z = "",
      b.j.z = ""
    ) %>%
      gt() %>%
      tab_spanner_delim(
        delim = ".",
        split = "first"
      )
```

<img width="946" alt="tab-spanner-delim-fix" src="https://user-images.githubusercontent.com/5612024/185709688-b7186175-5857-4663-8f61-5aa217f177c7.png">

Also, using `split = "last"` also works. Added several testthat tests for this.

Fixes: https://github.com/rstudio/gt/issues/1000
