### PR TITLE
Improve documentation for CLDR-type formatting patterns

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -2874,51 +2874,59 @@ fmt_time <- function(
 #'
 #' ## Quarter
 #'
-#' ### Quarter of the Year: formatting ver.
+#' ### Quarter of the Year: formatting and standalone versions
+#'
+#' The quarter names are identified numerically, starting at `1` and ending at
+#' `4`. Quarter names may vary along two axes: the width and the context. The
+#' context is either 'formatting' (taken as a default), which the form used
+#' within a complete date format string, or, 'standalone', the form for date
+#' elements used independently (such as in calendar headers). The standalone
+#' form may be used in any other date format that shares the same form of the
+#' name. Here, the formatting form for quarters of the year consists of some run
+#' of `"Q"` values whereas the standalone form uses `"q"`.
 #'
 #' | Field Patterns    | Output          | Notes                             |
 #' |-------------------|-----------------|-----------------------------------|
-#' | `"Q"`             | `"3"`           | Numeric, one digit                |
-#' | `"QQ"`            | `"03"`          | Numeric, two digits (zero padded) |
-#' | `"QQQ"`           | `"Q3"`          | Abbreviated                       |
-#' | `"QQQQ"`          | `"3rd quarter"` | Wide                              |
-#' | `"QQQQQ"`         | `"3"`           | Narrow                            |
-#'
-#' ### Quarter of the Year: standalone ver.
-#'
-#' | Field Patterns    | Output          | Notes                             |
-#' |-------------------|-----------------|-----------------------------------|
-#' | `"q"`             | `"3"`           | Numeric, one digit                |
-#' | `"qq"`            | `"03"`          | Numeric, two digits (zero padded) |
-#' | `"qqq"`           | `"Q3"`          | Abbreviated                       |
-#' | `"qqqq"`          | `"3rd quarter"` | Wide                              |
-#' | `"qqqqq"`         | `"3"`           | Narrow                            |
+#' | `"Q"`/`"q"`       | `"3"`           | Numeric, one digit                |
+#' | `"QQ"`/`"qq"`     | `"03"`          | Numeric, two digits (zero padded) |
+#' | `"QQQ"`/`"qqq"`   | `"Q3"`          | Abbreviated                       |
+#' | `"QQQQ"`/`"qqqq"` | `"3rd quarter"` | Wide                              |
+#' | `"QQQQQ"`/`"qqqqq"` | `"3"`         | Narrow                            |
 #'
 #' ## Month
 #'
-#' ### Month: formatting ver.
+#' ### Month: formatting and standalone versions
+#'
+#' The month names are identified numerically, starting at `1` and ending at
+#' `12`. Month names may vary along two axes: the width and the context. The
+#' context is either 'formatting' (taken as a default), which the form used
+#' within a complete date format string, or, 'standalone', the form for date
+#' elements used independently (such as in calendar headers). The standalone
+#' form may be used in any other date format that shares the same form of the
+#' name. Here, the formatting form for months consists of some run of `"M"`
+#' values whereas the standalone form uses `"L"`.
 #'
 #' | Field Patterns    | Output          | Notes                             |
 #' |-------------------|-----------------|-----------------------------------|
-#' | `"M"`             | `"7"`           | Numeric, minimum digits           |
-#' | `"MM"`            | `"07"`          | Numeric, two digits (zero padded) |
-#' | `"MMM"`           | `"Jul"`         | Abbreviated                       |
-#' | `"MMMM"`          | `"July"`        | Wide                              |
-#' | `"MMMMM"`         | `"J"`           | Narrow                            |
-#'
-#' ### Month: standalone ver.
-#'
-#' | Field Patterns    | Output          | Notes                             |
-#' |-------------------|-----------------|-----------------------------------|
-#' | `"M"`             | `"7"`           | Numeric, minimum digits           |
-#' | `"MM"`            | `"07"`          | Numeric, two digits (zero padded) |
-#' | `"MMM"`           | `"Jul"`         | Abbreviated                       |
-#' | `"MMMM"`          | `"July"`        | Wide                              |
-#' | `"MMMMM"`         | `"J"`           | Narrow                            |
+#' | `"M"`/`"L"`       | `"7"`           | Numeric, minimum digits           |
+#' | `"MM"`/`"LL"`     | `"07"`          | Numeric, two digits (zero padded) |
+#' | `"MMM"`/`"LLL"`   | `"Jul"`         | Abbreviated                       |
+#' | `"MMMM"`/`"LLLL"` | `"July"`        | Wide                              |
+#' | `"MMMMM"`/`"LLLLL"` | `"J"`         | Narrow                            |
 #'
 #' ## Week
 #'
 #' ### Week of Year
+#'
+#' Values calculated for the week of year range from `1` to `53`. Week `1` for a
+#' year is the first week that contains at least the specified minimum number of
+#' days from that year. Weeks between week `1` of one year and week `1` of the
+#' following year are numbered sequentially from `2` to `52` or `53` (if
+#' needed).
+#'
+#' There are two available field lengths. Both will display the week of year
+#' value but the `"ww"` width will always show two digits (where weeks `1` to
+#' `9` are zero padded).
 #'
 #' | Field Patterns   | Output    | Notes                                    |
 #' |------------------|-----------|------------------------------------------|
@@ -2926,6 +2934,10 @@ fmt_time <- function(
 #' | `"ww"`           | `"27"`    | Two digits (zero padded)                 |
 #'
 #' ### Week of Month
+#'
+#' The week of a month can range from `1` to `5`. The first day of every month
+#' always begins at week `1` and with every transition into the beginning of a
+#' week, the week of month value is incremented by `1`.
 #'
 #' | Field Pattern    | Output                                               |
 #' |------------------|------------------------------------------------------|
@@ -2935,12 +2947,22 @@ fmt_time <- function(
 #'
 #' ### Day of Month
 #'
+#' The day of month value is always numeric and there are two available field
+#' length choices in its formatting. Both will display the day of month value
+#' but the `"dd"` formatting will always show two digits (where days `1` to `9`
+#' are zero padded).
+#'
 #' | Field Patterns | Output    | Notes                                      |
 #' |----------------|-----------|--------------------------------------------|
 #' | `"d"`          | `"4"`     | Minimum digits                             |
 #' | `"dd"`         | `"04"`    | Two digits, zero padded                    |
 #'
 #' ### Day of Year
+#'
+#' The day of year value ranges from `1` (January 1) to either `365` or `366`
+#' (December 31), where the higher value of the range indicates that the year is
+#' a leap year (29 days in February, instead of 28). The field length specifies
+#' the minimum number of digits, with zero-padding as necessary.
 #'
 #' | Field Patterns  | Output   | Notes                                      |
 #' |-----------------|----------|--------------------------------------------|
@@ -2950,11 +2972,28 @@ fmt_time <- function(
 #'
 #' ### Day of Week in Month
 #'
+#' The day of week in month returns a numerical value indicating the number of
+#' times a given weekday had occurred in the month (e.g., '2nd Monday in
+#' March'). This conveniently resolves to predicable case structure where ranges
+#' of day of the month values return predictable day of week in month values:
+#'
+#' - days `1` - `7` -> `1`
+#' - days `8` - `14` -> `2`
+#' - days `15` - `21` -> `3`
+#' - days `22` - `28` -> `4`
+#' - days `29` - `31` -> `5`
+#'
 #' | Field Pattern                  | Output                                 |
 #' |--------------------------------|----------------------------------------|
 #' | `"F"`                          | `"1"`                                  |
 #'
-#' ### Modified Julian Day
+#' ### Modified Julian Date
+#'
+#' The modified version of the Julian date is obtained by subtracting
+#' 2,400,000.5 days from the Julian date (the number of days since January 1,
+#' 4713 BC). This essentially results in the number of days since midnight
+#' November 17, 1858. There is a half day offset (unlike the Julian date, the
+#' modified Julian date is referenced to midnight instead of noon).
 #'
 #' | Field Patterns                 | Output                                 |
 #' |--------------------------------|----------------------------------------|
@@ -2963,6 +3002,8 @@ fmt_time <- function(
 #' ## Weekday
 #'
 #' ### Day of Week Name
+#'
+#' The name of the day of week is offered in four different widths.
 #'
 #' | Field Patterns             | Output         | Notes                     |
 #' |----------------------------|----------------|---------------------------|
@@ -2975,6 +3016,12 @@ fmt_time <- function(
 #'
 #' ### AM/PM Period of Day
 #'
+#' This denotes before noon and after noon time periods. May be upper or
+#' lowercase depending on the locale and other options. The wide form may be
+#' the same as the short form if the 'real' long form (e.g. 'ante meridiem') is
+#' not customarily used. The narrow form must be unique, unlike some other
+#' fields.
+#'
 #' | Field Patterns                 | Output   | Notes                       |
 #' |--------------------------------|----------|-----------------------------|
 #' | `"a"`, `"aa"`, or `"aaa"`      | `"PM"`   | Abbreviated                 |
@@ -2983,8 +3030,13 @@ fmt_time <- function(
 #'
 #' ### AM/PM Period of Day Plus Noon and Midnight
 #'
-#' (a) `input_midnight`: `"2020-05-05T00:00:00"`
+#' Provide AM and PM as well as phrases for exactly noon and midnight. May be
+#' upper or lowercase depending on the locale and other options. If the locale
+#' doesn't have the notion of a unique 'noon' (i.e., 12:00), then the PM form
+#' may be substituted. A similar behavior can occur for 'midnight' (00:00) and
+#' the AM form. The narrow form must be unique, unlike some other fields.
 #'
+#' (a) `input_midnight`: `"2020-05-05T00:00:00"`
 #' (b) `input_noon`: `"2020-05-05T12:00:00"`
 #'
 #' | Field Patterns                 | Output             | Notes             |
@@ -2998,8 +3050,12 @@ fmt_time <- function(
 #'
 #' ### Flexible Day Periods
 #'
-#' (a) `input_morning`: `"2020-05-05T00:08:30"`
+#' Flexible day periods denotes things like 'in the afternoon', 'in the
+#' evening', etc., and the flexibility comes from a locale's language and
+#' script. Each locale has an associated rule set that specifies when the day
+#' periods start and end for that locale.
 #'
+#' (a) `input_morning`: `"2020-05-05T00:08:30"`
 #' (b) `input_afternoon`: `"2020-05-05T14:00:00"`
 #'
 #' | Field Patterns             | Output                   | Notes           |
@@ -3013,43 +3069,63 @@ fmt_time <- function(
 #'
 #' ## Hours, Minutes, and Seconds
 #'
-#' ### Hour 1-12
-#'
-#' Using: `"2015-08-01T08:35:09"`
-#'
-#' | Field Patterns         | Output  | Notes                                |
-#' |------------------------|---------|--------------------------------------|
-#' | `"h"`                  | `"8"`   | Numeric, minimum digits              |
-#' | `"hh"`                 | `"08"`  | Numeric, 2 digits (zero padded)      |
-#'
 #' ### Hour 0-23
 #'
-#' Using: `"2015-08-01T08:35:09"`
+#' Hours from `0` to `23` are for a standard 24-hour clock cycle (midnight plus
+#' 1 minute is `00:01`) when using `"HH"` (which is the more common width that
+#' indicates zero-padding to 2 digits).
+#'
+#' Using `"2015-08-01T08:35:09"`:
 #'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
 #' | `"H"`                  | `"8"`   | Numeric, minimum digits              |
 #' | `"HH"`                 | `"08"`  | Numeric, 2 digits (zero padded)      |
 #'
-#' ### Hour 0-11
+#' ### Hour 1-12
 #'
-#' Using: `"2015-08-01T08:35:09"`
+#' Hours from `1` to `12` are for a standard 12-hour clock cycle (midnight plus
+#' 1 minute is `12:01`) when using `"hh"` (which is the more common width that
+#' indicates zero-padding to 2 digits).
+#'
+#' Using `"2015-08-01T08:35:09"`:
 #'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
-#' | `"K"`                  | `"7"`   | Numeric, minimum digits              |
-#' | `"KK"`                 | `"07"`  | Numeric, 2 digits (zero padded)      |
+#' | `"h"`                  | `"8"`   | Numeric, minimum digits              |
+#' | `"hh"`                 | `"08"`  | Numeric, 2 digits (zero padded)      |
 #'
 #' ### Hour 1-24
 #'
-#' Using: `"2015-08-01T08:35:09"`
+#' Using hours from `1` to `24` is a less common way to express a 24-hour clock
+#' cycle (midnight plus 1 minute is `24:01`) when using `"kk"` (which is the
+#' more common width that indicates zero-padding to 2 digits).
+#'
+#' Using `"2015-08-01T08:35:09"`:
 #'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
 #' | `"k"`                  | `"9"`   | Numeric, minimum digits              |
 #' | `"kk"`                 | `"09"`  | Numeric, 2 digits (zero padded)      |
 #'
+#' ### Hour 0-11
+#'
+#' Using hours from `0` to `11` is a less common way to express a 12-hour clock
+#' cycle (midnight plus 1 minute is `00:01`) when using `"KK"` (which is the
+#' more common width that indicates zero-padding to 2 digits).
+#'
+#' Using `"2015-08-01T08:35:09"`:
+#'
+#' | Field Patterns         | Output  | Notes                                |
+#' |------------------------|---------|--------------------------------------|
+#' | `"K"`                  | `"7"`   | Numeric, minimum digits              |
+#' | `"KK"`                 | `"07"`  | Numeric, 2 digits (zero padded)      |
+#'
 #' ### Minute
+#'
+#' The minute of the hour which can be any number from `0` to `59`. Use `"m"` to
+#' show the minimum number of digits, or `"mm"` to always show two digits
+#' (zero-padding, if necessary).
 #'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
@@ -3058,6 +3134,10 @@ fmt_time <- function(
 #'
 #' ### Seconds
 #'
+#' The second of the minute which can be any number from `0` to `59`. Use `"s"`
+#' to show the minimum number of digits, or `"ss"` to always show two digits
+#' (zero-padding, if necessary).
+#'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
 #' | `"s"`                  | `"9"`   | Numeric, minimum digits              |
@@ -3065,13 +3145,22 @@ fmt_time <- function(
 #'
 #' ### Fractional Second
 #'
+#' The fractional second truncates (like other time fields) to the width
+#' requested (i.e., count of letters). So using pattern `"SSSS"` will display
+#' four digits past the decimal (which, incidentally, needs to be added manually
+#' to the pattern).
+#'
 #' | Field Patterns                 | Output                                 |
 #' |--------------------------------|----------------------------------------|
 #' | `"S"` to `"SSSSSSSSS"`         | `"2"` -> `"235000000"`                 |
 #'
 #' ### Milliseconds Elapsed in Day
 #'
-#' Using: `"2011-07-27T00:07:19.7223"`
+#' There are 86,400,000 milliseconds in a day and the `"A"` pattern will provide
+#' the whole number. The width can go up to nine digits with `"AAAAAAAAA"` and
+#' these higher field widths will result in zero padding if necessary.
+#'
+#' Using `"2011-07-27T00:07:19.7223"`:
 #'
 #' | Field Patterns                 | Output                                 |
 #' |--------------------------------|----------------------------------------|
@@ -3081,7 +3170,9 @@ fmt_time <- function(
 #'
 #' ### The Era Designator
 #'
-#' This provides the era name for the given date.
+#' This provides the era name for the given date. The Gregorian calendar has two
+#' eras: AD and BC. In the AD year numbering system, AD 1 is immediately
+#' preceded by 1 BC, with nothing in between them (there was no year zero).
 #'
 #' | Field Patterns                 | Output          | Notes                |
 #' |--------------------------------|-----------------|----------------------|
@@ -3093,12 +3184,27 @@ fmt_time <- function(
 #'
 #' ### TZ // Short and Long Specific non-Location Format
 #'
+#' The short and long specific non-location formats for time zones are suggested
+#' for displaying a time with a user friendly time zone name. Where the short
+#' specific format is unavailable, it will fall back to the short localized GMT
+#' format (`"O"`). Where the long specific format is unavailable, it will fall
+#' back to the long localized GMT format (`"OOOO"`).
+#'
 #' | Field Patterns             | Output                    | Notes          |
 #' |----------------------------|---------------------------|----------------|
 #' | `"z"`, `"zz"`, or `"zzz"`  | `"PDT"`                   | Short Specific |
 #' | `"zzzz"`                   | `"Pacific Daylight Time"` | Long Specific  |
 #'
-#' ### TZ // Short and Long Specific non-Location Formats
+#' ### TZ // Common UTC Offset Formats
+#'
+#' The ISO8601 basic format with hours, minutes and optional seconds fields is
+#' represented by `"Z"`, `"ZZ"`, or `"ZZZ"`. The format is equivalent to RFC 822
+#' zone format (when the optional seconds field is absent). This is equivalent
+#' to the `"xxxx"` specifier. The field pattern `"ZZZZ"` represents the long
+#' localized GMT format. This is equivalent to the `"OOOO"` specifier. Finally,
+#' `"ZZZZZ"` pattern yields the ISO8601 extended format with hours, minutes and
+#' optional seconds fields. The ISO8601 UTC indicator `Z` is used when local
+#' time offset is `0`. This is equivalent to the `"XXXXX"` specifier.
 #'
 #' | Field Patterns             | Output       | Notes                       |
 #' |----------------------------|--------------|-----------------------------|
@@ -3108,19 +3214,34 @@ fmt_time <- function(
 #'
 #' ### TZ // Short and Long Localized GMT Formats
 #'
+#' The localized GMT formats come in two widths `"O"` (which removes the minutes
+#' field if it's `0`) and `"OOOO"` (which always contains the minutes field).
+#' The use of the `GMT` indicator changes according to the locale.
+#'
 #' | Field Patterns          | Output        | Notes                         |
 #' |-------------------------|---------------|-------------------------------|
 #' | `"O"`                   | `"GMT-7"`     | Short localized GMT format    |
 #' | `"OOOO"`                | `"GMT-07:00"` | Long localized GMT format     |
 #'
-#' ### TZ // Short and Long Localized GMT Formats
+#' ### TZ // Short and Long Generic non-Location Formats
+#'
+#' The generic non-location formats are useful for displaying a recurring wall
+#' time (e.g., events, meetings) or anywhere people do not want to be overly
+#' specific. Where either of these is unavailable, there is a fallback to the
+#' generic location format (`"VVVV"`), then the short localized GMT format as
+#' the final fallback.
 #'
 #' | Field Patterns  | Output           | Notes                              |
 #' |-----------------|------------------|------------------------------------|
 #' | `"v"`           | `"PT"`           | Short generic non-location format  |
 #' | `"vvvv"`        | `"Pacific Time"` | Long generic non-location format   |
 #'
-#' ### TZ // Short Time Zone IDs and Exemplar City Formats (big V)
+#' ### TZ // Short Time Zone IDs and Exemplar City Formats
+#'
+#' These formats provide variations of the time zone ID and often include the
+#' exemplar city. The widest of these formats, `"VVVV"`, is useful for
+#' populating a choice list for time zones, because it supports 1-to-1 name/zone
+#' ID mapping and is more uniform than other text formats.
 #'
 #' | Field Patterns     | Output                | Notes                      |
 #' |--------------------|-----------------------|----------------------------|
@@ -3131,6 +3252,12 @@ fmt_time <- function(
 #'
 #' ### TZ // ISO 8601 Formats with Z for +0000
 #'
+#' The `"X"`-`"XXX"` field patterns represent valid ISO 8601 patterns for time
+#' zone offsets in datetimes. The final two widths, `"XXXX"` and `"XXXXX"` allow
+#' for optional seconds fields. The seconds field is *not* supported by the ISO
+#' 8601 specification. For all of these, the ISO 8601 UTC indicator `Z` is used
+#' when the local time offset is `0`.
+#'
 #' | Field Patterns | Output     | Notes                                     |
 #' |----------------|------------|-------------------------------------------|
 #' | `"X"`          | `"-07"`    | ISO 8601 basic format (h, optional m)     |
@@ -3140,6 +3267,11 @@ fmt_time <- function(
 #' | `"XXXXX"`      | `"-07:00"` | ISO 8601 extended format (h & m, optional s) |
 #'
 #' ### TZ // ISO 8601 Formats (no use of Z for +0000)
+#'
+#' The `"x"`-`"xxxxx"` field patterns represent valid ISO 8601 patterns for time
+#' zone offsets in datetimes. They are similar to the `"X"`-`"XXXXX"` field
+#' patterns except that the ISO 8601 UTC indicator `Z` *will not* be used when
+#' the local time offset is `0`.
 #'
 #' | Field Patterns | Output     | Notes                                     |
 #' |----------------|------------|-------------------------------------------|

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -2070,51 +2070,59 @@ vec_fmt_time <- function(
 #'
 #' ## Quarter
 #'
-#' ### Quarter of the Year: formatting ver.
+#' ### Quarter of the Year: formatting and standalone versions
+#'
+#' The quarter names are identified numerically, starting at `1` and ending at
+#' `4`. Quarter names may vary along two axes: the width and the context. The
+#' context is either 'formatting' (taken as a default), which the form used
+#' within a complete date format string, or, 'standalone', the form for date
+#' elements used independently (such as in calendar headers). The standalone
+#' form may be used in any other date format that shares the same form of the
+#' name. Here, the formatting form for quarters of the year consists of some run
+#' of `"Q"` values whereas the standalone form uses `"q"`.
 #'
 #' | Field Patterns    | Output          | Notes                             |
 #' |-------------------|-----------------|-----------------------------------|
-#' | `"Q"`             | `"3"`           | Numeric, one digit                |
-#' | `"QQ"`            | `"03"`          | Numeric, two digits (zero padded) |
-#' | `"QQQ"`           | `"Q3"`          | Abbreviated                       |
-#' | `"QQQQ"`          | `"3rd quarter"` | Wide                              |
-#' | `"QQQQQ"`         | `"3"`           | Narrow                            |
-#'
-#' ### Quarter of the Year: standalone ver.
-#'
-#' | Field Patterns    | Output          | Notes                             |
-#' |-------------------|-----------------|-----------------------------------|
-#' | `"q"`             | `"3"`           | Numeric, one digit                |
-#' | `"qq"`            | `"03"`          | Numeric, two digits (zero padded) |
-#' | `"qqq"`           | `"Q3"`          | Abbreviated                       |
-#' | `"qqqq"`          | `"3rd quarter"` | Wide                              |
-#' | `"qqqqq"`         | `"3"`           | Narrow                            |
+#' | `"Q"`/`"q"`       | `"3"`           | Numeric, one digit                |
+#' | `"QQ"`/`"qq"`     | `"03"`          | Numeric, two digits (zero padded) |
+#' | `"QQQ"`/`"qqq"`   | `"Q3"`          | Abbreviated                       |
+#' | `"QQQQ"`/`"qqqq"` | `"3rd quarter"` | Wide                              |
+#' | `"QQQQQ"`/`"qqqqq"` | `"3"`         | Narrow                            |
 #'
 #' ## Month
 #'
-#' ### Month: formatting ver.
+#' ### Month: formatting and standalone versions
+#'
+#' The month names are identified numerically, starting at `1` and ending at
+#' `12`. Month names may vary along two axes: the width and the context. The
+#' context is either 'formatting' (taken as a default), which the form used
+#' within a complete date format string, or, 'standalone', the form for date
+#' elements used independently (such as in calendar headers). The standalone
+#' form may be used in any other date format that shares the same form of the
+#' name. Here, the formatting form for months consists of some run of `"M"`
+#' values whereas the standalone form uses `"L"`.
 #'
 #' | Field Patterns    | Output          | Notes                             |
 #' |-------------------|-----------------|-----------------------------------|
-#' | `"M"`             | `"7"`           | Numeric, minimum digits           |
-#' | `"MM"`            | `"07"`          | Numeric, two digits (zero padded) |
-#' | `"MMM"`           | `"Jul"`         | Abbreviated                       |
-#' | `"MMMM"`          | `"July"`        | Wide                              |
-#' | `"MMMMM"`         | `"J"`           | Narrow                            |
-#'
-#' ### Month: standalone ver.
-#'
-#' | Field Patterns    | Output          | Notes                             |
-#' |-------------------|-----------------|-----------------------------------|
-#' | `"M"`             | `"7"`           | Numeric, minimum digits           |
-#' | `"MM"`            | `"07"`          | Numeric, two digits (zero padded) |
-#' | `"MMM"`           | `"Jul"`         | Abbreviated                       |
-#' | `"MMMM"`          | `"July"`        | Wide                              |
-#' | `"MMMMM"`         | `"J"`           | Narrow                            |
+#' | `"M"`/`"L"`       | `"7"`           | Numeric, minimum digits           |
+#' | `"MM"`/`"LL"`     | `"07"`          | Numeric, two digits (zero padded) |
+#' | `"MMM"`/`"LLL"`   | `"Jul"`         | Abbreviated                       |
+#' | `"MMMM"`/`"LLLL"` | `"July"`        | Wide                              |
+#' | `"MMMMM"`/`"LLLLL"` | `"J"`         | Narrow                            |
 #'
 #' ## Week
 #'
 #' ### Week of Year
+#'
+#' Values calculated for the week of year range from `1` to `53`. Week `1` for a
+#' year is the first week that contains at least the specified minimum number of
+#' days from that year. Weeks between week `1` of one year and week `1` of the
+#' following year are numbered sequentially from `2` to `52` or `53` (if
+#' needed).
+#'
+#' There are two available field lengths. Both will display the week of year
+#' value but the `"ww"` width will always show two digits (where weeks `1` to
+#' `9` are zero padded).
 #'
 #' | Field Patterns   | Output    | Notes                                    |
 #' |------------------|-----------|------------------------------------------|
@@ -2122,6 +2130,10 @@ vec_fmt_time <- function(
 #' | `"ww"`           | `"27"`    | Two digits (zero padded)                 |
 #'
 #' ### Week of Month
+#'
+#' The week of a month can range from `1` to `5`. The first day of every month
+#' always begins at week `1` and with every transition into the beginning of a
+#' week, the week of month value is incremented by `1`.
 #'
 #' | Field Pattern    | Output                                               |
 #' |------------------|------------------------------------------------------|
@@ -2131,12 +2143,22 @@ vec_fmt_time <- function(
 #'
 #' ### Day of Month
 #'
+#' The day of month value is always numeric and there are two available field
+#' length choices in its formatting. Both will display the day of month value
+#' but the `"dd"` formatting will always show two digits (where days `1` to `9`
+#' are zero padded).
+#'
 #' | Field Patterns | Output    | Notes                                      |
 #' |----------------|-----------|--------------------------------------------|
 #' | `"d"`          | `"4"`     | Minimum digits                             |
 #' | `"dd"`         | `"04"`    | Two digits, zero padded                    |
 #'
 #' ### Day of Year
+#'
+#' The day of year value ranges from `1` (January 1) to either `365` or `366`
+#' (December 31), where the higher value of the range indicates that the year is
+#' a leap year (29 days in February, instead of 28). The field length specifies
+#' the minimum number of digits, with zero-padding as necessary.
 #'
 #' | Field Patterns  | Output   | Notes                                      |
 #' |-----------------|----------|--------------------------------------------|
@@ -2146,11 +2168,28 @@ vec_fmt_time <- function(
 #'
 #' ### Day of Week in Month
 #'
+#' The day of week in month returns a numerical value indicating the number of
+#' times a given weekday had occurred in the month (e.g., '2nd Monday in
+#' March'). This conveniently resolves to predicable case structure where ranges
+#' of day of the month values return predictable day of week in month values:
+#'
+#' - days `1` - `7` -> `1`
+#' - days `8` - `14` -> `2`
+#' - days `15` - `21` -> `3`
+#' - days `22` - `28` -> `4`
+#' - days `29` - `31` -> `5`
+#'
 #' | Field Pattern                  | Output                                 |
 #' |--------------------------------|----------------------------------------|
 #' | `"F"`                          | `"1"`                                  |
 #'
-#' ### Modified Julian Day
+#' ### Modified Julian Date
+#'
+#' The modified version of the Julian date is obtained by subtracting
+#' 2,400,000.5 days from the Julian date (the number of days since January 1,
+#' 4713 BC). This essentially results in the number of days since midnight
+#' November 17, 1858. There is a half day offset (unlike the Julian date, the
+#' modified Julian date is referenced to midnight instead of noon).
 #'
 #' | Field Patterns                 | Output                                 |
 #' |--------------------------------|----------------------------------------|
@@ -2159,6 +2198,8 @@ vec_fmt_time <- function(
 #' ## Weekday
 #'
 #' ### Day of Week Name
+#'
+#' The name of the day of week is offered in four different widths.
 #'
 #' | Field Patterns             | Output         | Notes                     |
 #' |----------------------------|----------------|---------------------------|
@@ -2171,6 +2212,12 @@ vec_fmt_time <- function(
 #'
 #' ### AM/PM Period of Day
 #'
+#' This denotes before noon and after noon time periods. May be upper or
+#' lowercase depending on the locale and other options. The wide form may be
+#' the same as the short form if the 'real' long form (e.g. 'ante meridiem') is
+#' not customarily used. The narrow form must be unique, unlike some other
+#' fields.
+#'
 #' | Field Patterns                 | Output   | Notes                       |
 #' |--------------------------------|----------|-----------------------------|
 #' | `"a"`, `"aa"`, or `"aaa"`      | `"PM"`   | Abbreviated                 |
@@ -2179,8 +2226,13 @@ vec_fmt_time <- function(
 #'
 #' ### AM/PM Period of Day Plus Noon and Midnight
 #'
-#' (a) `input_midnight`: `"2020-05-05T00:00:00"`
+#' Provide AM and PM as well as phrases for exactly noon and midnight. May be
+#' upper or lowercase depending on the locale and other options. If the locale
+#' doesn't have the notion of a unique 'noon' (i.e., 12:00), then the PM form
+#' may be substituted. A similar behavior can occur for 'midnight' (00:00) and
+#' the AM form. The narrow form must be unique, unlike some other fields.
 #'
+#' (a) `input_midnight`: `"2020-05-05T00:00:00"`
 #' (b) `input_noon`: `"2020-05-05T12:00:00"`
 #'
 #' | Field Patterns                 | Output             | Notes             |
@@ -2194,8 +2246,12 @@ vec_fmt_time <- function(
 #'
 #' ### Flexible Day Periods
 #'
-#' (a) `input_morning`: `"2020-05-05T00:08:30"`
+#' Flexible day periods denotes things like 'in the afternoon', 'in the
+#' evening', etc., and the flexibility comes from a locale's language and
+#' script. Each locale has an associated rule set that specifies when the day
+#' periods start and end for that locale.
 #'
+#' (a) `input_morning`: `"2020-05-05T00:08:30"`
 #' (b) `input_afternoon`: `"2020-05-05T14:00:00"`
 #'
 #' | Field Patterns             | Output                   | Notes           |
@@ -2209,43 +2265,63 @@ vec_fmt_time <- function(
 #'
 #' ## Hours, Minutes, and Seconds
 #'
-#' ### Hour 1-12
-#'
-#' Using: `"2015-08-01T08:35:09"`
-#'
-#' | Field Patterns         | Output  | Notes                                |
-#' |------------------------|---------|--------------------------------------|
-#' | `"h"`                  | `"8"`   | Numeric, minimum digits              |
-#' | `"hh"`                 | `"08"`  | Numeric, 2 digits (zero padded)      |
-#'
 #' ### Hour 0-23
 #'
-#' Using: `"2015-08-01T08:35:09"`
+#' Hours from `0` to `23` are for a standard 24-hour clock cycle (midnight plus
+#' 1 minute is `00:01`) when using `"HH"` (which is the more common width that
+#' indicates zero-padding to 2 digits).
+#'
+#' Using `"2015-08-01T08:35:09"`:
 #'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
 #' | `"H"`                  | `"8"`   | Numeric, minimum digits              |
 #' | `"HH"`                 | `"08"`  | Numeric, 2 digits (zero padded)      |
 #'
-#' ### Hour 0-11
+#' ### Hour 1-12
 #'
-#' Using: `"2015-08-01T08:35:09"`
+#' Hours from `1` to `12` are for a standard 12-hour clock cycle (midnight plus
+#' 1 minute is `12:01`) when using `"hh"` (which is the more common width that
+#' indicates zero-padding to 2 digits).
+#'
+#' Using `"2015-08-01T08:35:09"`:
 #'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
-#' | `"K"`                  | `"7"`   | Numeric, minimum digits              |
-#' | `"KK"`                 | `"07"`  | Numeric, 2 digits (zero padded)      |
+#' | `"h"`                  | `"8"`   | Numeric, minimum digits              |
+#' | `"hh"`                 | `"08"`  | Numeric, 2 digits (zero padded)      |
 #'
 #' ### Hour 1-24
 #'
-#' Using: `"2015-08-01T08:35:09"`
+#' Using hours from `1` to `24` is a less common way to express a 24-hour clock
+#' cycle (midnight plus 1 minute is `24:01`) when using `"kk"` (which is the
+#' more common width that indicates zero-padding to 2 digits).
+#'
+#' Using `"2015-08-01T08:35:09"`:
 #'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
 #' | `"k"`                  | `"9"`   | Numeric, minimum digits              |
 #' | `"kk"`                 | `"09"`  | Numeric, 2 digits (zero padded)      |
 #'
+#' ### Hour 0-11
+#'
+#' Using hours from `0` to `11` is a less common way to express a 12-hour clock
+#' cycle (midnight plus 1 minute is `00:01`) when using `"KK"` (which is the
+#' more common width that indicates zero-padding to 2 digits).
+#'
+#' Using `"2015-08-01T08:35:09"`:
+#'
+#' | Field Patterns         | Output  | Notes                                |
+#' |------------------------|---------|--------------------------------------|
+#' | `"K"`                  | `"7"`   | Numeric, minimum digits              |
+#' | `"KK"`                 | `"07"`  | Numeric, 2 digits (zero padded)      |
+#'
 #' ### Minute
+#'
+#' The minute of the hour which can be any number from `0` to `59`. Use `"m"` to
+#' show the minimum number of digits, or `"mm"` to always show two digits
+#' (zero-padding, if necessary).
 #'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
@@ -2254,6 +2330,10 @@ vec_fmt_time <- function(
 #'
 #' ### Seconds
 #'
+#' The second of the minute which can be any number from `0` to `59`. Use `"s"`
+#' to show the minimum number of digits, or `"ss"` to always show two digits
+#' (zero-padding, if necessary).
+#'
 #' | Field Patterns         | Output  | Notes                                |
 #' |------------------------|---------|--------------------------------------|
 #' | `"s"`                  | `"9"`   | Numeric, minimum digits              |
@@ -2261,13 +2341,22 @@ vec_fmt_time <- function(
 #'
 #' ### Fractional Second
 #'
+#' The fractional second truncates (like other time fields) to the width
+#' requested (i.e., count of letters). So using pattern `"SSSS"` will display
+#' four digits past the decimal (which, incidentally, needs to be added manually
+#' to the pattern).
+#'
 #' | Field Patterns                 | Output                                 |
 #' |--------------------------------|----------------------------------------|
 #' | `"S"` to `"SSSSSSSSS"`         | `"2"` -> `"235000000"`                 |
 #'
 #' ### Milliseconds Elapsed in Day
 #'
-#' Using: `"2011-07-27T00:07:19.7223"`
+#' There are 86,400,000 milliseconds in a day and the `"A"` pattern will provide
+#' the whole number. The width can go up to nine digits with `"AAAAAAAAA"` and
+#' these higher field widths will result in zero padding if necessary.
+#'
+#' Using `"2011-07-27T00:07:19.7223"`:
 #'
 #' | Field Patterns                 | Output                                 |
 #' |--------------------------------|----------------------------------------|
@@ -2277,7 +2366,9 @@ vec_fmt_time <- function(
 #'
 #' ### The Era Designator
 #'
-#' This provides the era name for the given date.
+#' This provides the era name for the given date. The Gregorian calendar has two
+#' eras: AD and BC. In the AD year numbering system, AD 1 is immediately
+#' preceded by 1 BC, with nothing in between them (there was no year zero).
 #'
 #' | Field Patterns                 | Output          | Notes                |
 #' |--------------------------------|-----------------|----------------------|
@@ -2289,12 +2380,27 @@ vec_fmt_time <- function(
 #'
 #' ### TZ // Short and Long Specific non-Location Format
 #'
+#' The short and long specific non-location formats for time zones are suggested
+#' for displaying a time with a user friendly time zone name. Where the short
+#' specific format is unavailable, it will fall back to the short localized GMT
+#' format (`"O"`). Where the long specific format is unavailable, it will fall
+#' back to the long localized GMT format (`"OOOO"`).
+#'
 #' | Field Patterns             | Output                    | Notes          |
 #' |----------------------------|---------------------------|----------------|
 #' | `"z"`, `"zz"`, or `"zzz"`  | `"PDT"`                   | Short Specific |
 #' | `"zzzz"`                   | `"Pacific Daylight Time"` | Long Specific  |
 #'
-#' ### TZ // Short and Long Specific non-Location Formats
+#' ### TZ // Common UTC Offset Formats
+#'
+#' The ISO8601 basic format with hours, minutes and optional seconds fields is
+#' represented by `"Z"`, `"ZZ"`, or `"ZZZ"`. The format is equivalent to RFC 822
+#' zone format (when the optional seconds field is absent). This is equivalent
+#' to the `"xxxx"` specifier. The field pattern `"ZZZZ"` represents the long
+#' localized GMT format. This is equivalent to the `"OOOO"` specifier. Finally,
+#' `"ZZZZZ"` pattern yields the ISO8601 extended format with hours, minutes and
+#' optional seconds fields. The ISO8601 UTC indicator `Z` is used when local
+#' time offset is `0`. This is equivalent to the `"XXXXX"` specifier.
 #'
 #' | Field Patterns             | Output       | Notes                       |
 #' |----------------------------|--------------|-----------------------------|
@@ -2304,19 +2410,34 @@ vec_fmt_time <- function(
 #'
 #' ### TZ // Short and Long Localized GMT Formats
 #'
+#' The localized GMT formats come in two widths `"O"` (which removes the minutes
+#' field if it's `0`) and `"OOOO"` (which always contains the minutes field).
+#' The use of the `GMT` indicator changes according to the locale.
+#'
 #' | Field Patterns          | Output        | Notes                         |
 #' |-------------------------|---------------|-------------------------------|
 #' | `"O"`                   | `"GMT-7"`     | Short localized GMT format    |
 #' | `"OOOO"`                | `"GMT-07:00"` | Long localized GMT format     |
 #'
-#' ### TZ // Short and Long Localized GMT Formats
+#' ### TZ // Short and Long Generic non-Location Formats
+#'
+#' The generic non-location formats are useful for displaying a recurring wall
+#' time (e.g., events, meetings) or anywhere people do not want to be overly
+#' specific. Where either of these is unavailable, there is a fallback to the
+#' generic location format (`"VVVV"`), then the short localized GMT format as
+#' the final fallback.
 #'
 #' | Field Patterns  | Output           | Notes                              |
 #' |-----------------|------------------|------------------------------------|
 #' | `"v"`           | `"PT"`           | Short generic non-location format  |
 #' | `"vvvv"`        | `"Pacific Time"` | Long generic non-location format   |
 #'
-#' ### TZ // Short Time Zone IDs and Exemplar City Formats (big V)
+#' ### TZ // Short Time Zone IDs and Exemplar City Formats
+#'
+#' These formats provide variations of the time zone ID and often include the
+#' exemplar city. The widest of these formats, `"VVVV"`, is useful for
+#' populating a choice list for time zones, because it supports 1-to-1 name/zone
+#' ID mapping and is more uniform than other text formats.
 #'
 #' | Field Patterns     | Output                | Notes                      |
 #' |--------------------|-----------------------|----------------------------|
@@ -2327,6 +2448,12 @@ vec_fmt_time <- function(
 #'
 #' ### TZ // ISO 8601 Formats with Z for +0000
 #'
+#' The `"X"`-`"XXX"` field patterns represent valid ISO 8601 patterns for time
+#' zone offsets in datetimes. The final two widths, `"XXXX"` and `"XXXXX"` allow
+#' for optional seconds fields. The seconds field is *not* supported by the ISO
+#' 8601 specification. For all of these, the ISO 8601 UTC indicator `Z` is used
+#' when the local time offset is `0`.
+#'
 #' | Field Patterns | Output     | Notes                                     |
 #' |----------------|------------|-------------------------------------------|
 #' | `"X"`          | `"-07"`    | ISO 8601 basic format (h, optional m)     |
@@ -2336,6 +2463,11 @@ vec_fmt_time <- function(
 #' | `"XXXXX"`      | `"-07:00"` | ISO 8601 extended format (h & m, optional s) |
 #'
 #' ### TZ // ISO 8601 Formats (no use of Z for +0000)
+#'
+#' The `"x"`-`"xxxxx"` field patterns represent valid ISO 8601 patterns for time
+#' zone offsets in datetimes. They are similar to the `"X"`-`"XXXXX"` field
+#' patterns except that the ISO 8601 UTC indicator `Z` *will not* be used when
+#' the local time offset is `0`.
 #'
 #' | Field Patterns | Output     | Notes                                     |
 #' |----------------|------------|-------------------------------------------|

--- a/man/fmt_datetime.Rd
+++ b/man/fmt_datetime.Rd
@@ -269,24 +269,22 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Quarter}{
-\subsection{Quarter of the Year: formatting ver.}{\tabular{lll}{
-   Field Patterns \tab Output \tab Notes \cr
-   \code{"Q"} \tab \code{"3"} \tab Numeric, one digit \cr
-   \code{"QQ"} \tab \code{"03"} \tab Numeric, two digits (zero padded) \cr
-   \code{"QQQ"} \tab \code{"Q3"} \tab Abbreviated \cr
-   \code{"QQQQ"} \tab \code{"3rd quarter"} \tab Wide \cr
-   \code{"QQQQQ"} \tab \code{"3"} \tab Narrow \cr
-}
+\subsection{Quarter of the Year: formatting and standalone versions}{
 
-}
-
-\subsection{Quarter of the Year: standalone ver.}{\tabular{lll}{
+The quarter names are identified numerically, starting at \code{1} and ending at
+\code{4}. Quarter names may vary along two axes: the width and the context. The
+context is either 'formatting' (taken as a default), which the form used
+within a complete date format string, or, 'standalone', the form for date
+elements used independently (such as in calendar headers). The standalone
+form may be used in any other date format that shares the same form of the
+name. Here, the formatting form for quarters of the year consists of some run
+of \code{"Q"} values whereas the standalone form uses \code{"q"}.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
-   \code{"q"} \tab \code{"3"} \tab Numeric, one digit \cr
-   \code{"qq"} \tab \code{"03"} \tab Numeric, two digits (zero padded) \cr
-   \code{"qqq"} \tab \code{"Q3"} \tab Abbreviated \cr
-   \code{"qqqq"} \tab \code{"3rd quarter"} \tab Wide \cr
-   \code{"qqqqq"} \tab \code{"3"} \tab Narrow \cr
+   \code{"Q"}/\code{"q"} \tab \code{"3"} \tab Numeric, one digit \cr
+   \code{"QQ"}/\code{"qq"} \tab \code{"03"} \tab Numeric, two digits (zero padded) \cr
+   \code{"QQQ"}/\code{"qqq"} \tab \code{"Q3"} \tab Abbreviated \cr
+   \code{"QQQQ"}/\code{"qqqq"} \tab \code{"3rd quarter"} \tab Wide \cr
+   \code{"QQQQQ"}/\code{"qqqqq"} \tab \code{"3"} \tab Narrow \cr
 }
 
 }
@@ -294,24 +292,22 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Month}{
-\subsection{Month: formatting ver.}{\tabular{lll}{
-   Field Patterns \tab Output \tab Notes \cr
-   \code{"M"} \tab \code{"7"} \tab Numeric, minimum digits \cr
-   \code{"MM"} \tab \code{"07"} \tab Numeric, two digits (zero padded) \cr
-   \code{"MMM"} \tab \code{"Jul"} \tab Abbreviated \cr
-   \code{"MMMM"} \tab \code{"July"} \tab Wide \cr
-   \code{"MMMMM"} \tab \code{"J"} \tab Narrow \cr
-}
+\subsection{Month: formatting and standalone versions}{
 
-}
-
-\subsection{Month: standalone ver.}{\tabular{lll}{
+The month names are identified numerically, starting at \code{1} and ending at
+\code{12}. Month names may vary along two axes: the width and the context. The
+context is either 'formatting' (taken as a default), which the form used
+within a complete date format string, or, 'standalone', the form for date
+elements used independently (such as in calendar headers). The standalone
+form may be used in any other date format that shares the same form of the
+name. Here, the formatting form for months consists of some run of \code{"M"}
+values whereas the standalone form uses \code{"L"}.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
-   \code{"M"} \tab \code{"7"} \tab Numeric, minimum digits \cr
-   \code{"MM"} \tab \code{"07"} \tab Numeric, two digits (zero padded) \cr
-   \code{"MMM"} \tab \code{"Jul"} \tab Abbreviated \cr
-   \code{"MMMM"} \tab \code{"July"} \tab Wide \cr
-   \code{"MMMMM"} \tab \code{"J"} \tab Narrow \cr
+   \code{"M"}/\code{"L"} \tab \code{"7"} \tab Numeric, minimum digits \cr
+   \code{"MM"}/\code{"LL"} \tab \code{"07"} \tab Numeric, two digits (zero padded) \cr
+   \code{"MMM"}/\code{"LLL"} \tab \code{"Jul"} \tab Abbreviated \cr
+   \code{"MMMM"}/\code{"LLLL"} \tab \code{"July"} \tab Wide \cr
+   \code{"MMMMM"}/\code{"LLLLL"} \tab \code{"J"} \tab Narrow \cr
 }
 
 }
@@ -319,7 +315,17 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Week}{
-\subsection{Week of Year}{\tabular{lll}{
+\subsection{Week of Year}{
+
+Values calculated for the week of year range from \code{1} to \code{53}. Week \code{1} for a
+year is the first week that contains at least the specified minimum number of
+days from that year. Weeks between week \code{1} of one year and week \code{1} of the
+following year are numbered sequentially from \code{2} to \code{52} or \code{53} (if
+needed).
+
+There are two available field lengths. Both will display the week of year
+value but the \code{"ww"} width will always show two digits (where weeks \code{1} to
+\code{9} are zero padded).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"w"} \tab \code{"27"} \tab Minimum digits \cr
    \code{"ww"} \tab \code{"27"} \tab Two digits (zero padded) \cr
@@ -327,7 +333,11 @@ defined by ISO 8601.\tabular{ll}{
 
 }
 
-\subsection{Week of Month}{\tabular{ll}{
+\subsection{Week of Month}{
+
+The week of a month can range from \code{1} to \code{5}. The first day of every month
+always begins at week \code{1} and with every transition into the beginning of a
+week, the week of month value is incremented by \code{1}.\tabular{ll}{
    Field Pattern \tab Output \cr
    \code{"W"} \tab \code{"1"} \cr
 }
@@ -337,7 +347,12 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Day}{
-\subsection{Day of Month}{\tabular{lll}{
+\subsection{Day of Month}{
+
+The day of month value is always numeric and there are two available field
+length choices in its formatting. Both will display the day of month value
+but the \code{"dd"} formatting will always show two digits (where days \code{1} to \code{9}
+are zero padded).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"d"} \tab \code{"4"} \tab Minimum digits \cr
    \code{"dd"} \tab \code{"04"} \tab Two digits, zero padded \cr
@@ -345,7 +360,12 @@ defined by ISO 8601.\tabular{ll}{
 
 }
 
-\subsection{Day of Year}{\tabular{lll}{
+\subsection{Day of Year}{
+
+The day of year value ranges from \code{1} (January 1) to either \code{365} or \code{366}
+(December 31), where the higher value of the range indicates that the year is
+a leap year (29 days in February, instead of 28). The field length specifies
+the minimum number of digits, with zero-padding as necessary.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"D"} \tab \code{"185"} \tab  \cr
    \code{"DD"} \tab \code{"185"} \tab Zero padded to minimum width of 2 \cr
@@ -354,14 +374,32 @@ defined by ISO 8601.\tabular{ll}{
 
 }
 
-\subsection{Day of Week in Month}{\tabular{ll}{
+\subsection{Day of Week in Month}{
+
+The day of week in month returns a numerical value indicating the number of
+times a given weekday had occurred in the month (e.g., '2nd Monday in
+March'). This conveniently resolves to predicable case structure where ranges
+of day of the month values return predictable day of week in month values:
+\itemize{
+\item days \code{1} - \code{7} -> \code{1}
+\item days \code{8} - \code{14} -> \code{2}
+\item days \code{15} - \code{21} -> \code{3}
+\item days \code{22} - \code{28} -> \code{4}
+\item days \code{29} - \code{31} -> \code{5}
+}\tabular{ll}{
    Field Pattern \tab Output \cr
    \code{"F"} \tab \code{"1"} \cr
 }
 
 }
 
-\subsection{Modified Julian Day}{\tabular{ll}{
+\subsection{Modified Julian Date}{
+
+The modified version of the Julian date is obtained by subtracting
+2,400,000.5 days from the Julian date (the number of days since January 1,
+4713 BC). This essentially results in the number of days since midnight
+November 17, 1858. There is a half day offset (unlike the Julian date, the
+modified Julian date is referenced to midnight instead of noon).\tabular{ll}{
    Field Patterns \tab Output \cr
    \code{"g"} to \code{"ggggggggg"} \tab \code{"58303"} -> \code{"000058303"} \cr
 }
@@ -371,7 +409,9 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Weekday}{
-\subsection{Day of Week Name}{\tabular{lll}{
+\subsection{Day of Week Name}{
+
+The name of the day of week is offered in four different widths.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"E"}, \code{"EE"}, or \code{"EEE"} \tab \code{"Wed"} \tab Abbreviated \cr
    \code{"EEEE"} \tab \code{"Wednesday"} \tab Wide \cr
@@ -384,7 +424,13 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Periods}{
-\subsection{AM/PM Period of Day}{\tabular{lll}{
+\subsection{AM/PM Period of Day}{
+
+This denotes before noon and after noon time periods. May be upper or
+lowercase depending on the locale and other options. The wide form may be
+the same as the short form if the 'real' long form (e.g. 'ante meridiem') is
+not customarily used. The narrow form must be unique, unlike some other
+fields.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"a"}, \code{"aa"}, or \code{"aaa"} \tab \code{"PM"} \tab Abbreviated \cr
    \code{"aaaa"} \tab \code{"PM"} \tab Wide \cr
@@ -395,8 +441,13 @@ defined by ISO 8601.\tabular{ll}{
 
 \subsection{AM/PM Period of Day Plus Noon and Midnight}{
 
-(a) \code{input_midnight}: \code{"2020-05-05T00:00:00"}
+Provide AM and PM as well as phrases for exactly noon and midnight. May be
+upper or lowercase depending on the locale and other options. If the locale
+doesn't have the notion of a unique 'noon' (i.e., 12:00), then the PM form
+may be substituted. A similar behavior can occur for 'midnight' (00:00) and
+the AM form. The narrow form must be unique, unlike some other fields.
 
+(a) \code{input_midnight}: \code{"2020-05-05T00:00:00"}
 (b) \code{input_noon}: \code{"2020-05-05T12:00:00"}\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"b"}, \code{"bb"}, or \code{"bbb"} \tab (a) \code{"midnight"} \tab Abbreviated \cr
@@ -411,8 +462,12 @@ defined by ISO 8601.\tabular{ll}{
 
 \subsection{Flexible Day Periods}{
 
-(a) \code{input_morning}: \code{"2020-05-05T00:08:30"}
+Flexible day periods denotes things like 'in the afternoon', 'in the
+evening', etc., and the flexibility comes from a locale's language and
+script. Each locale has an associated rule set that specifies when the day
+periods start and end for that locale.
 
+(a) \code{input_morning}: \code{"2020-05-05T00:08:30"}
 (b) \code{input_afternoon}: \code{"2020-05-05T14:00:00"}\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"B"}, \code{"BB"}, or \code{"BBB"} \tab (a) \code{"in the morning"} \tab Abbreviated \cr
@@ -428,19 +483,13 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Hours, Minutes, and Seconds}{
-\subsection{Hour 1-12}{
-
-Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
-   Field Patterns \tab Output \tab Notes \cr
-   \code{"h"} \tab \code{"8"} \tab Numeric, minimum digits \cr
-   \code{"hh"} \tab \code{"08"} \tab Numeric, 2 digits (zero padded) \cr
-}
-
-}
-
 \subsection{Hour 0-23}{
 
-Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
+Hours from \code{0} to \code{23} are for a standard 24-hour clock cycle (midnight plus
+1 minute is \code{00:01}) when using \code{"HH"} (which is the more common width that
+indicates zero-padding to 2 digits).
+
+Using \code{"2015-08-01T08:35:09"}:\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"H"} \tab \code{"8"} \tab Numeric, minimum digits \cr
    \code{"HH"} \tab \code{"08"} \tab Numeric, 2 digits (zero padded) \cr
@@ -448,19 +497,27 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 }
 
-\subsection{Hour 0-11}{
+\subsection{Hour 1-12}{
 
-Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
+Hours from \code{1} to \code{12} are for a standard 12-hour clock cycle (midnight plus
+1 minute is \code{12:01}) when using \code{"hh"} (which is the more common width that
+indicates zero-padding to 2 digits).
+
+Using \code{"2015-08-01T08:35:09"}:\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
-   \code{"K"} \tab \code{"7"} \tab Numeric, minimum digits \cr
-   \code{"KK"} \tab \code{"07"} \tab Numeric, 2 digits (zero padded) \cr
+   \code{"h"} \tab \code{"8"} \tab Numeric, minimum digits \cr
+   \code{"hh"} \tab \code{"08"} \tab Numeric, 2 digits (zero padded) \cr
 }
 
 }
 
 \subsection{Hour 1-24}{
 
-Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
+Using hours from \code{1} to \code{24} is a less common way to express a 24-hour clock
+cycle (midnight plus 1 minute is \code{24:01}) when using \code{"kk"} (which is the
+more common width that indicates zero-padding to 2 digits).
+
+Using \code{"2015-08-01T08:35:09"}:\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"k"} \tab \code{"9"} \tab Numeric, minimum digits \cr
    \code{"kk"} \tab \code{"09"} \tab Numeric, 2 digits (zero padded) \cr
@@ -468,7 +525,25 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 }
 
-\subsection{Minute}{\tabular{lll}{
+\subsection{Hour 0-11}{
+
+Using hours from \code{0} to \code{11} is a less common way to express a 12-hour clock
+cycle (midnight plus 1 minute is \code{00:01}) when using \code{"KK"} (which is the
+more common width that indicates zero-padding to 2 digits).
+
+Using \code{"2015-08-01T08:35:09"}:\tabular{lll}{
+   Field Patterns \tab Output \tab Notes \cr
+   \code{"K"} \tab \code{"7"} \tab Numeric, minimum digits \cr
+   \code{"KK"} \tab \code{"07"} \tab Numeric, 2 digits (zero padded) \cr
+}
+
+}
+
+\subsection{Minute}{
+
+The minute of the hour which can be any number from \code{0} to \code{59}. Use \code{"m"} to
+show the minimum number of digits, or \code{"mm"} to always show two digits
+(zero-padding, if necessary).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"m"} \tab \code{"5"} \tab Numeric, minimum digits \cr
    \code{"mm"} \tab \code{"06"} \tab Numeric, 2 digits (zero padded) \cr
@@ -476,7 +551,11 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 }
 
-\subsection{Seconds}{\tabular{lll}{
+\subsection{Seconds}{
+
+The second of the minute which can be any number from \code{0} to \code{59}. Use \code{"s"}
+to show the minimum number of digits, or \code{"ss"} to always show two digits
+(zero-padding, if necessary).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"s"} \tab \code{"9"} \tab Numeric, minimum digits \cr
    \code{"ss"} \tab \code{"09"} \tab Numeric, 2 digits (zero padded) \cr
@@ -484,7 +563,12 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 }
 
-\subsection{Fractional Second}{\tabular{ll}{
+\subsection{Fractional Second}{
+
+The fractional second truncates (like other time fields) to the width
+requested (i.e., count of letters). So using pattern \code{"SSSS"} will display
+four digits past the decimal (which, incidentally, needs to be added manually
+to the pattern).\tabular{ll}{
    Field Patterns \tab Output \cr
    \code{"S"} to \code{"SSSSSSSSS"} \tab \code{"2"} -> \code{"235000000"} \cr
 }
@@ -493,7 +577,11 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 \subsection{Milliseconds Elapsed in Day}{
 
-Using: \code{"2011-07-27T00:07:19.7223"}\tabular{ll}{
+There are 86,400,000 milliseconds in a day and the \code{"A"} pattern will provide
+the whole number. The width can go up to nine digits with \code{"AAAAAAAAA"} and
+these higher field widths will result in zero padding if necessary.
+
+Using \code{"2011-07-27T00:07:19.7223"}:\tabular{ll}{
    Field Patterns \tab Output \cr
    \code{"A"} to \code{"AAAAAAAAA"} \tab \code{"439722"} -> \code{"000439722"} \cr
 }
@@ -505,7 +593,9 @@ Using: \code{"2011-07-27T00:07:19.7223"}\tabular{ll}{
 \subsection{Era}{
 \subsection{The Era Designator}{
 
-This provides the era name for the given date.\tabular{lll}{
+This provides the era name for the given date. The Gregorian calendar has two
+eras: AD and BC. In the AD year numbering system, AD 1 is immediately
+preceded by 1 BC, with nothing in between them (there was no year zero).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"G"}, \code{"GG"}, or \code{"GGG"} \tab \code{"AD"} \tab Abbreviated \cr
    \code{"GGGG"} \tab \code{"Anno Domini"} \tab Wide \cr
@@ -517,7 +607,13 @@ This provides the era name for the given date.\tabular{lll}{
 }
 
 \subsection{Time Zones}{
-\subsection{TZ // Short and Long Specific non-Location Format}{\tabular{lll}{
+\subsection{TZ // Short and Long Specific non-Location Format}{
+
+The short and long specific non-location formats for time zones are suggested
+for displaying a time with a user friendly time zone name. Where the short
+specific format is unavailable, it will fall back to the short localized GMT
+format (\code{"O"}). Where the long specific format is unavailable, it will fall
+back to the long localized GMT format (\code{"OOOO"}).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"z"}, \code{"zz"}, or \code{"zzz"} \tab \code{"PDT"} \tab Short Specific \cr
    \code{"zzzz"} \tab \code{"Pacific Daylight Time"} \tab Long Specific \cr
@@ -525,7 +621,16 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // Short and Long Specific non-Location Formats}{\tabular{lll}{
+\subsection{TZ // Common UTC Offset Formats}{
+
+The ISO8601 basic format with hours, minutes and optional seconds fields is
+represented by \code{"Z"}, \code{"ZZ"}, or \code{"ZZZ"}. The format is equivalent to RFC 822
+zone format (when the optional seconds field is absent). This is equivalent
+to the \code{"xxxx"} specifier. The field pattern \code{"ZZZZ"} represents the long
+localized GMT format. This is equivalent to the \code{"OOOO"} specifier. Finally,
+\code{"ZZZZZ"} pattern yields the ISO8601 extended format with hours, minutes and
+optional seconds fields. The ISO8601 UTC indicator \code{Z} is used when local
+time offset is \code{0}. This is equivalent to the \code{"XXXXX"} specifier.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"Z"}, \code{"ZZ"}, or \code{"ZZZ"} \tab \code{"-0700"} \tab ISO 8601 basic format \cr
    \code{"ZZZZ"} \tab \code{"GMT-7:00"} \tab Long localized GMT format \cr
@@ -534,7 +639,11 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // Short and Long Localized GMT Formats}{\tabular{lll}{
+\subsection{TZ // Short and Long Localized GMT Formats}{
+
+The localized GMT formats come in two widths \code{"O"} (which removes the minutes
+field if it's \code{0}) and \code{"OOOO"} (which always contains the minutes field).
+The use of the \code{GMT} indicator changes according to the locale.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"O"} \tab \code{"GMT-7"} \tab Short localized GMT format \cr
    \code{"OOOO"} \tab \code{"GMT-07:00"} \tab Long localized GMT format \cr
@@ -542,7 +651,13 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // Short and Long Localized GMT Formats}{\tabular{lll}{
+\subsection{TZ // Short and Long Generic non-Location Formats}{
+
+The generic non-location formats are useful for displaying a recurring wall
+time (e.g., events, meetings) or anywhere people do not want to be overly
+specific. Where either of these is unavailable, there is a fallback to the
+generic location format (\code{"VVVV"}), then the short localized GMT format as
+the final fallback.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"v"} \tab \code{"PT"} \tab Short generic non-location format \cr
    \code{"vvvv"} \tab \code{"Pacific Time"} \tab Long generic non-location format \cr
@@ -550,7 +665,12 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // Short Time Zone IDs and Exemplar City Formats (big V)}{\tabular{lll}{
+\subsection{TZ // Short Time Zone IDs and Exemplar City Formats}{
+
+These formats provide variations of the time zone ID and often include the
+exemplar city. The widest of these formats, \code{"VVVV"}, is useful for
+populating a choice list for time zones, because it supports 1-to-1 name/zone
+ID mapping and is more uniform than other text formats.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"V"} \tab \code{"cavan"} \tab Short time zone ID \cr
    \code{"VV"} \tab \code{"America/Vancouver"} \tab Long time zone ID \cr
@@ -560,7 +680,13 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // ISO 8601 Formats with Z for +0000}{\tabular{lll}{
+\subsection{TZ // ISO 8601 Formats with Z for +0000}{
+
+The \code{"X"}-\code{"XXX"} field patterns represent valid ISO 8601 patterns for time
+zone offsets in datetimes. The final two widths, \code{"XXXX"} and \code{"XXXXX"} allow
+for optional seconds fields. The seconds field is \emph{not} supported by the ISO
+8601 specification. For all of these, the ISO 8601 UTC indicator \code{Z} is used
+when the local time offset is \code{0}.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"X"} \tab \code{"-07"} \tab ISO 8601 basic format (h, optional m) \cr
    \code{"XX"} \tab \code{"-0700"} \tab ISO 8601 basic format (h & m) \cr
@@ -571,7 +697,12 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // ISO 8601 Formats (no use of Z for +0000)}{\tabular{lll}{
+\subsection{TZ // ISO 8601 Formats (no use of Z for +0000)}{
+
+The \code{"x"}-\code{"xxxxx"} field patterns represent valid ISO 8601 patterns for time
+zone offsets in datetimes. They are similar to the \code{"X"}-\code{"XXXXX"} field
+patterns except that the ISO 8601 UTC indicator \code{Z} \emph{will not} be used when
+the local time offset is \code{0}.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"x"} \tab \code{"-07"} \tab ISO 8601 basic format (h, optional m) \cr
    \code{"xx"} \tab \code{"-0700"} \tab ISO 8601 basic format (h & m) \cr

--- a/man/vec_fmt_datetime.Rd
+++ b/man/vec_fmt_datetime.Rd
@@ -248,24 +248,22 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Quarter}{
-\subsection{Quarter of the Year: formatting ver.}{\tabular{lll}{
-   Field Patterns \tab Output \tab Notes \cr
-   \code{"Q"} \tab \code{"3"} \tab Numeric, one digit \cr
-   \code{"QQ"} \tab \code{"03"} \tab Numeric, two digits (zero padded) \cr
-   \code{"QQQ"} \tab \code{"Q3"} \tab Abbreviated \cr
-   \code{"QQQQ"} \tab \code{"3rd quarter"} \tab Wide \cr
-   \code{"QQQQQ"} \tab \code{"3"} \tab Narrow \cr
-}
+\subsection{Quarter of the Year: formatting and standalone versions}{
 
-}
-
-\subsection{Quarter of the Year: standalone ver.}{\tabular{lll}{
+The quarter names are identified numerically, starting at \code{1} and ending at
+\code{4}. Quarter names may vary along two axes: the width and the context. The
+context is either 'formatting' (taken as a default), which the form used
+within a complete date format string, or, 'standalone', the form for date
+elements used independently (such as in calendar headers). The standalone
+form may be used in any other date format that shares the same form of the
+name. Here, the formatting form for quarters of the year consists of some run
+of \code{"Q"} values whereas the standalone form uses \code{"q"}.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
-   \code{"q"} \tab \code{"3"} \tab Numeric, one digit \cr
-   \code{"qq"} \tab \code{"03"} \tab Numeric, two digits (zero padded) \cr
-   \code{"qqq"} \tab \code{"Q3"} \tab Abbreviated \cr
-   \code{"qqqq"} \tab \code{"3rd quarter"} \tab Wide \cr
-   \code{"qqqqq"} \tab \code{"3"} \tab Narrow \cr
+   \code{"Q"}/\code{"q"} \tab \code{"3"} \tab Numeric, one digit \cr
+   \code{"QQ"}/\code{"qq"} \tab \code{"03"} \tab Numeric, two digits (zero padded) \cr
+   \code{"QQQ"}/\code{"qqq"} \tab \code{"Q3"} \tab Abbreviated \cr
+   \code{"QQQQ"}/\code{"qqqq"} \tab \code{"3rd quarter"} \tab Wide \cr
+   \code{"QQQQQ"}/\code{"qqqqq"} \tab \code{"3"} \tab Narrow \cr
 }
 
 }
@@ -273,24 +271,22 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Month}{
-\subsection{Month: formatting ver.}{\tabular{lll}{
-   Field Patterns \tab Output \tab Notes \cr
-   \code{"M"} \tab \code{"7"} \tab Numeric, minimum digits \cr
-   \code{"MM"} \tab \code{"07"} \tab Numeric, two digits (zero padded) \cr
-   \code{"MMM"} \tab \code{"Jul"} \tab Abbreviated \cr
-   \code{"MMMM"} \tab \code{"July"} \tab Wide \cr
-   \code{"MMMMM"} \tab \code{"J"} \tab Narrow \cr
-}
+\subsection{Month: formatting and standalone versions}{
 
-}
-
-\subsection{Month: standalone ver.}{\tabular{lll}{
+The month names are identified numerically, starting at \code{1} and ending at
+\code{12}. Month names may vary along two axes: the width and the context. The
+context is either 'formatting' (taken as a default), which the form used
+within a complete date format string, or, 'standalone', the form for date
+elements used independently (such as in calendar headers). The standalone
+form may be used in any other date format that shares the same form of the
+name. Here, the formatting form for months consists of some run of \code{"M"}
+values whereas the standalone form uses \code{"L"}.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
-   \code{"M"} \tab \code{"7"} \tab Numeric, minimum digits \cr
-   \code{"MM"} \tab \code{"07"} \tab Numeric, two digits (zero padded) \cr
-   \code{"MMM"} \tab \code{"Jul"} \tab Abbreviated \cr
-   \code{"MMMM"} \tab \code{"July"} \tab Wide \cr
-   \code{"MMMMM"} \tab \code{"J"} \tab Narrow \cr
+   \code{"M"}/\code{"L"} \tab \code{"7"} \tab Numeric, minimum digits \cr
+   \code{"MM"}/\code{"LL"} \tab \code{"07"} \tab Numeric, two digits (zero padded) \cr
+   \code{"MMM"}/\code{"LLL"} \tab \code{"Jul"} \tab Abbreviated \cr
+   \code{"MMMM"}/\code{"LLLL"} \tab \code{"July"} \tab Wide \cr
+   \code{"MMMMM"}/\code{"LLLLL"} \tab \code{"J"} \tab Narrow \cr
 }
 
 }
@@ -298,7 +294,17 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Week}{
-\subsection{Week of Year}{\tabular{lll}{
+\subsection{Week of Year}{
+
+Values calculated for the week of year range from \code{1} to \code{53}. Week \code{1} for a
+year is the first week that contains at least the specified minimum number of
+days from that year. Weeks between week \code{1} of one year and week \code{1} of the
+following year are numbered sequentially from \code{2} to \code{52} or \code{53} (if
+needed).
+
+There are two available field lengths. Both will display the week of year
+value but the \code{"ww"} width will always show two digits (where weeks \code{1} to
+\code{9} are zero padded).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"w"} \tab \code{"27"} \tab Minimum digits \cr
    \code{"ww"} \tab \code{"27"} \tab Two digits (zero padded) \cr
@@ -306,7 +312,11 @@ defined by ISO 8601.\tabular{ll}{
 
 }
 
-\subsection{Week of Month}{\tabular{ll}{
+\subsection{Week of Month}{
+
+The week of a month can range from \code{1} to \code{5}. The first day of every month
+always begins at week \code{1} and with every transition into the beginning of a
+week, the week of month value is incremented by \code{1}.\tabular{ll}{
    Field Pattern \tab Output \cr
    \code{"W"} \tab \code{"1"} \cr
 }
@@ -316,7 +326,12 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Day}{
-\subsection{Day of Month}{\tabular{lll}{
+\subsection{Day of Month}{
+
+The day of month value is always numeric and there are two available field
+length choices in its formatting. Both will display the day of month value
+but the \code{"dd"} formatting will always show two digits (where days \code{1} to \code{9}
+are zero padded).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"d"} \tab \code{"4"} \tab Minimum digits \cr
    \code{"dd"} \tab \code{"04"} \tab Two digits, zero padded \cr
@@ -324,7 +339,12 @@ defined by ISO 8601.\tabular{ll}{
 
 }
 
-\subsection{Day of Year}{\tabular{lll}{
+\subsection{Day of Year}{
+
+The day of year value ranges from \code{1} (January 1) to either \code{365} or \code{366}
+(December 31), where the higher value of the range indicates that the year is
+a leap year (29 days in February, instead of 28). The field length specifies
+the minimum number of digits, with zero-padding as necessary.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"D"} \tab \code{"185"} \tab  \cr
    \code{"DD"} \tab \code{"185"} \tab Zero padded to minimum width of 2 \cr
@@ -333,14 +353,32 @@ defined by ISO 8601.\tabular{ll}{
 
 }
 
-\subsection{Day of Week in Month}{\tabular{ll}{
+\subsection{Day of Week in Month}{
+
+The day of week in month returns a numerical value indicating the number of
+times a given weekday had occurred in the month (e.g., '2nd Monday in
+March'). This conveniently resolves to predicable case structure where ranges
+of day of the month values return predictable day of week in month values:
+\itemize{
+\item days \code{1} - \code{7} -> \code{1}
+\item days \code{8} - \code{14} -> \code{2}
+\item days \code{15} - \code{21} -> \code{3}
+\item days \code{22} - \code{28} -> \code{4}
+\item days \code{29} - \code{31} -> \code{5}
+}\tabular{ll}{
    Field Pattern \tab Output \cr
    \code{"F"} \tab \code{"1"} \cr
 }
 
 }
 
-\subsection{Modified Julian Day}{\tabular{ll}{
+\subsection{Modified Julian Date}{
+
+The modified version of the Julian date is obtained by subtracting
+2,400,000.5 days from the Julian date (the number of days since January 1,
+4713 BC). This essentially results in the number of days since midnight
+November 17, 1858. There is a half day offset (unlike the Julian date, the
+modified Julian date is referenced to midnight instead of noon).\tabular{ll}{
    Field Patterns \tab Output \cr
    \code{"g"} to \code{"ggggggggg"} \tab \code{"58303"} -> \code{"000058303"} \cr
 }
@@ -350,7 +388,9 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Weekday}{
-\subsection{Day of Week Name}{\tabular{lll}{
+\subsection{Day of Week Name}{
+
+The name of the day of week is offered in four different widths.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"E"}, \code{"EE"}, or \code{"EEE"} \tab \code{"Wed"} \tab Abbreviated \cr
    \code{"EEEE"} \tab \code{"Wednesday"} \tab Wide \cr
@@ -363,7 +403,13 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Periods}{
-\subsection{AM/PM Period of Day}{\tabular{lll}{
+\subsection{AM/PM Period of Day}{
+
+This denotes before noon and after noon time periods. May be upper or
+lowercase depending on the locale and other options. The wide form may be
+the same as the short form if the 'real' long form (e.g. 'ante meridiem') is
+not customarily used. The narrow form must be unique, unlike some other
+fields.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"a"}, \code{"aa"}, or \code{"aaa"} \tab \code{"PM"} \tab Abbreviated \cr
    \code{"aaaa"} \tab \code{"PM"} \tab Wide \cr
@@ -374,8 +420,13 @@ defined by ISO 8601.\tabular{ll}{
 
 \subsection{AM/PM Period of Day Plus Noon and Midnight}{
 
-(a) \code{input_midnight}: \code{"2020-05-05T00:00:00"}
+Provide AM and PM as well as phrases for exactly noon and midnight. May be
+upper or lowercase depending on the locale and other options. If the locale
+doesn't have the notion of a unique 'noon' (i.e., 12:00), then the PM form
+may be substituted. A similar behavior can occur for 'midnight' (00:00) and
+the AM form. The narrow form must be unique, unlike some other fields.
 
+(a) \code{input_midnight}: \code{"2020-05-05T00:00:00"}
 (b) \code{input_noon}: \code{"2020-05-05T12:00:00"}\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"b"}, \code{"bb"}, or \code{"bbb"} \tab (a) \code{"midnight"} \tab Abbreviated \cr
@@ -390,8 +441,12 @@ defined by ISO 8601.\tabular{ll}{
 
 \subsection{Flexible Day Periods}{
 
-(a) \code{input_morning}: \code{"2020-05-05T00:08:30"}
+Flexible day periods denotes things like 'in the afternoon', 'in the
+evening', etc., and the flexibility comes from a locale's language and
+script. Each locale has an associated rule set that specifies when the day
+periods start and end for that locale.
 
+(a) \code{input_morning}: \code{"2020-05-05T00:08:30"}
 (b) \code{input_afternoon}: \code{"2020-05-05T14:00:00"}\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"B"}, \code{"BB"}, or \code{"BBB"} \tab (a) \code{"in the morning"} \tab Abbreviated \cr
@@ -407,19 +462,13 @@ defined by ISO 8601.\tabular{ll}{
 }
 
 \subsection{Hours, Minutes, and Seconds}{
-\subsection{Hour 1-12}{
-
-Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
-   Field Patterns \tab Output \tab Notes \cr
-   \code{"h"} \tab \code{"8"} \tab Numeric, minimum digits \cr
-   \code{"hh"} \tab \code{"08"} \tab Numeric, 2 digits (zero padded) \cr
-}
-
-}
-
 \subsection{Hour 0-23}{
 
-Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
+Hours from \code{0} to \code{23} are for a standard 24-hour clock cycle (midnight plus
+1 minute is \code{00:01}) when using \code{"HH"} (which is the more common width that
+indicates zero-padding to 2 digits).
+
+Using \code{"2015-08-01T08:35:09"}:\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"H"} \tab \code{"8"} \tab Numeric, minimum digits \cr
    \code{"HH"} \tab \code{"08"} \tab Numeric, 2 digits (zero padded) \cr
@@ -427,19 +476,27 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 }
 
-\subsection{Hour 0-11}{
+\subsection{Hour 1-12}{
 
-Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
+Hours from \code{1} to \code{12} are for a standard 12-hour clock cycle (midnight plus
+1 minute is \code{12:01}) when using \code{"hh"} (which is the more common width that
+indicates zero-padding to 2 digits).
+
+Using \code{"2015-08-01T08:35:09"}:\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
-   \code{"K"} \tab \code{"7"} \tab Numeric, minimum digits \cr
-   \code{"KK"} \tab \code{"07"} \tab Numeric, 2 digits (zero padded) \cr
+   \code{"h"} \tab \code{"8"} \tab Numeric, minimum digits \cr
+   \code{"hh"} \tab \code{"08"} \tab Numeric, 2 digits (zero padded) \cr
 }
 
 }
 
 \subsection{Hour 1-24}{
 
-Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
+Using hours from \code{1} to \code{24} is a less common way to express a 24-hour clock
+cycle (midnight plus 1 minute is \code{24:01}) when using \code{"kk"} (which is the
+more common width that indicates zero-padding to 2 digits).
+
+Using \code{"2015-08-01T08:35:09"}:\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"k"} \tab \code{"9"} \tab Numeric, minimum digits \cr
    \code{"kk"} \tab \code{"09"} \tab Numeric, 2 digits (zero padded) \cr
@@ -447,7 +504,25 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 }
 
-\subsection{Minute}{\tabular{lll}{
+\subsection{Hour 0-11}{
+
+Using hours from \code{0} to \code{11} is a less common way to express a 12-hour clock
+cycle (midnight plus 1 minute is \code{00:01}) when using \code{"KK"} (which is the
+more common width that indicates zero-padding to 2 digits).
+
+Using \code{"2015-08-01T08:35:09"}:\tabular{lll}{
+   Field Patterns \tab Output \tab Notes \cr
+   \code{"K"} \tab \code{"7"} \tab Numeric, minimum digits \cr
+   \code{"KK"} \tab \code{"07"} \tab Numeric, 2 digits (zero padded) \cr
+}
+
+}
+
+\subsection{Minute}{
+
+The minute of the hour which can be any number from \code{0} to \code{59}. Use \code{"m"} to
+show the minimum number of digits, or \code{"mm"} to always show two digits
+(zero-padding, if necessary).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"m"} \tab \code{"5"} \tab Numeric, minimum digits \cr
    \code{"mm"} \tab \code{"06"} \tab Numeric, 2 digits (zero padded) \cr
@@ -455,7 +530,11 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 }
 
-\subsection{Seconds}{\tabular{lll}{
+\subsection{Seconds}{
+
+The second of the minute which can be any number from \code{0} to \code{59}. Use \code{"s"}
+to show the minimum number of digits, or \code{"ss"} to always show two digits
+(zero-padding, if necessary).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"s"} \tab \code{"9"} \tab Numeric, minimum digits \cr
    \code{"ss"} \tab \code{"09"} \tab Numeric, 2 digits (zero padded) \cr
@@ -463,7 +542,12 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 }
 
-\subsection{Fractional Second}{\tabular{ll}{
+\subsection{Fractional Second}{
+
+The fractional second truncates (like other time fields) to the width
+requested (i.e., count of letters). So using pattern \code{"SSSS"} will display
+four digits past the decimal (which, incidentally, needs to be added manually
+to the pattern).\tabular{ll}{
    Field Patterns \tab Output \cr
    \code{"S"} to \code{"SSSSSSSSS"} \tab \code{"2"} -> \code{"235000000"} \cr
 }
@@ -472,7 +556,11 @@ Using: \code{"2015-08-01T08:35:09"}\tabular{lll}{
 
 \subsection{Milliseconds Elapsed in Day}{
 
-Using: \code{"2011-07-27T00:07:19.7223"}\tabular{ll}{
+There are 86,400,000 milliseconds in a day and the \code{"A"} pattern will provide
+the whole number. The width can go up to nine digits with \code{"AAAAAAAAA"} and
+these higher field widths will result in zero padding if necessary.
+
+Using \code{"2011-07-27T00:07:19.7223"}:\tabular{ll}{
    Field Patterns \tab Output \cr
    \code{"A"} to \code{"AAAAAAAAA"} \tab \code{"439722"} -> \code{"000439722"} \cr
 }
@@ -484,7 +572,9 @@ Using: \code{"2011-07-27T00:07:19.7223"}\tabular{ll}{
 \subsection{Era}{
 \subsection{The Era Designator}{
 
-This provides the era name for the given date.\tabular{lll}{
+This provides the era name for the given date. The Gregorian calendar has two
+eras: AD and BC. In the AD year numbering system, AD 1 is immediately
+preceded by 1 BC, with nothing in between them (there was no year zero).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"G"}, \code{"GG"}, or \code{"GGG"} \tab \code{"AD"} \tab Abbreviated \cr
    \code{"GGGG"} \tab \code{"Anno Domini"} \tab Wide \cr
@@ -496,7 +586,13 @@ This provides the era name for the given date.\tabular{lll}{
 }
 
 \subsection{Time Zones}{
-\subsection{TZ // Short and Long Specific non-Location Format}{\tabular{lll}{
+\subsection{TZ // Short and Long Specific non-Location Format}{
+
+The short and long specific non-location formats for time zones are suggested
+for displaying a time with a user friendly time zone name. Where the short
+specific format is unavailable, it will fall back to the short localized GMT
+format (\code{"O"}). Where the long specific format is unavailable, it will fall
+back to the long localized GMT format (\code{"OOOO"}).\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"z"}, \code{"zz"}, or \code{"zzz"} \tab \code{"PDT"} \tab Short Specific \cr
    \code{"zzzz"} \tab \code{"Pacific Daylight Time"} \tab Long Specific \cr
@@ -504,7 +600,16 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // Short and Long Specific non-Location Formats}{\tabular{lll}{
+\subsection{TZ // Common UTC Offset Formats}{
+
+The ISO8601 basic format with hours, minutes and optional seconds fields is
+represented by \code{"Z"}, \code{"ZZ"}, or \code{"ZZZ"}. The format is equivalent to RFC 822
+zone format (when the optional seconds field is absent). This is equivalent
+to the \code{"xxxx"} specifier. The field pattern \code{"ZZZZ"} represents the long
+localized GMT format. This is equivalent to the \code{"OOOO"} specifier. Finally,
+\code{"ZZZZZ"} pattern yields the ISO8601 extended format with hours, minutes and
+optional seconds fields. The ISO8601 UTC indicator \code{Z} is used when local
+time offset is \code{0}. This is equivalent to the \code{"XXXXX"} specifier.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"Z"}, \code{"ZZ"}, or \code{"ZZZ"} \tab \code{"-0700"} \tab ISO 8601 basic format \cr
    \code{"ZZZZ"} \tab \code{"GMT-7:00"} \tab Long localized GMT format \cr
@@ -513,7 +618,11 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // Short and Long Localized GMT Formats}{\tabular{lll}{
+\subsection{TZ // Short and Long Localized GMT Formats}{
+
+The localized GMT formats come in two widths \code{"O"} (which removes the minutes
+field if it's \code{0}) and \code{"OOOO"} (which always contains the minutes field).
+The use of the \code{GMT} indicator changes according to the locale.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"O"} \tab \code{"GMT-7"} \tab Short localized GMT format \cr
    \code{"OOOO"} \tab \code{"GMT-07:00"} \tab Long localized GMT format \cr
@@ -521,7 +630,13 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // Short and Long Localized GMT Formats}{\tabular{lll}{
+\subsection{TZ // Short and Long Generic non-Location Formats}{
+
+The generic non-location formats are useful for displaying a recurring wall
+time (e.g., events, meetings) or anywhere people do not want to be overly
+specific. Where either of these is unavailable, there is a fallback to the
+generic location format (\code{"VVVV"}), then the short localized GMT format as
+the final fallback.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"v"} \tab \code{"PT"} \tab Short generic non-location format \cr
    \code{"vvvv"} \tab \code{"Pacific Time"} \tab Long generic non-location format \cr
@@ -529,7 +644,12 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // Short Time Zone IDs and Exemplar City Formats (big V)}{\tabular{lll}{
+\subsection{TZ // Short Time Zone IDs and Exemplar City Formats}{
+
+These formats provide variations of the time zone ID and often include the
+exemplar city. The widest of these formats, \code{"VVVV"}, is useful for
+populating a choice list for time zones, because it supports 1-to-1 name/zone
+ID mapping and is more uniform than other text formats.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"V"} \tab \code{"cavan"} \tab Short time zone ID \cr
    \code{"VV"} \tab \code{"America/Vancouver"} \tab Long time zone ID \cr
@@ -539,7 +659,13 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // ISO 8601 Formats with Z for +0000}{\tabular{lll}{
+\subsection{TZ // ISO 8601 Formats with Z for +0000}{
+
+The \code{"X"}-\code{"XXX"} field patterns represent valid ISO 8601 patterns for time
+zone offsets in datetimes. The final two widths, \code{"XXXX"} and \code{"XXXXX"} allow
+for optional seconds fields. The seconds field is \emph{not} supported by the ISO
+8601 specification. For all of these, the ISO 8601 UTC indicator \code{Z} is used
+when the local time offset is \code{0}.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"X"} \tab \code{"-07"} \tab ISO 8601 basic format (h, optional m) \cr
    \code{"XX"} \tab \code{"-0700"} \tab ISO 8601 basic format (h & m) \cr
@@ -550,7 +676,12 @@ This provides the era name for the given date.\tabular{lll}{
 
 }
 
-\subsection{TZ // ISO 8601 Formats (no use of Z for +0000)}{\tabular{lll}{
+\subsection{TZ // ISO 8601 Formats (no use of Z for +0000)}{
+
+The \code{"x"}-\code{"xxxxx"} field patterns represent valid ISO 8601 patterns for time
+zone offsets in datetimes. They are similar to the \code{"X"}-\code{"XXXXX"} field
+patterns except that the ISO 8601 UTC indicator \code{Z} \emph{will not} be used when
+the local time offset is \code{0}.\tabular{lll}{
    Field Patterns \tab Output \tab Notes \cr
    \code{"x"} \tab \code{"-07"} \tab ISO 8601 basic format (h, optional m) \cr
    \code{"xx"} \tab \code{"-0700"} \tab ISO 8601 basic format (h & m) \cr


### PR DESCRIPTION
This improves the documentation within `fmt_datetime()` and `vec_fmt_datetime()`, particularly within the 'Formatting with a *CLDR* datetime pattern' section (available in both functions).