### PR TITLE
Include `"day_m"` option in `fmt_date()` and `vec_fmt_date()`

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -2251,11 +2251,12 @@ fmt_bytes <- function(
 #' 7. `"day_m_year"`: `29 Feb 2000`
 #' 8. `"day_month_year"`: `29 February 2000`
 #' 9. `"day_month"`: `29 February`
-#' 10. `"year"`: `2000`
-#' 11. `"month"`: `February`
-#' 12. `"day"`: `29`
-#' 13. `"year.mn.day"`: `2000/02/29`
-#' 14. `"y.mn.day"`: `00/02/29`
+#' 10. `"day_m"`: `29 Feb`
+#' 11. `"year"`: `2000`
+#' 12. `"month"`: `February`
+#' 13. `"day"`: `29`
+#' 14. `"year.mn.day"`: `2000/02/29`
+#' 15. `"y.mn.day"`: `00/02/29`
 #'
 #' We can use the [info_date_style()] function for a useful reference on all of
 #' the possible inputs to `date_style`.
@@ -2267,7 +2268,7 @@ fmt_bytes <- function(
 #' argument. See the *Arguments* section for more information on this.
 #'
 #' @inheritParams fmt_number
-#' @param date_style The date style to use. Supply a number (from `1` to `14`)
+#' @param date_style The date style to use. Supply a number (from `1` to `15`)
 #'   that corresponds to the preferred date style, or, provide a named date
 #'   style (`"wday_month_day_year"`, `"m_day_year"`, `"year.mn.day"`, etc.). Use
 #'   [info_date_style()] to see the different numbered and named date presets.
@@ -2329,7 +2330,7 @@ fmt_date <- function(
     data,
     columns,
     rows = everything(),
-    date_style = 2,
+    date_style = 1,
     pattern = "{x}"
 ) {
 
@@ -2485,7 +2486,7 @@ fmt_time <- function(
     data,
     columns,
     rows = everything(),
-    time_style = 2,
+    time_style = 1,
     pattern = "{x}"
 ) {
 
@@ -2581,11 +2582,12 @@ fmt_time <- function(
 #' 7. `"day_m_year"`: `29 Feb 2000`
 #' 8. `"day_month_year"`: `29 February 2000`
 #' 9. `"day_month"`: `29 February`
-#' 10. `"year"`: `2000`
-#' 11. `"month"`: `February`
-#' 12. `"day"`: `29`
-#' 13. `"year.mn.day"`: `2000/02/29`
-#' 14. `"y.mn.day"`: `00/02/29`
+#' 10. `"day_m"`: `29 Feb`
+#' 11. `"year"`: `2000`
+#' 12. `"month"`: `February`
+#' 13. `"day"`: `29`
+#' 14. `"year.mn.day"`: `2000/02/29`
+#' 15. `"y.mn.day"`: `00/02/29`
 #'
 #' The following time styles are available for formatting of the time portion
 #' (all using the input time of `14:35:00` in the example output times):
@@ -2706,8 +2708,8 @@ fmt_datetime <- function(
     data,
     columns,
     rows = everything(),
-    date_style = 2,
-    time_style = 2,
+    date_style = 1,
+    time_style = 1,
     sep = " ",
     format = NULL,
     tz = NULL,

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -1573,17 +1573,18 @@ vec_fmt_bytes <- function(
 #' 7. `"day_m_year"`: `29 Feb 2000`
 #' 8. `"day_month_year"`: `29 February 2000`
 #' 9. `"day_month"`: `29 February`
-#' 10. `"year"`: `2000`
-#' 11. `"month"`: `February`
-#' 12. `"day"`: `29`
-#' 13. `"year.mn.day"`: `2000/02/29`
-#' 14. `"y.mn.day"`: `00/02/29`
+#' 10. `"day_m"`: `29 Feb`
+#' 11. `"year"`: `2000`
+#' 12. `"month"`: `February`
+#' 13. `"day"`: `29`
+#' 14. `"year.mn.day"`: `2000/02/29`
+#' 15. `"y.mn.day"`: `00/02/29`
 #'
 #' We can use the [info_date_style()] function for a useful reference on all of
 #' the possible inputs to `date_style`.
 #'
 #' @inheritParams vec_fmt_number
-#' @param date_style The date style to use. Supply a number (from `1` to `14`)
+#' @param date_style The date style to use. Supply a number (from `1` to `15`)
 #'   that corresponds to the preferred date style, or, provide a named date
 #'   style (`"wday_month_day_year"`, `"m_day_year"`, `"year.mn.day"`, etc.). Use
 #'   [info_date_style()] to see the different numbered and named date presets.
@@ -1612,7 +1613,7 @@ vec_fmt_bytes <- function(
 #' #> [3] "Monday, March 23, 2015" NA
 #' ```
 #'
-#' We can change the formatting style by choosing a number from `1` to `14`:
+#' We can change the formatting style by choosing a number from `1` to `15`:
 #'
 #' ```r
 #' vec_fmt_date(str_vals, date_style = 6)
@@ -1643,7 +1644,7 @@ vec_fmt_bytes <- function(
 #' @export
 vec_fmt_date <- function(
     x,
-    date_style = 2,
+    date_style = 1,
     pattern = "{x}",
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
@@ -1756,7 +1757,7 @@ vec_fmt_date <- function(
 #' @export
 vec_fmt_time <- function(
     x,
-    time_style = 2,
+    time_style = 1,
     pattern = "{x}",
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
@@ -1813,11 +1814,12 @@ vec_fmt_time <- function(
 #' 7. `"day_m_year"`: `29 Feb 2000`
 #' 8. `"day_month_year"`: `29 February 2000`
 #' 9. `"day_month"`: `29 February`
-#' 10. `"year"`: `2000`
-#' 11. `"month"`: `February`
-#' 12. `"day"`: `29`
-#' 13. `"year.mn.day"`: `2000/02/29`
-#' 14. `"y.mn.day"`: `00/02/29`
+#' 10. `"day_m"`: `29 Feb`
+#' 11. `"year"`: `2000`
+#' 12. `"month"`: `February`
+#' 13. `"day"`: `29`
+#' 14. `"year.mn.day"`: `2000/02/29`
+#' 15. `"y.mn.day"`: `00/02/29`
 #'
 #' The following time styles are available for formatting of the time portion
 #' (all using the input time of `14:35:00` in the example output times):
@@ -1925,7 +1927,7 @@ vec_fmt_time <- function(
 #' ```
 #'
 #' We can change the formatting style of the date and time portions separately
-#' with the `date_style` (values `1`-`14`) and `time_style` (values `1`-`5`)
+#' with the `date_style` (values `1`-`15`) and `time_style` (values `1`-`5`)
 #' arguments. The `sep` option allows for a customized separator string between
 #' the date and time.
 #'
@@ -1984,8 +1986,8 @@ vec_fmt_time <- function(
 #' @export
 vec_fmt_datetime <- function(
     x,
-    date_style = 2,
-    time_style = 2,
+    date_style = 1,
+    time_style = 1,
     sep = " ",
     format = NULL,
     tz = NULL,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,7 @@
-#' Create a tibble containing date formats
+#' Get a tibble containing date formats
 #'
 #' @noRd
 date_formats <- function() {
-
   dplyr::tribble(
     ~format_number, ~format_name,           ~format_code,
     "1",	          "iso",                  "%F",
@@ -14,25 +13,27 @@ date_formats <- function() {
     "7",	          "day_m_year",           "%d %b %Y",
     "8",	          "day_month_year",       "%d %B %Y",
     "9",	          "day_month",            "%d %B",
-    "10",	          "year",                 "%Y",
-    "11",	          "month",                "%B",
-    "12",	          "day",                  "%d",
-    "13",	          "year.mn.day",          "%Y/%m/%d",
-    "14",	          "y.mn.day",             "%y/%m/%d")
+    "10",	          "day_m",                "%d %b",
+    "11",	          "year",                 "%Y",
+    "12",	          "month",                "%B",
+    "13",	          "day",                  "%d",
+    "14",	          "year.mn.day",          "%Y/%m/%d",
+    "15",	          "y.mn.day",             "%y/%m/%d"
+  )
 }
 
-#' Create a tibble containing time formats
+#' Get a tibble containing time formats
 #'
 #' @noRd
 time_formats <- function() {
-
   dplyr::tribble(
     ~format_number, ~format_name, ~format_code,
     "1",	          "hms",        "%H:%M:%S",
     "2",	          "hm",         "%H:%M",
     "3",	          "hms_p",      "%I:%M:%S %P",
     "4",	          "hm_p",       "%I:%M %P",
-    "5",	          "h_p",        "%I %P")
+    "5",	          "h_p",        "%I %P"
+  )
 }
 
 #' Transform a `date_style` to a `date_format`

--- a/man/fmt_date.Rd
+++ b/man/fmt_date.Rd
@@ -4,7 +4,7 @@
 \alias{fmt_date}
 \title{Format values as dates}
 \usage{
-fmt_date(data, columns, rows = everything(), date_style = 2, pattern = "{x}")
+fmt_date(data, columns, rows = everything(), date_style = 1, pattern = "{x}")
 }
 \arguments{
 \item{data}{A table object that is created using the \code{\link[=gt]{gt()}} function.}
@@ -24,7 +24,7 @@ functions are: \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with
 to filter down to the rows we need (e.g.,
 \verb{[colname_1] > 100 & [colname_2] < 50}).}
 
-\item{date_style}{The date style to use. Supply a number (from \code{1} to \code{14})
+\item{date_style}{The date style to use. Supply a number (from \code{1} to \code{15})
 that corresponds to the preferred date style, or, provide a named date
 style (\code{"wday_month_day_year"}, \code{"m_day_year"}, \code{"year.mn.day"}, etc.). Use
 \code{\link[=info_date_style]{info_date_style()}} to see the different numbered and named date presets.}
@@ -56,6 +56,7 @@ following date styles are available for use (all using the input date of
 \item \code{"day_m_year"}: \verb{29 Feb 2000}
 \item \code{"day_month_year"}: \verb{29 February 2000}
 \item \code{"day_month"}: \verb{29 February}
+\item \code{"day_m"}: \verb{29 Feb}
 \item \code{"year"}: \code{2000}
 \item \code{"month"}: \code{February}
 \item \code{"day"}: \code{29}

--- a/man/fmt_datetime.Rd
+++ b/man/fmt_datetime.Rd
@@ -8,8 +8,8 @@ fmt_datetime(
   data,
   columns,
   rows = everything(),
-  date_style = 2,
-  time_style = 2,
+  date_style = 1,
+  time_style = 1,
   sep = " ",
   format = NULL,
   tz = NULL,
@@ -34,7 +34,7 @@ functions are: \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with
 to filter down to the rows we need (e.g.,
 \verb{[colname_1] > 100 & [colname_2] < 50}).}
 
-\item{date_style}{The date style to use. Supply a number (from \code{1} to \code{14})
+\item{date_style}{The date style to use. Supply a number (from \code{1} to \code{15})
 that corresponds to the preferred date style, or, provide a named date
 style (\code{"wday_month_day_year"}, \code{"m_day_year"}, \code{"year.mn.day"}, etc.). Use
 \code{\link[=info_date_style]{info_date_style()}} to see the different numbered and named date presets.}
@@ -87,6 +87,7 @@ output dates):
 \item \code{"day_m_year"}: \verb{29 Feb 2000}
 \item \code{"day_month_year"}: \verb{29 February 2000}
 \item \code{"day_month"}: \verb{29 February}
+\item \code{"day_m"}: \verb{29 Feb}
 \item \code{"year"}: \code{2000}
 \item \code{"month"}: \code{February}
 \item \code{"day"}: \code{29}

--- a/man/fmt_time.Rd
+++ b/man/fmt_time.Rd
@@ -4,7 +4,7 @@
 \alias{fmt_time}
 \title{Format values as times}
 \usage{
-fmt_time(data, columns, rows = everything(), time_style = 2, pattern = "{x}")
+fmt_time(data, columns, rows = everything(), time_style = 1, pattern = "{x}")
 }
 \arguments{
 \item{data}{A table object that is created using the \code{\link[=gt]{gt()}} function.}

--- a/man/vec_fmt_date.Rd
+++ b/man/vec_fmt_date.Rd
@@ -6,7 +6,7 @@
 \usage{
 vec_fmt_date(
   x,
-  date_style = 2,
+  date_style = 1,
   pattern = "{x}",
   output = c("auto", "plain", "html", "latex", "rtf", "word")
 )
@@ -14,7 +14,7 @@ vec_fmt_date(
 \arguments{
 \item{x}{A numeric vector.}
 
-\item{date_style}{The date style to use. Supply a number (from \code{1} to \code{14})
+\item{date_style}{The date style to use. Supply a number (from \code{1} to \code{15})
 that corresponds to the preferred date style, or, provide a named date
 style (\code{"wday_month_day_year"}, \code{"m_day_year"}, \code{"year.mn.day"}, etc.). Use
 \code{\link[=info_date_style]{info_date_style()}} to see the different numbered and named date presets.}
@@ -50,6 +50,7 @@ in the example output dates):
 \item \code{"day_m_year"}: \verb{29 Feb 2000}
 \item \code{"day_month_year"}: \verb{29 February 2000}
 \item \code{"day_month"}: \verb{29 February}
+\item \code{"day_m"}: \verb{29 Feb}
 \item \code{"year"}: \code{2000}
 \item \code{"month"}: \code{February}
 \item \code{"day"}: \code{29}
@@ -81,7 +82,7 @@ argument (here, it is of the \code{"plain"} output type).
 #> [3] "Monday, March 23, 2015" NA
 }\if{html}{\out{</div>}}
 
-We can change the formatting style by choosing a number from \code{1} to \code{14}:
+We can change the formatting style by choosing a number from \code{1} to \code{15}:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{vec_fmt_date(str_vals, date_style = 6)
 }\if{html}{\out{</div>}}

--- a/man/vec_fmt_datetime.Rd
+++ b/man/vec_fmt_datetime.Rd
@@ -6,8 +6,8 @@
 \usage{
 vec_fmt_datetime(
   x,
-  date_style = 2,
-  time_style = 2,
+  date_style = 1,
+  time_style = 1,
   sep = " ",
   format = NULL,
   tz = NULL,
@@ -18,7 +18,7 @@ vec_fmt_datetime(
 \arguments{
 \item{x}{A numeric vector.}
 
-\item{date_style}{The date style to use. Supply a number (from \code{1} to \code{14})
+\item{date_style}{The date style to use. Supply a number (from \code{1} to \code{15})
 that corresponds to the preferred date style, or, provide a named date
 style (\code{"wday_month_day_year"}, \code{"m_day_year"}, \code{"year.mn.day"}, etc.). Use
 \code{\link[=info_date_style]{info_date_style()}} to see the different numbered and named date presets.}
@@ -77,6 +77,7 @@ output dates):
 \item \code{"day_m_year"}: \verb{29 Feb 2000}
 \item \code{"day_month_year"}: \verb{29 February 2000}
 \item \code{"day_month"}: \verb{29 February}
+\item \code{"day_m"}: \verb{29 Feb}
 \item \code{"year"}: \code{2000}
 \item \code{"month"}: \code{February}
 \item \code{"day"}: \code{29}
@@ -178,7 +179,7 @@ argument (here, it is of the \code{"plain"} output type).
 }\if{html}{\out{</div>}}
 
 We can change the formatting style of the date and time portions separately
-with the \code{date_style} (values \code{1}-\code{14}) and \code{time_style} (values \code{1}-\code{5})
+with the \code{date_style} (values \code{1}-\code{15}) and \code{time_style} (values \code{1}-\code{5})
 arguments. The \code{sep} option allows for a customized separator string between
 the date and time.
 

--- a/man/vec_fmt_time.Rd
+++ b/man/vec_fmt_time.Rd
@@ -6,7 +6,7 @@
 \usage{
 vec_fmt_time(
   x,
-  time_style = 2,
+  time_style = 1,
   pattern = "{x}",
   output = c("auto", "plain", "html", "latex", "rtf", "word")
 )

--- a/tests/testthat/test-fmt_date_time.R
+++ b/tests/testthat/test-fmt_date_time.R
@@ -70,60 +70,74 @@ test_that("the `fmt_date()` function works correctly", {
       (tab %>%
          fmt_date(columns = "date", date_style = 2) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("Sunday, October 15, 2017", "Friday, February 22, 2013",
+      c(
+        "Sunday, October 15, 2017", "Friday, February 22, 2013",
         "Monday, September 22, 2014", "Wednesday, January 10, 2018",
-        "Saturday, January 1, 2000")
+        "Saturday, January 1, 2000"
+      )
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 3) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("Sun, Oct 15, 2017", "Fri, Feb 22, 2013",
+      c(
+        "Sun, Oct 15, 2017", "Fri, Feb 22, 2013",
         "Mon, Sep 22, 2014", "Wed, Jan 10, 2018",
-        "Sat, Jan 1, 2000")
+        "Sat, Jan 1, 2000"
+      )
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 4) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("Sunday 15 October 2017", "Friday 22 February 2013",
+      c(
+        "Sunday 15 October 2017", "Friday 22 February 2013",
         "Monday 22 September 2014", "Wednesday 10 January 2018",
-        "Saturday 1 January 2000")
+        "Saturday 1 January 2000"
+      )
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 5) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("October 15, 2017", "February 22, 2013",
+      c(
+        "October 15, 2017", "February 22, 2013",
         "September 22, 2014", "January 10, 2018",
-        "January 1, 2000")
+        "January 1, 2000"
+      )
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 6) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("Oct 15, 2017", "Feb 22, 2013", "Sep 22, 2014",
-        "Jan 10, 2018", "Jan 1, 2000")
+      c(
+        "Oct 15, 2017", "Feb 22, 2013", "Sep 22, 2014",
+        "Jan 10, 2018", "Jan 1, 2000"
+      )
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 7) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("15 Oct 2017", "22 Feb 2013", "22 Sep 2014",
-        "10 Jan 2018", "1 Jan 2000")
+      c(
+        "15 Oct 2017", "22 Feb 2013", "22 Sep 2014",
+        "10 Jan 2018", "1 Jan 2000"
+      )
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 8) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("15 October 2017", "22 February 2013", "22 September 2014",
-        "10 January 2018", "1 January 2000")
+      c(
+        "15 October 2017", "22 February 2013", "22 September 2014",
+        "10 January 2018", "1 January 2000"
+      )
     )
 
     expect_equal(
@@ -137,33 +151,40 @@ test_that("the `fmt_date()` function works correctly", {
       (tab %>%
          fmt_date(columns = "date", date_style = 10) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("2017", "2013", "2014", "2018", "2000")
+      c("15 Oct", "22 Feb", "22 Sep", "10 Jan", "1 Jan")
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 11) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("October", "February", "September", "January", "January")
+      c("2017", "2013", "2014", "2018", "2000")
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 12) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("15", "22", "22", "10", "01")
+      c("October", "February", "September", "January", "January")
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 13) %>%
          render_formats_test(context = "html"))[["date"]],
-      c("2017/10/15", "2013/02/22", "2014/09/22", "2018/01/10", "2000/01/01")
+      c("15", "22", "22", "10", "01")
     )
 
     expect_equal(
       (tab %>%
          fmt_date(columns = "date", date_style = 14) %>%
+         render_formats_test(context = "html"))[["date"]],
+      c("2017/10/15", "2013/02/22", "2014/09/22", "2018/01/10", "2000/01/01")
+    )
+
+    expect_equal(
+      (tab %>%
+         fmt_date(columns = "date", date_style = 15) %>%
          render_formats_test(context = "html"))[["date"]],
       c("17/10/15", "13/02/22", "14/09/22", "18/01/10", "00/01/01")
     )
@@ -398,14 +419,14 @@ test_that("the `fmt_time()` function works correctly", {
       gt() %>%
       fmt_time(columns = "date") %>%
       render_formats_test(context = "default"))[["date"]],
-    rep("00:00", 2)
+    rep("00:00:00", 2)
   )
   expect_equal(
     (dplyr::tibble(date = c("2013-12-30", "2017-03-15 12:30")) %>%
        gt() %>%
        fmt_time(columns = "date") %>%
        render_formats_test(context = "default"))[["date"]],
-    rep("00:00", 2)
+    rep("00:00:00", 2)
   )
 
   # Don't expect an error if any string-based date-times have invalid

--- a/tests/testthat/test-l_fmt_date_time.R
+++ b/tests/testthat/test-l_fmt_date_time.R
@@ -4,7 +4,8 @@ test_that("the `fmt_date()` function works correctly", {
   # that contains dates as character values
   data_tbl <-
     dplyr::tibble(date = c(
-      "2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10"))
+      "2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10"
+    ))
 
   # Create a `tbl_latex` object with `gt()` and the `data_tbl` dataset
   tbl_latex <- gt(data_tbl)
@@ -17,97 +18,128 @@ test_that("the `fmt_date()` function works correctly", {
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 1) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10"))
+    c("2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 2) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("Sunday, October 15, 2017", "Friday, February 22, 2013",
-      "Monday, September 22, 2014", "Wednesday, January 10, 2018"))
+    c(
+      "Sunday, October 15, 2017", "Friday, February 22, 2013",
+      "Monday, September 22, 2014", "Wednesday, January 10, 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 3) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("Sun, Oct 15, 2017", "Fri, Feb 22, 2013",
-      "Mon, Sep 22, 2014", "Wed, Jan 10, 2018"))
+    c(
+      "Sun, Oct 15, 2017", "Fri, Feb 22, 2013",
+      "Mon, Sep 22, 2014", "Wed, Jan 10, 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 4) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("Sunday 15 October 2017", "Friday 22 February 2013",
-      "Monday 22 September 2014", "Wednesday 10 January 2018"))
+    c(
+      "Sunday 15 October 2017", "Friday 22 February 2013",
+      "Monday 22 September 2014", "Wednesday 10 January 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 5) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("October 15, 2017", "February 22, 2013",
-      "September 22, 2014", "January 10, 2018"))
+    c(
+      "October 15, 2017", "February 22, 2013",
+      "September 22, 2014", "January 10, 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 6) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("Oct 15, 2017", "Feb 22, 2013",
-      "Sep 22, 2014", "Jan 10, 2018"))
+    c("Oct 15, 2017", "Feb 22, 2013", "Sep 22, 2014", "Jan 10, 2018")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 7) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("15 Oct 2017", "22 Feb 2013", "22 Sep 2014", "10 Jan 2018"))
+    c("15 Oct 2017", "22 Feb 2013", "22 Sep 2014", "10 Jan 2018")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 8) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("15 October 2017", "22 February 2013",
-      "22 September 2014", "10 January 2018"))
+    c(
+      "15 October 2017", "22 February 2013",
+      "22 September 2014", "10 January 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 9) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("15 October", "22 February", "22 September", "10 January"))
+    c("15 October", "22 February", "22 September", "10 January")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 10) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("2017", "2013", "2014", "2018"))
+    c("15 Oct", "22 Feb", "22 Sep", "10 Jan")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 11) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("October", "February", "September", "January"))
+    c("2017", "2013", "2014", "2018")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 12) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("15", "22", "22", "10"))
+    c("October", "February", "September", "January")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 13) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("2017/10/15", "2013/02/22", "2014/09/22", "2018/01/10"))
+    c("15", "22", "22", "10")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 14) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("17/10/15", "13/02/22", "14/09/22", "18/01/10"))
+    c("2017/10/15", "2013/02/22", "2014/09/22", "2018/01/10")
+  )
+
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 15) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("17/10/15", "13/02/22", "14/09/22", "18/01/10")
+  )
 
   # Create an input tibble frame with a single column
   # that contains dates as `Date` values
   data_tbl <-
     dplyr::tibble(date = as.Date(c(
-      "2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10")))
+      "2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10"
+    )))
 
   # Create a `tbl_latex` object with `gt()` and the `data_tbl` dataset
   tbl_latex <- gt(data_tbl)
