### PR TITLE
Revisions to the `extract_cells()` function

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,6 +20,7 @@ tests/testthat/test-as_raw_html.R
 tests/testthat/test-as_word.R
 tests/testthat/test-cols_width_rtf.R
 tests/testthat/test-data_color.R
+tests/testthat/test-extract_cells.R
 tests/testthat/test-fmt_duration.R
 tests/testthat/test-fmt_fraction.R
 tests/testthat/test-fmt_ratio.R

--- a/R/export.R
+++ b/R/export.R
@@ -904,7 +904,6 @@ extract_summary <- function(data) {
   as.list(summary_tbl)
 }
 
-
 #' Extract a vector of formatted cells from a **gt** object
 #'
 #' @description
@@ -931,6 +930,47 @@ extract_summary <- function(data) {
 #'   `"auto"` option will choose the correct `output` value
 #'
 #' @return A vector of cell data extracted from a **gt** table.
+#'
+#' @section Examples:
+#'
+#' Let's create a **gt** table with the [`exibble`] dataset to use in the next
+#' few examples:
+#'
+#' ```r
+#' gt_tbl <- gt(exibble, rowname_col = "row", groupname_col = "group")
+#' ```
+#'
+#' We can extract a cell from the table with the `extract_cells()` function.
+#' This is done by providing a column and a row intersection:
+#'
+#' ```r
+#' extract_cells(gt_tbl, columns = num, row = 1)
+#' ```
+#' ```
+#' #> [1] "1.111e-01"
+#' ```
+#'
+#' Multiple cells can be extracted. Let's get the first four cells from the
+#' `char` column.
+#'
+#' ```r
+#' extract_cells(gt_tbl, columns = char, rows = 1:4)
+#' ```
+#' ```
+#' #> [1] "apricot" "banana" "coconut" "durian"
+#' ```
+#'
+#' We can format cells and expect that the formatting is fully retained after
+#' extraction.
+#'
+#' ```r
+#' gt_tbl %>%
+#'   fmt_number(columns = num, decimals = 2) %>%
+#'   extract_cells(columns = num, rows = 1)
+#' ```
+#' ```
+#' #> [1] "0.11"
+#' ```
 #'
 #' @family table export functions
 #' @section Function ID:

--- a/R/export.R
+++ b/R/export.R
@@ -905,7 +905,7 @@ extract_summary <- function(data) {
 }
 
 
-#' Extract a summary list from a **gt** object
+#' Extract a vector of formatted cells from a **gt** object
 #'
 #' @description
 #' Get a vector of cell data from a `gt_tbl` object. The output vector will have

--- a/R/export.R
+++ b/R/export.R
@@ -967,7 +967,18 @@ extract_cells <- function(
       data = data
     )
 
-  built_data <- build_data(data = data, context = output)
+  data <- dt_body_build(data = data)
+  data <- render_formats(data = data, context = output)
+  data <- render_substitutions(data = data, context = output)
+  data <- migrate_unformatted_to_output(data = data, context = output)
+  data <- perform_col_merge(data = data, context = output)
+  data <- dt_body_reassemble(data = data)
+  data <- reorder_stub_df(data = data)
+  data <- reorder_footnotes(data = data)
+  data <- reorder_styles(data = data)
+  data <- perform_text_transforms(data = data)
+  built_data <- data
+
   data_body <- built_data[["_body"]]
 
   out_vec <- c()

--- a/man/extract_cells.Rd
+++ b/man/extract_cells.Rd
@@ -41,6 +41,45 @@ A vector of cell data extracted from a \strong{gt} table.
 Get a vector of cell data from a \code{gt_tbl} object. The output vector will have
 cell data formatted in the same way as the table.
 }
