### PR TITLE
Don't manipulate raw style rules (i.e., strings) as input to `tab_style()`

### DIFF
--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -26,7 +26,7 @@ styles_to_html <- function(styles) {
       FUN.VALUE = character(1), USE.NAMES = FALSE,
       FUN = function(x) {
         if (any(is.null(names(x)))) {
-          style <- gsub(":", ": ", x, fixed = TRUE)
+          style <- x
         } else if (all(names(x) != "")) {
           x <- cell_style_to_html(x)
           style <- tidy_gsub(paste0(names(x), ": ", x, ";", collapse = " "), ";;", ";")

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -25,7 +25,9 @@ styles_to_html <- function(styles) {
       styles,
       FUN.VALUE = character(1), USE.NAMES = FALSE,
       FUN = function(x) {
-        if (all(names(x) != "")) {
+        if (any(is.null(names(x)))) {
+          style <- as.character(x)
+        } else if (all(names(x) != "")) {
           x <- cell_style_to_html(x)
           style <- tidy_gsub(paste0(names(x), ": ", x, ";", collapse = " "), ";;", ";")
         } else {

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -25,9 +25,7 @@ styles_to_html <- function(styles) {
       styles,
       FUN.VALUE = character(1), USE.NAMES = FALSE,
       FUN = function(x) {
-        if (any(is.null(names(x)))) {
-          style <- as.character(x)
-        } else if (all(names(x) != "")) {
+        if (all(names(x) != "")) {
           x <- cell_style_to_html(x)
           style <- tidy_gsub(paste0(names(x), ": ", x, ";", collapse = " "), ";;", ";")
         } else {

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -26,7 +26,7 @@ styles_to_html <- function(styles) {
       FUN.VALUE = character(1), USE.NAMES = FALSE,
       FUN = function(x) {
         if (any(is.null(names(x)))) {
-          style <- x
+          style <- as.character(x)
         } else if (all(names(x) != "")) {
           x <- cell_style_to_html(x)
           style <- tidy_gsub(paste0(names(x), ": ", x, ";", collapse = " "), ";;", ";")


### PR DESCRIPTION
The `tab_style()` function allows for raw styles to be added as in the `style` list. This PR removes the string manipulation of inserting a space character after any colon. This is unnecessary and also disrupts any rules that contain a colon within the value portion (e.g., URLs enclosed in `url()`.

Fixes: https://github.com/rstudio/gt/issues/1083