@@ -120,92 +152,121 @@ test_that("the `fmt_date()` function works correctly", {
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 1) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10"))
+    c("2017-10-15", "2013-02-22", "2014-09-22", "2018-01-10")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 2) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("Sunday, October 15, 2017", "Friday, February 22, 2013",
-      "Monday, September 22, 2014", "Wednesday, January 10, 2018"))
+    c(
+      "Sunday, October 15, 2017", "Friday, February 22, 2013",
+      "Monday, September 22, 2014", "Wednesday, January 10, 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 3) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("Sun, Oct 15, 2017", "Fri, Feb 22, 2013",
-      "Mon, Sep 22, 2014", "Wed, Jan 10, 2018"))
+    c(
+      "Sun, Oct 15, 2017", "Fri, Feb 22, 2013",
+      "Mon, Sep 22, 2014", "Wed, Jan 10, 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 4) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("Sunday 15 October 2017", "Friday 22 February 2013",
-      "Monday 22 September 2014", "Wednesday 10 January 2018"))
+    c(
+      "Sunday 15 October 2017", "Friday 22 February 2013",
+      "Monday 22 September 2014", "Wednesday 10 January 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 5) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("October 15, 2017", "February 22, 2013",
-      "September 22, 2014", "January 10, 2018"))
+    c(
+      "October 15, 2017", "February 22, 2013",
+      "September 22, 2014", "January 10, 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 6) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("Oct 15, 2017", "Feb 22, 2013",
-      "Sep 22, 2014", "Jan 10, 2018"))
+    c("Oct 15, 2017", "Feb 22, 2013", "Sep 22, 2014", "Jan 10, 2018")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 7) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("15 Oct 2017", "22 Feb 2013", "22 Sep 2014", "10 Jan 2018"))
+    c("15 Oct 2017", "22 Feb 2013", "22 Sep 2014", "10 Jan 2018")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 8) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("15 October 2017", "22 February 2013",
-      "22 September 2014", "10 January 2018"))
+    c(
+      "15 October 2017", "22 February 2013",
+      "22 September 2014", "10 January 2018"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 9) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("15 October", "22 February", "22 September", "10 January"))
+    c("15 October", "22 February", "22 September", "10 January")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 10) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("2017", "2013", "2014", "2018"))
+    c("15 Oct", "22 Feb", "22 Sep", "10 Jan")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 11) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("October", "February", "September", "January"))
+    c("2017", "2013", "2014", "2018")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 12) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("15", "22", "22", "10"))
+    c("October", "February", "September", "January")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 13) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("2017/10/15", "2013/02/22", "2014/09/22", "2018/01/10"))
+    c("15", "22", "22", "10")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_date(columns = "date", date_style = 14) %>%
        render_formats_test(context = "latex"))[["date"]],