+\section{Examples}{
+
+
+Let's create a \strong{gt} table with the \code{\link{exibble}} dataset to use in the next
+few examples:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{gt_tbl <- gt(exibble, rowname_col = "row", groupname_col = "group")
+}\if{html}{\out{</div>}}
+
+We can extract a cell from the table with the \code{extract_cells()} function.
+This is done by providing a column and a row intersection:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{extract_cells(gt_tbl, columns = num, row = 1)
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{#> [1] "1.111e-01"
+}\if{html}{\out{</div>}}
+
+Multiple cells can be extracted. Let's get the first four cells from the
+\code{char} column.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{extract_cells(gt_tbl, columns = char, rows = 1:4)
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{#> [1] "apricot" "banana" "coconut" "durian"
+}\if{html}{\out{</div>}}
+
+We can format cells and expect that the formatting is fully retained after
+extraction.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{gt_tbl \%>\%
+  fmt_number(columns = num, decimals = 2) \%>\%
+  extract_cells(columns = num, rows = 1)
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{#> [1] "0.11"
+}\if{html}{\out{</div>}}
+}
+
 \section{Function ID}{
 
 13-7

--- a/tests/testthat/test-extract_cells.R
+++ b/tests/testthat/test-extract_cells.R
@@ -7,7 +7,7 @@ test_that("Extraction of table cells works well", {
   # extraction to occur from the top to bottom of column, left to
   # right columns
   expect_equal(
-    gt_tbl %>% extract_cells(columns = everything()),
+    gt_tbl %>% extract_cells(columns = everything(), output = "plain"),
     c(
       "1.111e-01", "2.222e+00", "3.333e+01", "4.444e+02", "5.550e+03",
       "NA", "7.770e+05", "8.880e+06", "apricot", "banana", "coconut",
@@ -29,14 +29,14 @@ test_that("Extraction of table cells works well", {
   expect_equal(
     gt_tbl %>%
       cols_move_to_end(columns = num) %>%
-      extract_cells(columns = everything()),
+      extract_cells(columns = everything(), output = "plain"),
     gt_tbl %>%
-      extract_cells(columns = everything())
+      extract_cells(columns = everything(), output = "plain")
   )
 
   # Expect that a single column of cells can be extracted
   expect_equal(
-    gt_tbl %>% extract_cells(columns = char),
+    gt_tbl %>% extract_cells(columns = char, output = "plain"),
     c(
       "apricot", "banana", "coconut", "durian", NA,
       "fig", "grapefruit", "honeydew"
@@ -46,15 +46,15 @@ test_that("Extraction of table cells works well", {
   # Expect that `rows` works to get a subset of cells
   # from one or more columns
   expect_equal(
-    gt_tbl %>% extract_cells(columns = char, rows = c(1, 3)),
+    gt_tbl %>% extract_cells(columns = char, rows = c(1, 3), output = "plain"),
     c("apricot", "coconut")
   )
   expect_equal(
-    gt_tbl %>% extract_cells(columns = c(char, fctr), rows = c(1, 3)),
+    gt_tbl %>% extract_cells(columns = c(char, fctr), rows = c(1, 3), output = "plain"),
     c("apricot", "coconut", "one", "three")
   )
   expect_equal(
-    gt_tbl %>% extract_cells(columns = everything(), rows = 1),
+    gt_tbl %>% extract_cells(columns = everything(), rows = 1, output = "plain"),
     c(
       "1.111e-01", "apricot", "one", "2015-01-15", "13:35",
       "2018-01-01 02:22", "49.950", "row_1", "grp_a"
@@ -65,13 +65,13 @@ test_that("Extraction of table cells works well", {
   expect_equal(
     gt_tbl %>%
       fmt_number(columns = num, decimals = 5) %>%
-      extract_cells(columns = num, rows = c(1, 3)),
+      extract_cells(columns = num, rows = c(1, 3), output = "plain"),
     c("0.11110","33.33000")
   )
   expect_equal(
     gt_tbl %>%
       fmt_number(columns = num, rows = 1, decimals = 5) %>%
-      extract_cells(columns = num, rows = c(1, 3)),
+      extract_cells(columns = num, rows = c(1, 3), output = "plain"),
     c("0.11110","3.333e+01")
   )
   expect_equal(
@@ -80,7 +80,7 @@ test_that("Extraction of table cells works well", {
       fmt_number(columns = num, decimals = 4, rows = 1:2) %>%
       fmt_number(columns = num, decimals = 3, rows = 3) %>%
       fmt_number(columns = currency, decimals = 10) %>%
-      extract_cells(columns = num, rows = c(1, 3)),
+      extract_cells(columns = num, rows = c(1, 3), output = "plain"),
     c("0.1111","33.330")
   )
 
@@ -89,7 +89,7 @@ test_that("Extraction of table cells works well", {
     gt_tbl %>%
       fmt_number(columns = num, decimals = 5) %>%
       tab_footnote(footnote = "Footnote", locations = cells_body(columns = num)) %>%
-      extract_cells(columns = num, rows = c(1, 3)),
+      extract_cells(columns = num, rows = c(1, 3), output = "plain"),
     c("0.11110","33.33000")
   )
 
@@ -98,12 +98,6 @@ test_that("Extraction of table cells works well", {
     dplyr::tibble(a = c(0.1, 0.3, 0.9, -1.3, -2.233)) %>%
     gt()
 
-  expect_equal(
-    gt_tbl_2 %>%
-      fmt_fraction(columns = a, layout = "diagonal") %>%
-      extract_cells(columns = a),
-    c("1/9", "2/7", "8/9", "-1 2/7", "-2 2/9")
-  )
   expect_equal(
     gt_tbl_2 %>%
       fmt_fraction(columns = a, layout = "diagonal") %>%
@@ -154,30 +148,30 @@ test_that("Extraction of table cells works well", {
   expect_equal(
     gt_tbl_3 %>%
       fmt_number(columns = num, decimals = 5) %>%
-      extract_cells(columns = num, rows = c("row_1", "row_3")),
+      extract_cells(columns = num, rows = c("row_1", "row_3"), output = "plain"),
     c("0.11110", "33.33000")
   )
   expect_equal(
     gt_tbl_3 %>%
-      extract_cells(columns = row, rows = c("row_1", "row_3")),
+      extract_cells(columns = row, rows = c("row_1", "row_3"), output = "plain"),
     c("row_1", "row_3")
   )
   expect_null(
     gt_tbl_3 %>%
-      extract_cells(columns = group, rows = c("row_1", "row_3"))
+      extract_cells(columns = group, rows = c("row_1", "row_3"), output = "plain")
   )
   expect_equal(
     dplyr::tibble(a = c("*hey*", "**there**"), b = 1:2) %>%
       gt(rowname_col = "a") %>%
       fmt_markdown(columns = a) %>%
-      extract_cells(columns = a),
+      extract_cells(columns = a, output = "plain"),
     c("hey", "there")
   )
   expect_equal(
     dplyr::tibble(a = c("*hey*", "**there**"), b = 1:2) %>%
       gt(rowname_col = "a") %>%
       fmt_markdown(columns = stub()) %>%
-      extract_cells(columns = stub()),
+      extract_cells(columns = stub(), output = "plain"),
     c("hey", "there")
   )
   expect_equal(
@@ -190,13 +184,45 @@ test_that("Extraction of table cells works well", {
       "<div class='gt_from_md'><p><strong>there</strong></p>\n</div>"
     )
   )
+  expect_equal(
+    dplyr::tibble(a = c("*hey*", "**there**"), b = 1:2) %>%
+      gt(rowname_col = "a") %>%
+      fmt_markdown(columns = a) %>%
+      extract_cells(columns = a, output = "rtf"),
+    c("{\\i hey}", "{\\b there}")
+  )
+  expect_equal(
+    dplyr::tibble(a = c("*hey*", "**there**"), b = 1:2) %>%
+      gt(rowname_col = "a") %>%
+      fmt_markdown(columns = a) %>%
+      extract_cells(columns = a, output = "word"),
+    c(
+      "<w:rPr><w:i>true</w:i></w:rPr>hey<w:rPr><w:i>false</w:i></w:rPr>",
+      "<w:rPr><w:b w:val=\"true\"></w:b></w:rPr>there<w:rPr><w:b w:val=\"false\"></w:b></w:rPr>"
+    )
+  )
+
+  # Expect that text transforms are incorporated in the extracted vectors
+  expect_equal(
+    gt_tbl_3 %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      text_transform(
+        locations = cells_body(columns = num),
+        fn = function(x) paste0(x, "!")
+      ) %>%
+      extract_cells(columns = num, output = "plain"),
+    c(
+      "0.11110!", "2.22200!", "33.33000!", "444.40000!", "5,550.00000!",
+      "NA!", "777,000.00000!", "8,880,000.00000!"
+    )
+  )
 
   # Expect that cells from hidden columns can be extracted
   expect_equal(
     gt_tbl_3 %>%
       fmt_number(columns = num, decimals = 5) %>%
       cols_hide(columns = num) %>%
-      extract_cells(columns = num, rows = c("row_1", "row_3")),
+      extract_cells(columns = num, rows = c("row_1", "row_3"), output = "plain"),
     c("0.11110", "33.33000")
   )
 
@@ -204,16 +230,16 @@ test_that("Extraction of table cells works well", {
   expect_error(
     gt_tbl_3 %>%
       fmt_number(columns = num, decimals = 5) %>%
-      extract_cells(columns = num, rows = "row_50")
+      extract_cells(columns = num, rows = "row_50", output = "plain")
   )
   expect_error(
     gt_tbl_3 %>%
       fmt_number(columns = num, decimals = 5) %>%
-      extract_cells(columns = num, rows = c("row_2", "row_50"))
+      extract_cells(columns = num, rows = c("row_2", "row_50"), output = "plain")
   )
   expect_error(
     gt_tbl_3 %>%
       fmt_number(columns = num, decimals = 5) %>%
-      extract_cells(columns = 10)
+      extract_cells(columns = 10, output = "plain")
   )
 })

--- a/tests/testthat/test-extract_cells.R
+++ b/tests/testthat/test-extract_cells.R
@@ -1,0 +1,219 @@
+test_that("Extraction of table cells works well", {
+
+  # Create a simple gt table using the exibble dataset
+  gt_tbl <- gt(exibble)
+
+  # Extract every cell from the table; expect the order of cell
+  # extraction to occur from the top to bottom of column, left to
+  # right columns
+  expect_equal(
+    gt_tbl %>% extract_cells(columns = everything()),
+    c(
+      "1.111e-01", "2.222e+00", "3.333e+01", "4.444e+02", "5.550e+03",
+      "NA", "7.770e+05", "8.880e+06", "apricot", "banana", "coconut",
+      "durian", NA, "fig", "grapefruit", "honeydew", "one", "two",
+      "three", "four", "five", "six", "seven", "eight", "2015-01-15",
+      "2015-02-15", "2015-03-15", "2015-04-15", "2015-05-15", "2015-06-15",
+      NA, "2015-08-15", "13:35", "14:40", "15:45", "16:50", "17:55",
+      NA, "19:10", "20:20", "2018-01-01 02:22", "2018-02-02 14:33",
+      "2018-03-03 03:44", "2018-04-04 15:55", "2018-05-05 04:00", "2018-06-06 16:11",
+      "2018-07-07 05:22", NA, "49.950", "17.950", "1.390", "65100.000",
+      "1325.810", "13.255", "NA", "0.440", "row_1", "row_2", "row_3",
+      "row_4", "row_5", "row_6", "row_7", "row_8", "grp_a", "grp_a",
+      "grp_a", "grp_a", "grp_b", "grp_b", "grp_b", "grp_b"
+    )
+  )
+
+  # Expect that moving columns with `cols_move*()` fns don't affect the
+  # ordering of the vector containing all extracted cells
+  expect_equal(
+    gt_tbl %>%
+      cols_move_to_end(columns = num) %>%
+      extract_cells(columns = everything()),
+    gt_tbl %>%
+      extract_cells(columns = everything())
+  )
+
+  # Expect that a single column of cells can be extracted
+  expect_equal(
+    gt_tbl %>% extract_cells(columns = char),
+    c(
+      "apricot", "banana", "coconut", "durian", NA,
+      "fig", "grapefruit", "honeydew"
+    )
+  )
+
+  # Expect that `rows` works to get a subset of cells
+  # from one or more columns
+  expect_equal(
+    gt_tbl %>% extract_cells(columns = char, rows = c(1, 3)),
+    c("apricot", "coconut")
+  )
+  expect_equal(
+    gt_tbl %>% extract_cells(columns = c(char, fctr), rows = c(1, 3)),
+    c("apricot", "coconut", "one", "three")
+  )
+  expect_equal(
+    gt_tbl %>% extract_cells(columns = everything(), rows = 1),
+    c(
+      "1.111e-01", "apricot", "one", "2015-01-15", "13:35",
+      "2018-01-01 02:22", "49.950", "row_1", "grp_a"
+    )
+  )
+
+  # Format values and expect the formatted values to be extracted
+  expect_equal(
+    gt_tbl %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      extract_cells(columns = num, rows = c(1, 3)),
+    c("0.11110","33.33000")
+  )
+  expect_equal(
+    gt_tbl %>%
+      fmt_number(columns = num, rows = 1, decimals = 5) %>%
+      extract_cells(columns = num, rows = c(1, 3)),
+    c("0.11110","3.333e+01")
+  )
+  expect_equal(
+    gt_tbl %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      fmt_number(columns = num, decimals = 4, rows = 1:2) %>%
+      fmt_number(columns = num, decimals = 3, rows = 3) %>%
+      fmt_number(columns = currency, decimals = 10) %>%
+      extract_cells(columns = num, rows = c(1, 3)),
+    c("0.1111","33.330")
+  )
+
+  # Expect that footnotes won't appear in the output vector
+  expect_equal(
+    gt_tbl %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      tab_footnote(footnote = "Footnote", locations = cells_body(columns = num)) %>%
+      extract_cells(columns = num, rows = c(1, 3)),
+    c("0.11110","33.33000")
+  )
+
+  # Expect that the correct rendering context will be used
+  gt_tbl_2 <-
+    dplyr::tibble(a = c(0.1, 0.3, 0.9, -1.3, -2.233)) %>%
+    gt()
+
+  expect_equal(
+    gt_tbl_2 %>%
+      fmt_fraction(columns = a, layout = "diagonal") %>%
+      extract_cells(columns = a),
+    c("1/9", "2/7", "8/9", "-1 2/7", "-2 2/9")
+  )
+  expect_equal(
+    gt_tbl_2 %>%
+      fmt_fraction(columns = a, layout = "diagonal") %>%
+      extract_cells(columns = a, output = "plain"),
+    c("1/9", "2/7", "8/9", "-1 2/7", "-2 2/9")
+  )
+  expect_equal(
+    gt_tbl_2 %>%
+      fmt_fraction(columns = a, layout = "diagonal") %>%
+      extract_cells(columns = a, output = "html"),
+    c(
+      "<span style=\"font-size:0.6em;line-height:0.6em;vertical-align:0.45em;\">1</span><span style=\"font-size:0.7em;line-height:0.7em;vertical-align:0.15em;\">⁄</span><span style=\"font-size:0.6em;line-height:0.6em;vertical-align:-0.05em;\">9</span>",
+      "<span style=\"font-size:0.6em;line-height:0.6em;vertical-align:0.45em;\">2</span><span style=\"font-size:0.7em;line-height:0.7em;vertical-align:0.15em;\">⁄</span><span style=\"font-size:0.6em;line-height:0.6em;vertical-align:-0.05em;\">7</span>",
+      "<span style=\"font-size:0.6em;line-height:0.6em;vertical-align:0.45em;\">8</span><span style=\"font-size:0.7em;line-height:0.7em;vertical-align:0.15em;\">⁄</span><span style=\"font-size:0.6em;line-height:0.6em;vertical-align:-0.05em;\">9</span>",
+      "−1 <span style=\"font-size:0.6em;line-height:0.6em;vertical-align:0.45em;\">2</span><span style=\"font-size:0.7em;line-height:0.7em;vertical-align:0.15em;\">⁄</span><span style=\"font-size:0.6em;line-height:0.6em;vertical-align:-0.05em;\">7</span>",
+      "−2 <span style=\"font-size:0.6em;line-height:0.6em;vertical-align:0.45em;\">2</span><span style=\"font-size:0.7em;line-height:0.7em;vertical-align:0.15em;\">⁄</span><span style=\"font-size:0.6em;line-height:0.6em;vertical-align:-0.05em;\">9</span>"
+    )
+  )
+  expect_equal(
+    gt_tbl_2 %>%
+      fmt_fraction(columns = a, layout = "diagonal") %>%
+      extract_cells(columns = a, output = "latex"),
+    c(
+      "${{}^{1}\\!/_{9}}$", "${{}^{2}\\!/_{7}}$", "${{}^{8}\\!/_{9}}$",
+      "$-1\\, {{}^{2}\\!/_{7}}$", "$-2\\, {{}^{2}\\!/_{9}}$"
+    )
+  )
+  expect_equal(
+    gt_tbl_2 %>%
+      fmt_fraction(columns = a, layout = "diagonal") %>%
+      extract_cells(columns = a, output = "rtf"),
+    c(
+      "{\\super 1}/{\\sub 9}", "{\\super 2}/{\\sub 7}", "{\\super 8}/{\\sub 9}",
+      "-1{\\super 2}/{\\sub 7}", "-2{\\super 2}/{\\sub 9}"
+    )
+  )
+  expect_equal(
+    gt_tbl_2 %>%
+      fmt_fraction(columns = a, layout = "diagonal") %>%
+      extract_cells(columns = a, output = "word"),
+    c("1/9", "2/7", "8/9", "-1 2/7", "-2 2/9")
+  )
+
+  # Create a gt table with row groups and row labels using exibble
+  gt_tbl_3 <- gt(exibble, rowname_col = "row", groupname_col = "group")
+
+  # Format values and expect the formatted values to be extracted
+  expect_equal(
+    gt_tbl_3 %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      extract_cells(columns = num, rows = c("row_1", "row_3")),
+    c("0.11110", "33.33000")
+  )
+  expect_equal(
+    gt_tbl_3 %>%
+      extract_cells(columns = row, rows = c("row_1", "row_3")),
+    c("row_1", "row_3")
+  )
+  expect_null(
+    gt_tbl_3 %>%
+      extract_cells(columns = group, rows = c("row_1", "row_3"))
+  )
+  expect_equal(
+    dplyr::tibble(a = c("*hey*", "**there**"), b = 1:2) %>%
+      gt(rowname_col = "a") %>%
+      fmt_markdown(columns = a) %>%
+      extract_cells(columns = a),
+    c("hey", "there")
+  )
+  expect_equal(
+    dplyr::tibble(a = c("*hey*", "**there**"), b = 1:2) %>%
+      gt(rowname_col = "a") %>%
+      fmt_markdown(columns = stub()) %>%
+      extract_cells(columns = stub()),
+    c("hey", "there")
+  )
+  expect_equal(
+    dplyr::tibble(a = c("*hey*", "**there**"), b = 1:2) %>%
+      gt(rowname_col = "a") %>%
+      fmt_markdown(columns = a) %>%
+      extract_cells(columns = a, output = "html"),
+    c(
+      "<div class='gt_from_md'><p><em>hey</em></p>\n</div>",
+      "<div class='gt_from_md'><p><strong>there</strong></p>\n</div>"
+    )
+  )
+
+  # Expect that cells from hidden columns can be extracted
+  expect_equal(
+    gt_tbl_3 %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      cols_hide(columns = num) %>%
+      extract_cells(columns = num, rows = c("row_1", "row_3")),
+    c("0.11110", "33.33000")
+  )
+
+  # Expect an error when attempting to obtain cells that don't exist
+  expect_error(
+    gt_tbl_3 %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      extract_cells(columns = num, rows = "row_50")
+  )
+  expect_error(
+    gt_tbl_3 %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      extract_cells(columns = num, rows = c("row_2", "row_50"))
+  )
+  expect_error(
+    gt_tbl_3 %>%
+      fmt_number(columns = num, decimals = 5) %>%
+      extract_cells(columns = 10)
+  )
+})


### PR DESCRIPTION
This PR refines the new `extract_cells()` function by changing the internal build process (using a partial build that avoids the attachment of footnote marks to text), revising the documentation, and adding tests.