### PR TITLE
Update as_latex() documentation to include steps to take to ensure dependencies are present when rendering the document. 

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -427,6 +427,28 @@ as_raw_html <- function(
 #'
 #' @param data A table object that is created using the [gt()] function.
 #'
+#' @details
+#' LaTeX packages required to generate tables are:
+#' `r paste0(gt:::latex_packages(), collapse = ", ")`.
+#'
+#' In the event packages are not automatically added during the render phase
+#' of the document, please create and include a style file to load them.
+#'
+#' Inside the document's YAML metadata, please include:
+#'
+#' \preformatted{
+#' output:
+#'   pdf_document: # Change to appropriate LaTeX template
+#'     includes:
+#'       in_header: 'gt_packages.sty'
+#' }
+#'
+#' The `gt_packages.sty` file would then contain the listed dependencies above:
+#'
+#' \preformatted{
+#'   \usepackage{amsmath, booktabs, caption, longtable}
+#' }
+#'
 #' @section Examples:
 #'
 #' Use [`gtcars`] to create a **gt** table. Add a header and then export as an

--- a/man/as_latex.Rd
+++ b/man/as_latex.Rd
@@ -16,6 +16,28 @@ dependencies (i.e., the LaTeX packages required for the table). Using
 \code{as.character()} on the created object will result in a single-element vector
 containing the LaTeX code.
 }
+\details{
+LaTeX packages required to generate tables are:
+amsmath, booktabs, caption, longtable.
+
+In the event packages are not automatically added during the render phase
+of the document, please create and include a style file to load them.
+
+Inside the document's YAML metadata, please include:
+
+\preformatted{
+output:
+  pdf_document: # Change to appropriate LaTeX template
+    includes:
+      in_header: 'gt_packages.sty'
+}
+
+The \code{gt_packages.sty} file would then contain the listed dependencies above:
+
+\preformatted{
+  \usepackage{amsmath, booktabs, caption, longtable}
+}
+}
 \section{Examples}{
 
 


### PR DESCRIPTION
When I was working with a custom beamer template, the `as_latex()` function didn't add the appropriate package dependencies to the header. I've added a bit of documentation to emphasize the requirements and steps to take to ensure smooth sailing.

<img width="598" alt="Screen Shot 2020-06-30 at 1 06 08 PM" src="https://user-images.githubusercontent.com/833642/86161219-8d047700-bad2-11ea-8aee-39cb85b4e708.png">


Resubmission of #615 

Close #615