-    c("17/10/15", "13/02/22", "14/09/22", "18/01/10"))
+    c("2017/10/15", "2013/02/22", "2014/09/22", "2018/01/10")
+  )
 
+  expect_equal(
+    (tbl_latex %>%
+       fmt_date(columns = "date", date_style = 15) %>%
+       render_formats_test(context = "latex"))[["date"]],
+    c("17/10/15", "13/02/22", "14/09/22", "18/01/10")
+  )
 })
 
 test_that("the `fmt_time()` function works correctly", {
@@ -214,7 +275,8 @@ test_that("the `fmt_time()` function works correctly", {
   # that contains times as character values
   data_tbl <-
     dplyr::tibble(time = c(
-      "12:35:23", "15:01:34", "09:45:23", "01:32:00"))
+      "12:35:23", "15:01:34", "09:45:23", "01:32:00"
+    ))
 
   # Create a `tbl_latex` object with `gt()` and the `data_tbl` dataset
   tbl_latex <- gt(data_tbl)
@@ -227,31 +289,36 @@ test_that("the `fmt_time()` function works correctly", {
     (tbl_latex %>%
        fmt_time(columns = "time", time_style = 1) %>%
        render_formats_test(context = "latex"))[["time"]],
-    c("12:35:23", "15:01:34", "09:45:23", "01:32:00"))
+    c("12:35:23", "15:01:34", "09:45:23", "01:32:00")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_time(columns = "time", time_style = 2) %>%
        render_formats_test(context = "latex"))[["time"]],
-    c("12:35", "15:01", "09:45", "01:32"))
+    c("12:35", "15:01", "09:45", "01:32")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_time(columns = "time", time_style = 3) %>%
        render_formats_test(context = "latex"))[["time"]],
