### PR TITLE
Use the APCA contrast algorithm to better select light or dark text in `ideal_fgnd_color()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -113,6 +113,7 @@ Collate:
     'summary_rows.R'
     'text_transform.R'
     'utils.R'
+    'utils_color_contrast.R'
     'utils_formatters.R'
     'utils_general_str_formatting.R'
     'utils_pipe.R'

--- a/R/data_color.R
+++ b/R/data_color.R
@@ -59,9 +59,12 @@
 #'   include the cell background (the default, given as `"fill"`) or the cell
 #'   text (`"text"`).
 #' @param autocolor_text An option to let **gt** modify the coloring of text
-#'   within cells undergoing background coloring. This will in some cases yield
-#'   more optimal text-to-background color contrast. By default, this is set to
-#'   `TRUE`.
+#'   within cells undergoing background coloring. This will result in better
+#'   text-to-background color contrast. By default, this is set to `TRUE`.
+#' @param contrast_algo The color contrast algorithm to use when
+#'   `autocolor_text = TRUE`. By default this is `"apca"` (Accessible Perceptual
+#'   Contrast Algorithm) and the alternative to this is `"wcag"` (Web Content
+#'   Accessibility Guidelines).
 #'
 #' @return An object of class `gt_tbl`.
 #'
@@ -138,7 +141,8 @@ data_color <- function(
     colors,
     alpha = NULL,
     apply_to = c("fill", "text"),
-    autocolor_text = TRUE
+    autocolor_text = TRUE,
+    contrast_algo = c("apca", "wcag")
 ) {
 
   # Perform input object validation
@@ -146,6 +150,9 @@ data_color <- function(
 
   # Get the correct `apply_to` value
   apply_to <- match.arg(apply_to)
+
+  # Get the correct `contrast_algo` value
+  contrast_algo <- match.arg(contrast_algo)
 
   colors <- rlang::enquo(colors)
 
@@ -264,7 +271,11 @@ data_color <- function(
 
     if (apply_to == "fill" && autocolor_text) {
 
-      color_vals <- ideal_fgnd_color(bgnd_color = color_vals)
+      color_vals <-
+        ideal_fgnd_color(
+          bgnd_color = color_vals,
+          algo = contrast_algo
+        )
 
       color_styles <- lapply(color_vals, FUN = function(x) cell_text(color = x))
 
@@ -365,8 +376,12 @@ expand_short_hex <- function(colors) {
 ideal_fgnd_color <- function(
     bgnd_color,
     light = "#FFFFFF",
-    dark = "#000000"
+    dark = "#000000",
+    algo = c("apca", "wcag")
 ) {
+
+  # Get the correct `algo` value
+  algo <- match.arg(algo)
 
   # Normalize color to hexadecimal color if it is in the 'rgba()' string format
   bgnd_color <- rgba_to_hex(colors = bgnd_color)
@@ -374,9 +389,18 @@ ideal_fgnd_color <- function(
   # Normalize color to a #RRGGBB (stripping the alpha channel)
   bgnd_color <- html_color(colors = bgnd_color, alpha = 1)
 
-  # Determine the ideal color for the chosen background color with APCA
-  contrast_dark <- get_contrast_ratio(color_1 = dark, color_2 = bgnd_color)[, 1]
-  contrast_light <- get_contrast_ratio(color_1 = light, color_2 = bgnd_color)[, 1]
+  if (algo == "apca") {
+
+    # Determine the ideal color for the chosen background color with APCA
+    contrast_dark <- get_contrast_ratio(color_1 = dark, color_2 = bgnd_color, algo = "apca")[, 1]
+    contrast_light <- get_contrast_ratio(color_1 = light, color_2 = bgnd_color, algo = "apca")[, 1]
+
+  } else {
+
+    # Determine the ideal color for the chosen background color with WCAG
+    contrast_dark <- get_contrast_ratio(color_1 = dark, color_2 = bgnd_color, algo = "wcag")
+    contrast_light <- get_contrast_ratio(color_1 = light, color_2 = bgnd_color, algo = "wcag")
+  }
 
   ifelse(abs(contrast_dark) >= abs(contrast_light), dark, light)
 }

--- a/R/data_color.R
+++ b/R/data_color.R
@@ -374,11 +374,11 @@ ideal_fgnd_color <- function(
   # Normalize color to a #RRGGBB (stripping the alpha channel)
   bgnd_color <- html_color(colors = bgnd_color, alpha = 1)
 
-  # Determine the ideal color for the chosen background color
-  yiq_contrasted_threshold <- 128
-  colors <- grDevices::col2rgb(bgnd_color)
-  score <- colSums(colors * c(299, 587, 144)) / 1000
-  ifelse(score >= yiq_contrasted_threshold, dark, light)
+  # Determine the ideal color for the chosen background color with APCA
+  contrast_dark <- get_contrast_ratio(color_1 = dark, color_2 = bgnd_color)[, 1]
+  contrast_light <- get_contrast_ratio(color_1 = light, color_2 = bgnd_color)[, 1]
+
+  ifelse(abs(contrast_dark) >= abs(contrast_light), dark, light)
 }
 
 #' Convert colors in mixed formats (incl. rgba() strings) format to hexadecimal

--- a/R/utils_color_contrast.R
+++ b/R/utils_color_contrast.R
@@ -1,0 +1,81 @@
+apca_coeffs <-
+  list(
+    mainTRC = 2.4,
+    sRco = 0.2126729,
+    sGco = 0.7151522,
+    sBco = 0.0721750,
+    normBG = 0.56,
+    normTXT = 0.57,
+    revTXT = 0.62,
+    revBG = 0.65,
+    blkThrs = 0.022,
+    blkClmp = 1.414,
+    scaleBoW = 1.14,
+    scaleWoB = 1.14,
+    loBoWthresh = 0.035991,
+    loBoWfactor = 27.7847239587675,
+    loBoWoffset = 0.027,
+    loClip = 0.001,
+    deltaYmin = 0.0005
+  )
+
+get_contrast_ratio <- function(
+    color_1 = "black",
+    color_2 = "white"
+) {
+
+  if (length(color_1) < 1L || length(color_2) < 1L) {
+    cli::cli_abort(
+      "At least one color defined for each of `color_1` and `color_2`."
+    )
+  }
+
+  # Perform recycling of colors
+  n <- max(c(length(color_1), length(color_2)))
+  if (!(length(color_1) == n && length(color_2) == n)) {
+    color_1 <- rep_len(color_1, n)
+    color_2 <- rep_len(color_2, n)
+  }
+
+  # Obtain relative luminance for `color_1` and `color_2`
+  lum_1 <- get_relative_luminance(color_1)
+  lum_2 <- get_relative_luminance(color_2)
+
+  cbind(
+    "normal"  = get_apca_ratio(txt = lum_1, bgrnd = lum_2),
+    "reverse" = get_apca_ratio(txt = lum_2, bgrnd = lum_1)
+  )
+}
+
+get_apca_ratio <- function(txt, bgrnd) {
+
+  # Determine ratio for normal polarity
+  ratio <- (bgrnd^apca_coeffs$normBG - txt^apca_coeffs$normTXT) * apca_coeffs$scaleBoW
+  ratio <- ifelse(ratio < 0.1, 0, ratio - apca_coeffs$loBoWoffset)
+
+  # Determine ratio for reverse polarity
+  rev <- bgrnd <= txt
+  ratio[rev] <- (bgrnd[rev]^apca_coeffs$revBG - txt[rev]^apca_coeffs$revTXT) * apca_coeffs$scaleWoB
+  ratio[rev] <- ifelse(ratio[rev] > -0.1, 0, ratio[rev] + apca_coeffs$loBoWoffset)
+
+  # If the luminance difference between background and text is
+  # nearly the same, treat that as zero
+  ratio[abs(bgrnd - txt) < apca_coeffs$deltaYmin] <- 0
+
+  ratio * 100
+}
+
+get_relative_luminance <- function(col) {
+
+  rgb <- t(grDevices::col2rgb(col)) / 255
+
+  coef <- c(apca_coeffs$sRco, apca_coeffs$sGco, apca_coeffs$sBco)
+
+  rgb[] <- rgb^apca_coeffs$mainTRC
+  r_lum <- as.numeric(rgb %*% coef)
+  clamp <- r_lum <= apca_coeffs$blkThrs
+  r_lum[clamp] <-
+    (apca_coeffs$blkThrs - r_lum[clamp])^apca_coeffs$blkClmp + r_lum[clamp]
+
+  r_lum
+}

--- a/R/utils_color_contrast.R
+++ b/R/utils_color_contrast.R
@@ -1,3 +1,7 @@
+# Functionality to parse color values and determine Lc contrast taken from
+# the SAPC APCA (Accessible Perceptual Contrast Algorithm)
+# Coefficient values current as of Beta 0.0.98G-4g (Oct 1, 2021)
+
 apca_coeffs <-
   list(
     mainTRC = 2.4,

--- a/man/data_color.Rd
+++ b/man/data_color.Rd
@@ -10,7 +10,8 @@ data_color(
   colors,
   alpha = NULL,
   apply_to = c("fill", "text"),
-  autocolor_text = TRUE
+  autocolor_text = TRUE,
+  contrast_algo = c("apca", "wcag")
 )
 }
 \arguments{
@@ -36,9 +37,13 @@ include the cell background (the default, given as \code{"fill"}) or the cell
 text (\code{"text"}).}
 
 \item{autocolor_text}{An option to let \strong{gt} modify the coloring of text
-within cells undergoing background coloring. This will in some cases yield
-more optimal text-to-background color contrast. By default, this is set to
-\code{TRUE}.}
+within cells undergoing background coloring. This will result in better
+text-to-background color contrast. By default, this is set to \code{TRUE}.}
+
+\item{contrast_algo}{The color contrast algorithm to use when
+\code{autocolor_text = TRUE}. By default this is \code{"apca"} (Accessible Perceptual
+Contrast Algorithm) and the alternative to this is \code{"wcag"} (Web Content
+Accessibility Guidelines).}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/tests/testthat/test-color_handling.R
+++ b/tests/testthat/test-color_handling.R
@@ -281,10 +281,9 @@ test_that("the various color utility functions work correctly", {
   expect_equal(
     ideal_fgnd_color(bgnd_color = c(c_name, c_hex, c_hex_a, c_rgba)),
     c(
-      "#FFFFFF", "#000000", "#000000", "#000000", "#000000", "#FFFFFF",
-      "#000000",
-      "#000000", "#000000", "#FFFFFF", "#FFFFFF", "#FFFFFF", "#FFFFFF",
-      "#000000", "#000000", "#000000", "#000000", "#000000"
+      "#FFFFFF", "#FFFFFF", "#FFFFFF", "#000000", "#000000", "#FFFFFF",
+      "#000000", "#000000", "#000000", "#FFFFFF", "#FFFFFF", "#FFFFFF",
+      "#FFFFFF", "#000000", "#000000", "#000000", "#000000", "#000000"
     )
   )
 

--- a/tests/testthat/test-data_color.R
+++ b/tests/testthat/test-data_color.R
@@ -1229,7 +1229,10 @@ test_that("the various color utility functions work correctly", {
 
   # Expect an error if 'rgba()'-format colors are passed to `normalize_colors()`
   expect_error(
-    normalize_colors(colors = c(c_name, c_hex, c_hex_a, "rgba(210,215,33,0.5)"))
+    normalize_colors(
+      colors = c(c_name, c_hex, c_hex_a, "rgba(210,215,33,0.5)"),
+      alpha = 1.0
+    )
   )
 
   # Expect that the `ideal_fgnd_color()` function returns a vector containing
@@ -1239,7 +1242,7 @@ test_that("the various color utility functions work correctly", {
   expect_equal(
     ideal_fgnd_color(bgnd_color = c(c_name, c_hex, c_hex_a, c_rgba)),
     c(
-      "#FFFFFF", "#000000", "#000000", "#000000", "#000000", "#FFFFFF",
+      "#FFFFFF", "#FFFFFF", "#FFFFFF", "#000000", "#000000", "#FFFFFF",
       "#000000", "#000000", "#FFFFFF", "#FFFFFF", "#FFFFFF", "#FFFFFF",
       "#000000", "#000000", "#000000", "#000000", "#000000"
     )


### PR DESCRIPTION
This updates the `ideal_fgnd_color()` util function add the APCA contrast also. This determines Lc contrast between overlaid text on a background color. The background is fixed and the text color is swapped to the alternative (`light` or `dark`) that maximizes contrast. The code here is adapted from the SAPC APCA (Accessible Perceptual Contrast Algorithm). The WCAG algo has been added here as a (non-default) alternative in `data_color()`. Here is a comparison table demonstrating the differences between the WCAG and APCA contrast schemes.

![contrast-compare](https://user-images.githubusercontent.com/5612024/191389081-2e44a5a2-4cc0-472e-ae70-0736210e7a94.png)

