### PR TITLE
Skip if paletteer is not installed

### DIFF
--- a/tests/testthat/test-data_color.R
+++ b/tests/testthat/test-data_color.R
@@ -25,7 +25,7 @@ selection_text <- function(html, selection) {
 }
 
 test_that("the correct color values are obtained when defining a palette", {
-
+  skip_if_not_installed("paletteer")
   # Obtain a palette of 12 colors in #RRGGBB format
   pal_12 <-
     paletteer::paletteer_d(palette = "rcartocolor::Vivid") %>% as.character() %>%


### PR DESCRIPTION
# Summary

While working on another issue, I had a test that failed because paletteer was not installed.  Skip those tests when it is not installed.

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