-    c("12:35:23 PM", "3:01:34 PM", "9:45:23 AM", "1:32:00 AM"))
+    c("12:35:23 PM", "3:01:34 PM", "9:45:23 AM", "1:32:00 AM")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_time(columns = "time", time_style = 4) %>%
        render_formats_test(context = "latex"))[["time"]],
-    c("12:35 PM", "3:01 PM", "9:45 AM", "1:32 AM"))
+    c("12:35 PM", "3:01 PM", "9:45 AM", "1:32 AM")
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_time(columns = "time", time_style = 5) %>%
        render_formats_test(context = "latex"))[["time"]],
-    c("12 PM", "3 PM", "9 AM", "1 AM"))
+    c("12 PM", "3 PM", "9 AM", "1 AM")
+  )
 })
 
 test_that("the `fmt_datetime()` function works correctly", {
@@ -263,7 +330,8 @@ test_that("the `fmt_datetime()` function works correctly", {
       "2017-06-10 12:35:23",
       "2017-07-12 15:01:34",
       "2017-08-05 09:45:23",
-      "2017-10-23 01:32:00"))
+      "2017-10-23 01:32:00"
+    ))
 
   # Create a `tbl_latex` object with `gt()` and the `data_tbl` dataset
   tbl_latex <- gt(data_tbl)
