### PR TITLE
Use rlang::arg_match() instead of match.arg() - issue: #672

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 # gt 0.7.0
 
+*  Issue: [Use rlang::arg_match() instead of match.arg() #672](https://github.com/rstudio/gt/issues/672) , My GitHub username: [mojister](https://github.com/mojister) 
+
 ## New features
 
 * We can now export **gt** tables as Word documents. This is thanks to @thebioengineer (Ellis Hughes!) who not only made this type of output work through `gtsave()` (writes the .docx file) but also through `as_word()` (gives you an OOXML string) (#121, #929). (#962, #986, #1016)

--- a/R/data_color.R
+++ b/R/data_color.R
@@ -149,10 +149,10 @@ data_color <- function(
   stop_if_not_gt(data = data)
 
   # Get the correct `apply_to` value
-  apply_to <- match.arg(apply_to)
+  apply_to <- rlang::arg_match(apply_to)
 
   # Get the correct `contrast_algo` value
-  contrast_algo <- match.arg(contrast_algo)
+  contrast_algo <- rlang::arg_match(contrast_algo)
 
   colors <- rlang::enquo(colors)
 
@@ -381,7 +381,7 @@ ideal_fgnd_color <- function(
 ) {
 
   # Get the correct `algo` value
-  algo <- match.arg(algo)
+  algo <- rlang::arg_match(algo)
 
   # Normalize color to hexadecimal color if it is in the 'rgba()' string format
   bgnd_color <- rgba_to_hex(colors = bgnd_color)

--- a/R/export.R
+++ b/R/export.R
@@ -675,7 +675,7 @@ as_word <- function(
   # Perform input object validation
   stop_if_not_gt(data = data)
 
-  caption_location <- match.arg(caption_location)
+  caption_location <- rlang::arg_match(caption_location)
 
   # Build all table data objects through a common pipeline
   value <- build_data(data = data, context = "word")
@@ -1014,7 +1014,7 @@ extract_cells <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -184,7 +184,7 @@ fmt_number <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that arguments are matched
-  system <- match.arg(system)
+  system <- rlang::arg_match(system)
 
   # Resolve the `locale` value here with the global locale value
   locale <- resolve_locale(data = data, locale = locale)
@@ -810,7 +810,7 @@ fmt_symbol <- function(
 ) {
 
   # Ensure that arguments are matched
-  system <- match.arg(system)
+  system <- rlang::arg_match(system)
 
   # Use locale-based marks if a locale ID is provided
   sep_mark <- get_locale_sep_mark(locale, sep_mark, use_seps)
@@ -1027,7 +1027,7 @@ fmt_percent <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that arguments are matched
-  system <- match.arg(system)
+  system <- rlang::arg_match(system)
 
   # Resolve the `locale` value here with the global locale value
   locale <- resolve_locale(data = data, locale = locale)
@@ -1187,8 +1187,8 @@ fmt_partsper <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that arguments are matched
-  to_units <- match.arg(to_units)
-  system <- match.arg(system)
+  to_units <- rlang::arg_match(to_units)
+  system <- rlang::arg_match(system)
 
   # Resolve the `locale` value here with the global locale value
   locale <- resolve_locale(data = data, locale = locale)
@@ -1420,8 +1420,8 @@ fmt_fraction <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that arguments are matched
-  system <- match.arg(system)
-  layout <- match.arg(layout)
+  system <- rlang::arg_match(system)
+  layout <- rlang::arg_match(layout)
 
   if (is.null(accuracy)) {
 
@@ -1890,7 +1890,7 @@ fmt_currency <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that arguments are matched
-  system <- match.arg(system)
+  system <- rlang::arg_match(system)
 
   # Resolve the `locale` value here with the global locale value
   locale <- resolve_locale(data = data, locale = locale)
@@ -1997,7 +1997,7 @@ fmt_roman <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that arguments are matched
-  case <- match.arg(case)
+  case <- rlang::arg_match(case)
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
@@ -2165,7 +2165,7 @@ fmt_bytes <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that arguments are matched
-  standard <- match.arg(standard)
+  standard <- rlang::arg_match(standard)
 
   # Stop function if any columns have data that is incompatible
   # with this formatter
@@ -3722,8 +3722,8 @@ fmt_duration <- function(
   stop_if_not_gt(data = data)
 
   # Ensure that arguments are matched
-  duration_style <- match.arg(duration_style)
-  system <- match.arg(system)
+  duration_style <- rlang::arg_match(duration_style)
+  system <- rlang::arg_match(system)
 
   # Duration values will never have decimal marks
   dec_mark <- "unused"

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -182,7 +182,7 @@ vec_fmt_number <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -449,7 +449,7 @@ vec_fmt_scientific <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -586,7 +586,7 @@ vec_fmt_engineering <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -749,7 +749,7 @@ vec_fmt_percent <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -931,7 +931,7 @@ vec_fmt_partsper <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -941,7 +941,7 @@ vec_fmt_partsper <- function(
   stop_if_not_vector(x)
 
   # Ensure that `to_units` is matched correctly to one option
-  to_units <- match.arg(to_units)
+  to_units <- rlang::arg_match(to_units)
 
   # Stop function if class of `x` is incompatible with the formatting
   if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
@@ -1072,7 +1072,7 @@ vec_fmt_fraction <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1082,7 +1082,7 @@ vec_fmt_fraction <- function(
   stop_if_not_vector(x)
 
   # Ensure that `layout` is matched correctly to one option
-  layout <- match.arg(layout)
+  layout <- rlang::arg_match(layout)
 
   # Stop function if class of `x` is incompatible with the formatting
   if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
@@ -1256,7 +1256,7 @@ vec_fmt_currency <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1367,7 +1367,7 @@ vec_fmt_roman <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1377,7 +1377,7 @@ vec_fmt_roman <- function(
   stop_if_not_vector(x)
 
   # Ensure that `case` is matched correctly to one option
-  case <- match.arg(case)
+  case <- rlang::arg_match(case)
 
   # Stop function if class of `x` is incompatible with the formatting
   if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
@@ -1516,7 +1516,7 @@ vec_fmt_bytes <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1526,7 +1526,7 @@ vec_fmt_bytes <- function(
   stop_if_not_vector(x)
 
   # Ensure that `standard` is matched correctly to one option
-  standard <- match.arg(standard)
+  standard <- rlang::arg_match(standard)
 
   # Stop function if class of `x` is incompatible with the formatting
   if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
@@ -1701,7 +1701,7 @@ vec_fmt_date <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1863,7 +1863,7 @@ vec_fmt_time <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -2685,7 +2685,7 @@ vec_fmt_datetime <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -2908,7 +2908,7 @@ vec_fmt_duration <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -2918,7 +2918,7 @@ vec_fmt_duration <- function(
   stop_if_not_vector(x)
 
   # Ensure that `duration_style` is matched correctly to one option
-  duration_style <- match.arg(duration_style)
+  duration_style <- rlang::arg_match(duration_style)
 
   # Stop function if class of `x` is incompatible with the formatting
   if (!vector_class_is_valid(x, valid_classes = c("numeric", "difftime"))) {
@@ -3000,7 +3000,7 @@ vec_fmt_markdown <- function(
 ) {
 
   # Ensure that `output` is matched correctly to one option
-  output <- match.arg(output)
+  output <- rlang::arg_match(output)
 
   if (output == "auto") {
     output <- determine_output_format()

--- a/R/image.R
+++ b/R/image.R
@@ -338,7 +338,7 @@ ggplot_image <- function(
 #' @export
 test_image <- function(type = c("png", "svg")) {
 
-  type <- match.arg(type)
+  type <- rlang::arg_match(type)
 
   system_file(file = paste0("graphics/test_image.", type))
 }

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -62,7 +62,7 @@ cols_align <- function(
   stop_if_not_gt(data = data)
 
   # Get the `align` value, this stops the function if there is no match
-  align <- match.arg(align)
+  align <- rlang::arg_match(align)
 
   # Get the columns supplied in `columns` as a character vector
   column_names <-

--- a/R/opts.R
+++ b/R/opts.R
@@ -239,7 +239,7 @@ opt_align_table_header <- function(
   # Perform input object validation
   stop_if_not_gt(data = data)
 
-  align <- match.arg(align)
+  align <- rlang::arg_match(align)
 
   tab_options(
     data = data,
@@ -624,7 +624,7 @@ opt_table_lines <- function(
   # Perform input object validation
   stop_if_not_gt(data = data)
 
-  extent <- match.arg(extent)
+  extent <- rlang::arg_match(extent)
 
   # Normalize `extent` values to property values
   values_vec <- if (extent == "all") "solid" else extent

--- a/R/resolver.R
+++ b/R/resolver.R
@@ -185,7 +185,7 @@ resolve_cols_c <- function(
     null_means = c("everything", "nothing")
 ) {
 
-  null_means <- match.arg(null_means)
+  null_means <- rlang::arg_match(null_means)
 
   names(
     resolve_cols_i(
@@ -216,7 +216,7 @@ resolve_cols_i <- function(
 ) {
   quo <- rlang::enquo(expr)
   cols_excl <- c()
-  null_means <- match.arg(null_means)
+  null_means <- rlang::arg_match(null_means)
 
   if (is_gt(data)) {
 

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -382,7 +382,7 @@ tab_spanner_delim <- function(
   # Perform input object validation
   stop_if_not_gt(data = data)
 
-  split <- match.arg(split)
+  split <- rlang::arg_match(split)
 
   # Get all of the columns in the dataset
   all_cols <- dt_boxhead_get_vars(data = data)
@@ -1049,7 +1049,7 @@ tab_footnote <- function(
     placement = c("auto", "right", "left")
 ) {
 
-  placement <- match.arg(placement)
+  placement <- rlang::arg_match(placement)
 
   # Perform input object validation
   stop_if_not_gt(data = data)

--- a/R/utils_color_contrast.R
+++ b/R/utils_color_contrast.R
@@ -30,7 +30,7 @@ get_contrast_ratio <- function(
 ) {
 
   # Get the correct `algo` value
-  algo <- match.arg(algo)
+  algo <- rlang::arg_match(algo)
 
   if (length(color_1) < 1L || length(color_2) < 1L) {
     cli::cli_abort(

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -265,7 +265,7 @@ format_num_to_str <- function(
     system = c("intl", "ind")
 ) {
 
-  system <- match.arg(system)
+  system <- rlang::arg_match(system)
 
   # If this hardcoding is ever to change, then we need to
   # modify the regexes below
@@ -373,7 +373,7 @@ format_num_to_str_c <- function(
     system = c("intl", "ind")
 ) {
 
-  system <- match.arg(system)
+  system <- rlang::arg_match(system)
 
   format_num_to_str(
     x = x,

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -593,8 +593,8 @@ rtf_tbl_cell <- function(
 
   x <- paste(x, collapse = " ")
 
-  h_align <- substr(match.arg(h_align), 1, 1)
-  v_align <- substr(match.arg(v_align), 1, 1)
+  h_align <- substr(rlang::arg_match(h_align), 1, 1)
+  v_align <- substr(rlang::arg_match(v_align), 1, 1)
 
   # Set default padding values if `padding = NULL`
   if (is.null(padding)) padding <- c(25, 85, 25, 85)

--- a/R/utils_render_xml.R
+++ b/R/utils_render_xml.R
@@ -37,7 +37,7 @@ xml_tblW <- function(
     app = "word"
 ) {
 
-  type <- match.arg(type)
+  type <- rlang::arg_match(type)
 
   htmltools::tag(
     `_tag_name` = xml_tag_type("tblW", app),
@@ -98,8 +98,8 @@ xml_width <- function(
     app = "word"
 ) {
 
-  dir <- match.arg(dir)
-  type <- match.arg(type)
+  dir <- rlang::arg_match(dir)
+  type <- rlang::arg_match(type)
 
   dir <-
     switch(
@@ -155,7 +155,7 @@ xml_tr_height <- function(
     app = "word"
 ) {
 
-  h_rule <- match.arg(h_rule)
+  h_rule <- rlang::arg_match(h_rule)
 
   htmltools::tag(
     `_tag_name` = xml_tag_type("trHeight", app),
@@ -205,7 +205,7 @@ xml_tc_margins <- function(..., app = "word") {
 # Vertical alignment of paragraph in cell (child of `tcPr`)
 xml_v_align <- function(v_align = c("center", "bottom", "top"), app = "word") {
 
-  v_align <- match.arg(v_align)
+  v_align <- rlang::arg_match(v_align)
 
   htmltools::tag(
     `_tag_name` = xml_tag_type("vAlign", app),
@@ -225,7 +225,7 @@ xml_gridSpan <- function(val = "1", app = "word") {
 # Span cells vertically (child of `tcPr`)
 xml_v_merge <- function(val = c("restart", "continue"), app = "word") {
 
-  val <- match.arg(val)
+  val <- rlang::arg_match(val)
 
   htmltools::tag(
     `_tag_name` = xml_tag_type("vMerge", app),
@@ -253,7 +253,7 @@ xml_border <- function(
     app = "word"
 ) {
 
-  dir <- match.arg(dir)
+  dir <- rlang::arg_match(dir)
 
   dir <-
     switch(
@@ -334,7 +334,7 @@ xml_jc <- function(
     app = "word"
 ) {
 
-  val <- match.arg(val)
+  val <- rlang::arg_match(val)
 
   val <-
     switch(
@@ -417,7 +417,7 @@ xml_baseline_adj <- function(
     app = "word"
 ) {
 
-  v_align <- match.arg(v_align)
+  v_align <- rlang::arg_match(v_align)
 
   htmltools::tag(
     `_tag_name` = xml_tag_type("vertAlign", app),
@@ -432,7 +432,7 @@ xml_t <- function(
     app = "word"
 ) {
 
-  xml_space <- match.arg(xml_space)
+  xml_space <- rlang::arg_match(xml_space)
 
   # HTML-escape literal text
   htmltools::tag(
@@ -532,7 +532,7 @@ xml_fldChar <- function(
     app = "word"
 ) {
 
-  fldCharType <- match.arg(fldCharType)
+  fldCharType <- rlang::arg_match(fldCharType)
   stopifnot(is_bool(dirty))
 
   htmltools::tag(
@@ -1846,7 +1846,7 @@ cell_border <- function(
 
 cell_margin <- function(width, type = c("dxa", "nil")) {
 
-  type <- match.arg(type)
+  type <- rlang::arg_match(type)
 
   list(
     width = width,
@@ -1857,9 +1857,9 @@ cell_margin <- function(width, type = c("dxa", "nil")) {
 stretch_to_xml_stretch <- function(x) {
 
   x <-
-    match.arg(
+    rlang::arg_match(
       x,
-      choices = c(
+      values = c(
         "ultra-condensed",
         "extra-condensed",
         "condensed",
@@ -1887,8 +1887,8 @@ stretch_to_xml_stretch <- function(x) {
 
 v_align_to_xml_v_align <- function(x){
   x <-
-    match.arg(x,
-              choices = c("middle", "top", "bottom"))
+    rlang::arg_match(x,
+                     values = c("middle", "top", "bottom"))
 
   c(
     "middle" = "center",
@@ -1899,7 +1899,7 @@ v_align_to_xml_v_align <- function(x){
 
 row_span_to_xml_v_merge <- function(x){
 
-  x <- match.arg(x,choices = c("start","continue"))
+  x <- rlang::arg_match(x, values = c("start", "continue"))
 
   c(
     "continue" = "continue",

--- a/tests/testthat/test-as_word.R
+++ b/tests/testthat/test-as_word.R
@@ -47,8 +47,8 @@ body_add_gt <- function(
   stopifnot(inherits(x, "rdocx"))
   stopifnot(inherits(value, "gt_tbl"))
 
-  pos <- match.arg(pos)
-  caption_location <- match.arg(caption_location)
+  pos <- rlang::arg_match(pos)
+  caption_location <- rlang::arg_match(caption_location)
 
   # Build all table data objects through a common pipeline
   value <- build_data(data = value, context = "word")


### PR DESCRIPTION
# Summary

Use rlang::arg_match() instead of match.arg()

# Related GitHub Issues and PRs

- It closes #672

# Checklist

- [x] I replaced match.arg() with rlang::arg_match() 
- [x] I replaced choices argument of match.arg() with values in rlang::arg_match() 
- [x] I updated the News.md as it is described in [Guidelines for Contributing](https://gt.rstudio.com/CONTRIBUTING.html)

# Remarks

- There is an error as I check the package (even before undertaking any changes) on my system.  It complains about a failure in helper-render_formats.R file.
