### PR TITLE
Add container padding options

### DIFF
--- a/R/dt_options.R
+++ b/R/dt_options.R
@@ -38,6 +38,8 @@ dt_options_tbl <-
     "empty",                             FALSE,  "empty",            "value",   list(),
     "container_width",                   FALSE,  "container",        "px",      "auto",
     "container_height",                  FALSE,  "container",        "px",      "auto",
+    "container_padding_x",               FALSE,  "container",        "px",      "0px",
+    "container_padding_y",               FALSE,  "container",        "px",      "10px",
     "container_overflow_x",              FALSE,  "container",        "overflow","auto",
     "container_overflow_y",              FALSE,  "container",        "overflow","auto",
     "table_id",                          FALSE,  "table",            "value",   NA_character_,

--- a/R/print.R
+++ b/R/print.R
@@ -91,6 +91,8 @@ as.tags.gt_tbl <- function(x, ...) {
   css <- compile_scss(data = x, id = id)
 
   # Get options related to the enclosing <div>
+  container_padding_x <- dt_options_get_value(x, option = "container_padding_x")
+  container_padding_y <- dt_options_get_value(x, option = "container_padding_y")
   container_overflow_x <- dt_options_get_value(x, option = "container_overflow_x")
   container_overflow_y <- dt_options_get_value(x, option = "container_overflow_y")
   container_width <- dt_options_get_value(x, option = "container_width")
@@ -102,6 +104,10 @@ as.tags.gt_tbl <- function(x, ...) {
       id = id,
       htmltools::tags$style(htmltools::HTML(css)),
       style = htmltools::css(
+        `padding-left` = container_padding_x,
+        `padding-right` = container_padding_x,
+        `padding-top` = container_padding_y,
+        `padding-bottom` = container_padding_y,
         `overflow-x` = container_overflow_x,
         `overflow-y` = container_overflow_y,
         width = container_width,

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1944,11 +1944,13 @@ set_style.cells_source_notes <- function(loc, data, style) {
 #' components, the subcomponents, and the element that can adjusted.
 #'
 #' @inheritParams fmt_number
-#' @param container.width,container.height The width and height of the table's
-#'   container. Can be specified as a single-length character with units of
-#'   pixels or as a percentage. If provided as a single-length numeric vector,
-#'   it is assumed that the value is given in units of pixels. The [px()] and
-#'   [pct()] helper functions can also be used to pass in numeric values and
+#' @param container.width,container.height,container.padding.x,container.padding.y
+#'   The width and height of the table's container, and, the vertical and
+#'   horizontal padding of the table's container. The container width and height
+#'   can be specified with units of pixels or as a percentage. The padding is to
+#'   be specified as a length with units of pixels. If provided as a numeric
+#'   value, it is assumed that the value is given in units of pixels. The [px()]
+#'   and [pct()] helper functions can also be used to pass in numeric values and
 #'   obtain values as pixel or percent units.
 #' @param container.overflow.x,container.overflow.y Options to enable scrolling
 #'   in the horizontal and vertical directions when the table content overflows
@@ -2273,6 +2275,8 @@ tab_options <- function(
     data,
     container.width = NULL,
     container.height = NULL,
+    container.padding.x = NULL,
+    container.padding.y = NULL,
     container.overflow.x = NULL,
     container.overflow.y = NULL,
     table.width = NULL,

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -8,6 +8,8 @@ tab_options(
   data,
   container.width = NULL,
   container.height = NULL,
+  container.padding.x = NULL,
+  container.padding.y = NULL,
   container.overflow.x = NULL,
   container.overflow.y = NULL,
   table.width = NULL,
@@ -175,11 +177,12 @@ tab_options(
 \arguments{
 \item{data}{A table object that is created using the \code{\link[=gt]{gt()}} function.}
 
-\item{container.width, container.height}{The width and height of the table's
-container. Can be specified as a single-length character with units of
-pixels or as a percentage. If provided as a single-length numeric vector,
-it is assumed that the value is given in units of pixels. The \code{\link[=px]{px()}} and
-\code{\link[=pct]{pct()}} helper functions can also be used to pass in numeric values and
+\item{container.width, container.height, container.padding.x, container.padding.y}{The width and height of the table's container, and, the vertical and
+horizontal padding of the table's container. The container width and height
+can be specified with units of pixels or as a percentage. The padding is to
+be specified as a length with units of pixels. If provided as a numeric
+value, it is assumed that the value is given in units of pixels. The \code{\link[=px]{px()}}
+and \code{\link[=pct]{pct()}} helper functions can also be used to pass in numeric values and
 obtain values as pixel or percent units.}
 
 \item{container.overflow.x, container.overflow.y}{Options to enable scrolling

--- a/tests/testthat/helper-gt_attr_expectations.R
+++ b/tests/testthat/helper-gt_attr_expectations.R
@@ -107,7 +107,7 @@ expect_tab <- function(tab, df) {
 
   dt_options_get(data = tab) %>%
     dim() %>%
-    expect_equal(c(169, 5))
+    expect_equal(c(171, 5))
 
   dt_transforms_get(data = tab) %>%
     length() %>%


### PR DESCRIPTION
This adds two options in `tab_options()` for setting the left/right and top/bottom padding on the table's container (HTML only). This is necessary since the lack of default padding (and any means to set it) results in tables being uncomfortable close to paragraphs above and below.

Fixes: https://github.com/rstudio/gt/issues/1105
Fixes: https://github.com/rstudio/gt/issues/590