@@ -276,34 +344,49 @@ test_that("the `fmt_datetime()` function works correctly", {
     (tbl_latex %>%
        fmt_datetime(columns = "datetime", date_style = 1, time_style = 1) %>%
        render_formats_test(context = "latex"))[["datetime"]],
-    c("2017-06-10 12:35:23", "2017-07-12 15:01:34",
-      "2017-08-05 09:45:23", "2017-10-23 01:32:00"))
+    c(
+      "2017-06-10 12:35:23", "2017-07-12 15:01:34",
+      "2017-08-05 09:45:23", "2017-10-23 01:32:00"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_datetime(columns = "datetime", date_style = 2, time_style = 2) %>%
        render_formats_test(context = "latex"))[["datetime"]],
-    c("Saturday, June 10, 2017 12:35", "Wednesday, July 12, 2017 15:01",
-      "Saturday, August 5, 2017 09:45", "Monday, October 23, 2017 01:32"))
+    c(
+      "Saturday, June 10, 2017 12:35", "Wednesday, July 12, 2017 15:01",
+      "Saturday, August 5, 2017 09:45", "Monday, October 23, 2017 01:32"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_datetime(columns = "datetime", date_style = 3, time_style = 3) %>%
        render_formats_test(context = "latex"))[["datetime"]],
