### PR TITLE
Update print.R

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -24,7 +24,8 @@ knitr_is_rtf_output <- function() {
 
 knitr_is_word_output <- function() {
 
-  "word_document" %in% rmarkdown::all_output_formats(knitr::current_input())
+  "word_document" %in% rmarkdown::all_output_formats(knitr::current_input()) |
+  "docx" %in% knitr::opts_knit$get("rmarkdown.pandoc.to")
 }
 
 #' Knit print the table


### PR DESCRIPTION
Should resolve #1034 by changing how the gt determines if the output should be word

# Summary

Thank you for contributing to **gt**! To make this process easier for everyone, please explain the context and purpose of your contribution. Also, list the changes made to the existing code or documentation.

Currently outputs to word are determined by looking if the output format  is "word_document". This fails for bookdown::word_document2. I've added checks for what output type it is rendering to, so I _think_ would be more flexible? it matches the rtf but would preserve current functionality.

# Related GitHub Issues and PRs

- Ref: #1034

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.

Not sure how you've tested this in the past, but willing to sort out some tests if you want.