-    c("Sat, Jun 10, 2017 12:35:23 PM", "Wed, Jul 12, 2017 3:01:34 PM",
-      "Sat, Aug 5, 2017 9:45:23 AM", "Mon, Oct 23, 2017 1:32:00 AM"))
+    c(
+      "Sat, Jun 10, 2017 12:35:23 PM", "Wed, Jul 12, 2017 3:01:34 PM",
+      "Sat, Aug 5, 2017 9:45:23 AM", "Mon, Oct 23, 2017 1:32:00 AM"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_datetime(columns = "datetime", date_style = 4, time_style = 4) %>%
        render_formats_test(context = "latex"))[["datetime"]],
-    c("Saturday 10 June 2017 12:35 PM", "Wednesday 12 July 2017 3:01 PM",
-      "Saturday 5 August 2017 9:45 AM", "Monday 23 October 2017 1:32 AM"))
+    c(
+      "Saturday 10 June 2017 12:35 PM", "Wednesday 12 July 2017 3:01 PM",
+      "Saturday 5 August 2017 9:45 AM", "Monday 23 October 2017 1:32 AM"
+    )
+  )
 
   expect_equal(
     (tbl_latex %>%
        fmt_datetime(columns = "datetime", date_style = 5, time_style = 5) %>%
        render_formats_test(context = "default"))[["datetime"]],
-    c("June 10, 2017 12 PM", "July 12, 2017 3 PM",
-      "August 5, 2017 9 AM", "October 23, 2017 1 AM"))
+    c(
+      "June 10, 2017 12 PM", "July 12, 2017 3 PM",
+      "August 5, 2017 9 AM", "October 23, 2017 1 AM"
+    )
+  )
 })

--- a/tests/testthat/test-util_functions.R
+++ b/tests/testthat/test-util_functions.R
@@ -5,16 +5,11 @@ test_that("the `date_formats()` function works correctly", {
   expect_s3_class(date_formats(), c("tbl_df", "tbl", "data.frame"))
 
   # Expect the tibble to be of specific dimensions
-  expect_equal(
-    date_formats() %>%
-      dim(),
-    c(14, 3)
-  )
+  expect_equal(dim(date_formats()), c(15, 3))
 
   # Expect the tibble to have specific column names
   expect_equal(
-    date_formats() %>%
-      colnames(),
+    colnames(date_formats()),
     c("format_number", "format_name", "format_code")
   )
 })
@@ -26,16 +21,11 @@ test_that("the `time_formats()` util fcn works as expected", {
   expect_s3_class(time_formats(), c("tbl_df", "tbl", "data.frame"))
 
   # Expect the tibble to be of specific dimensions
-  expect_equal(
-    time_formats() %>%
-      dim(),
-    c(5, 3)
-  )
+  expect_equal(dim(time_formats()), c(5, 3))
 
   # Expect the tibble to have specific column names
   expect_equal(
-    time_formats() %>%
-      colnames(),
+    colnames(time_formats()),
     c("format_number", "format_name", "format_code")
   )
 })
@@ -44,21 +34,27 @@ test_that("the `get_date_format()` function works correctly", {
 
   # Expect specific `format_code` values for each
   # numeric `date_style` value passed in
-  lapply(1:14, get_date_format) %>%
+  lapply(1:15, get_date_format) %>%
     unlist() %>%
     expect_equal(
-      c("%F", "%A, %B %d, %Y", "%a, %b %d, %Y", "%A %d %B %Y",
-        "%B %d, %Y", "%b %d, %Y", "%d %b %Y", "%d %B %Y", "%d %B",
-        "%Y", "%B", "%d", "%Y/%m/%d", "%y/%m/%d"))
+      c(
+        "%F", "%A, %B %d, %Y", "%a, %b %d, %Y", "%A %d %B %Y",
+        "%B %d, %Y", "%b %d, %Y", "%d %b %Y", "%d %B %Y", "%d %B", "%d %b",
+        "%Y", "%B", "%d", "%Y/%m/%d", "%y/%m/%d"
+      )
+    )
 
   # Expect specific `format_code` values for each
   # text-based `date_style` value passed in
   lapply(date_formats()$format_name, get_date_format) %>%
     unlist() %>%
     expect_equal(
-      c("%F", "%A, %B %d, %Y", "%a, %b %d, %Y", "%A %d %B %Y",
-        "%B %d, %Y", "%b %d, %Y", "%d %b %Y", "%d %B %Y", "%d %B",
-        "%Y", "%B", "%d", "%Y/%m/%d", "%y/%m/%d"))
+      c(
+        "%F", "%A, %B %d, %Y", "%a, %b %d, %Y", "%A %d %B %Y",
+        "%B %d, %Y", "%b %d, %Y", "%d %b %Y", "%d %B %Y", "%d %B", "%d %b",
+        "%Y", "%B", "%d", "%Y/%m/%d", "%y/%m/%d"
+      )
+    )
 })
 
 test_that("the `get_time_format()` function works correctly", {
@@ -68,14 +64,16 @@ test_that("the `get_time_format()` function works correctly", {
   lapply(1:5, get_time_format) %>%
     unlist() %>%
     expect_equal(
-      c("%H:%M:%S", "%H:%M", "%I:%M:%S %P", "%I:%M %P", "%I %P"))
+      c("%H:%M:%S", "%H:%M", "%I:%M:%S %P", "%I:%M %P", "%I %P")
+    )
 
   # Expect specific `format_code` values for each
   # text-based `date_style` value passed in
   lapply(time_formats()$format_name, get_time_format) %>%
     unlist() %>%
     expect_equal(
-      c("%H:%M:%S", "%H:%M", "%I:%M:%S %P", "%I:%M %P", "%I %P"))
+      c("%H:%M:%S", "%H:%M", "%I:%M:%S %P", "%I:%M %P", "%I %P")
+    )
 })
 
 test_that("the `validate_currency()` function works correctly", {
@@ -163,7 +161,6 @@ test_that("the `get_currency_str()` function works correctly", {
 
   get_currency_str(currency = "hryvnia") %>%
     expect_equal("&#8372;")
-
 
   # Expect that various currency codes (3-letter) can
   # return a currency code when an HTML entity would

--- a/tests/testthat/test-vec_fmt.R
+++ b/tests/testthat/test-vec_fmt.R
@@ -4351,7 +4351,7 @@ test_that("The `vec_fmt_date()` function works", {
   )
 
   vec_fmt_date(dates, date_style = 10, output = "html") %>%
-    expect_equal(c("2020", "2021", "2022", "2023", "2024"))
+    expect_equal(c("5 Jan", "6 Feb", "7 Mar", "8 Apr", "9 May"))
   expect_equal(
     vec_fmt_date(as.character(dates), date_style = 10, output = "html"),
     vec_fmt_date(as.character(dates), date_style = 10, output = "latex")
@@ -4366,7 +4366,7 @@ test_that("The `vec_fmt_date()` function works", {
   )
 
   vec_fmt_date(dates, date_style = 11, output = "html") %>%
-    expect_equal(c("January", "February", "March", "April", "May"))
+    expect_equal(c("2020", "2021", "2022", "2023", "2024"))
   expect_equal(
     vec_fmt_date(as.character(dates), date_style = 11, output = "html"),
     vec_fmt_date(as.character(dates), date_style = 11, output = "latex")
@@ -4381,7 +4381,7 @@ test_that("The `vec_fmt_date()` function works", {
   )
 
   vec_fmt_date(dates, date_style = 12, output = "html") %>%
-    expect_equal(c("05", "06", "07", "08", "09"))
+    expect_equal(c("January", "February", "March", "April", "May"))
   expect_equal(
     vec_fmt_date(as.character(dates), date_style = 12, output = "html"),
     vec_fmt_date(as.character(dates), date_style = 12, output = "latex")
@@ -4396,11 +4396,7 @@ test_that("The `vec_fmt_date()` function works", {
   )
 
   vec_fmt_date(dates, date_style = 13, output = "html") %>%
-    expect_equal(
-      c(
-        "2020/01/05", "2021/02/06", "2022/03/07", "2023/04/08", "2024/05/09"
-      )
-    )
+    expect_equal(c("05", "06", "07", "08", "09"))
   expect_equal(
     vec_fmt_date(as.character(dates), date_style = 13, output = "html"),
     vec_fmt_date(as.character(dates), date_style = 13, output = "latex")
@@ -4417,7 +4413,7 @@ test_that("The `vec_fmt_date()` function works", {
   vec_fmt_date(dates, date_style = 14, output = "html") %>%
     expect_equal(
       c(
-        "20/01/05", "21/02/06", "22/03/07", "23/04/08", "24/05/09"
+        "2020/01/05", "2021/02/06", "2022/03/07", "2023/04/08", "2024/05/09"
       )
     )
   expect_equal(
@@ -4431,6 +4427,25 @@ test_that("The `vec_fmt_date()` function works", {
   expect_equal(
     vec_fmt_date(as.character(dates), date_style = 14, output = "html"),
     vec_fmt_date(as.character(dates), date_style = 14, output = "plain")
+  )
+
+  vec_fmt_date(dates, date_style = 15, output = "html") %>%
+    expect_equal(
+      c(
+        "20/01/05", "21/02/06", "22/03/07", "23/04/08", "24/05/09"
+      )
+    )
+  expect_equal(
+    vec_fmt_date(as.character(dates), date_style = 15, output = "html"),
+    vec_fmt_date(as.character(dates), date_style = 15, output = "latex")
+  )
+  expect_equal(
+    vec_fmt_date(as.character(dates), date_style = 15, output = "html"),
+    vec_fmt_date(as.character(dates), date_style = 15, output = "rtf")
+  )
+  expect_equal(
+    vec_fmt_date(as.character(dates), date_style = 15, output = "html"),
+    vec_fmt_date(as.character(dates), date_style = 15, output = "plain")
   )
 
   vec_fmt_date(dates, date_style = 2, pattern = "d{x}d", output = "html") %>%


### PR DESCRIPTION
This includes the `"day_m"` option for formatting dates with `fmt_date()` and `vec_fmt_date()`. This makes it possible to have a very short date (w/ implied year) in the table stub.

Now we can something like this:

```r
exibble %>%
  dplyr::select(date, time) %>%
  gt(rowname_col = "date") %>%
  fmt_date(
    columns = date,
    date_style = "day_m"
  ) %>%
  cols_align(
    align = "left",
    columns = stub()
  ) %>%
  sub_missing(
    columns= stub(),
    missing_text = ""
  )
```

<img width="881" alt="new-date-option" src="https://user-images.githubusercontent.com/5612024/188709699-dc2d1faf-66a9-467b-8e5a-b0a304d5854b.png">


Fixes: https://github.com/rstudio/gt/issues/1028