### PR TITLE
Allow the table stub to participate in column merging operations

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,6 +19,7 @@ tests/testthat/_snaps
 tests/testthat/test-as_raw_html.R
 tests/testthat/test-as_word.R
 tests/testthat/test-cols_align_decimal.R
+tests/testthat/test-cols_merge.R
 tests/testthat/test-cols_width_rtf.R
 tests/testthat/test-data_color.R
 tests/testthat/test-extract_cells.R

--- a/R/dt_boxhead.R
+++ b/R/dt_boxhead.R
@@ -113,7 +113,7 @@ dt_boxhead_set_hidden <- function(data, vars) {
 
   dt_boxhead <- dt_boxhead_get(data = data)
 
-  dt_boxhead[which(dt_boxhead$var %in% vars), "type"] <- "hidden"
+  dt_boxhead[which(dt_boxhead$var %in% vars & dt_boxhead$type != "stub"), "type"] <- "hidden"
 
   dt_boxhead_set(data = data, boxh = dt_boxhead)
 }
@@ -122,7 +122,7 @@ dt_boxhead_set_not_hidden <- function(data, vars) {
 
   dt_boxhead <- dt_boxhead_get(data = data)
 
-  dt_boxhead[which(dt_boxhead$var %in% vars), "type"] <- "default"
+  dt_boxhead[which(dt_boxhead$var %in% vars & dt_boxhead$type != "stub"), "type"] <- "default"
 
   dt_boxhead_set(data = data, boxh = dt_boxhead)
 }

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -1080,7 +1080,8 @@ cols_hide <- function(
   columns <-
     resolve_cols_c(
       expr = {{ columns }},
-      data = data
+      data = data,
+      excl_stub = FALSE
     )
 
   vars <- dt_boxhead_get_vars(data = data)
@@ -1450,7 +1451,8 @@ cols_merge_range <- function(
     col_end <-
       resolve_cols_c(
         expr = {{ col_end }},
-        data = data
+        data = data,
+        excl_stub = FALSE
       )
 
     data <-
@@ -1469,14 +1471,16 @@ cols_merge_resolver <- function(data, col_begin, col_end, sep) {
   col_begin <-
     resolve_cols_c(
       expr = {{ col_begin }},
-      data = data
+      data = data,
+      excl_stub = FALSE
     )
 
   # Get the columns supplied in `col_end` as a character vector
   col_end <-
     resolve_cols_c(
       expr = {{ col_end }},
-      data = data
+      data = data,
+      excl_stub = FALSE
     )
 
   columns <- c(col_begin, col_end)

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -1721,7 +1721,8 @@ cols_merge <- function(
   columns <-
     resolve_cols_c(
       expr = {{ columns }},
-      data = data
+      data = data,
+      excl_stub = FALSE
     )
 
   # NOTE: It's important that `hide_columns` NOT be evaluated until after the

--- a/tests/testthat/_snaps/cols_merge.md
+++ b/tests/testthat/_snaps/cols_merge.md
@@ -1,0 +1,21 @@
+# the function `cols_merge()` works correctly
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"b\">b</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part 1</th>\n<td headers=\"stub_1_1 b\" class=\"gt_row gt_left\">one</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part 2</th>\n<td headers=\"stub_1_2 b\" class=\"gt_row gt_left\">two</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part 3</th>\n<td headers=\"stub_1_3 b\" class=\"gt_row gt_left\">three</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part 4</th>\n<td headers=\"stub_1_4 b\" class=\"gt_row gt_left\">four</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part 5</th>\n<td headers=\"stub_1_5 b\" class=\"gt_row gt_left\">five</td></tr>\n  </tbody>\n  \n  \n</table>"
+
+---
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_right\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"a\">a</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part one</th>\n<td headers=\"stub_1_1 a\" class=\"gt_row gt_right\">1</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part two</th>\n<td headers=\"stub_1_2 a\" class=\"gt_row gt_right\">2</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part three</th>\n<td headers=\"stub_1_3 a\" class=\"gt_row gt_right\">3</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part four</th>\n<td headers=\"stub_1_4 a\" class=\"gt_row gt_right\">4</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part five</th>\n<td headers=\"stub_1_5 a\" class=\"gt_row gt_right\">5</td></tr>\n  </tbody>\n  \n  \n</table>"
+
+---
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"b\">b</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part i</th>\n<td headers=\"stub_1_1 b\" class=\"gt_row gt_left\">one</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part ii</th>\n<td headers=\"stub_1_2 b\" class=\"gt_row gt_left\">two</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part iii</th>\n<td headers=\"stub_1_3 b\" class=\"gt_row gt_left\">three</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part iv</th>\n<td headers=\"stub_1_4 b\" class=\"gt_row gt_left\">four</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part v</th>\n<td headers=\"stub_1_5 b\" class=\"gt_row gt_left\">five</td></tr>\n  </tbody>\n  \n  \n</table>"
+

--- a/tests/testthat/_snaps/cols_merge.md
+++ b/tests/testthat/_snaps/cols_merge.md
@@ -19,3 +19,45 @@
     Output
       [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"b\">b</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part i</th>\n<td headers=\"stub_1_1 b\" class=\"gt_row gt_left\">one</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part ii</th>\n<td headers=\"stub_1_2 b\" class=\"gt_row gt_left\">two</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part iii</th>\n<td headers=\"stub_1_3 b\" class=\"gt_row gt_left\">three</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part iv</th>\n<td headers=\"stub_1_4 b\" class=\"gt_row gt_left\">four</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_left gt_stub\">Part v</th>\n<td headers=\"stub_1_5 b\" class=\"gt_row gt_left\">five</td></tr>\n  </tbody>\n  \n  \n</table>"
 
+# the `cols_merge_uncert()` function works correctly
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"b\">b</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_right gt_stub\">2.3 ± 0.06</th>\n<td headers=\"stub_1_1 b\" class=\"gt_row gt_left\">A</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_right gt_stub\">6.3 ± 0.07</th>\n<td headers=\"stub_1_2 b\" class=\"gt_row gt_left\">B</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_right gt_stub\">2.5 ± 0.08</th>\n<td headers=\"stub_1_3 b\" class=\"gt_row gt_left\">C</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_right gt_stub\">2.4 ± 0.09</th>\n<td headers=\"stub_1_4 b\" class=\"gt_row gt_left\">D</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_right gt_stub\">6.5 ± 0.10</th>\n<td headers=\"stub_1_5 b\" class=\"gt_row gt_left\">E</td></tr>\n  </tbody>\n  \n  \n</table>"
+
+# the `cols_merge_range()` function works correctly
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"b\">b</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_right gt_stub\">1–6</th>\n<td headers=\"stub_1_1 b\" class=\"gt_row gt_left\">one</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_right gt_stub\">2–7</th>\n<td headers=\"stub_1_2 b\" class=\"gt_row gt_left\">two</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_right gt_stub\">3–8</th>\n<td headers=\"stub_1_3 b\" class=\"gt_row gt_left\">three</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_right gt_stub\">4–9</th>\n<td headers=\"stub_1_4 b\" class=\"gt_row gt_left\">four</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_right gt_stub\">5–10</th>\n<td headers=\"stub_1_5 b\" class=\"gt_row gt_left\">five</td></tr>\n  </tbody>\n  \n  \n</table>"
+
+---
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_right\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"a\">a</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_right gt_stub\">1–one</th>\n<td headers=\"stub_1_1 a\" class=\"gt_row gt_right\">6</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_right gt_stub\">2–two</th>\n<td headers=\"stub_1_2 a\" class=\"gt_row gt_right\">7</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_right gt_stub\">3–three</th>\n<td headers=\"stub_1_3 a\" class=\"gt_row gt_right\">8</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_right gt_stub\">4–four</th>\n<td headers=\"stub_1_4 a\" class=\"gt_row gt_right\">9</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_right gt_stub\">5–five</th>\n<td headers=\"stub_1_5 a\" class=\"gt_row gt_right\">10</td></tr>\n  </tbody>\n  \n  \n</table>"
+
+---
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"b\">b</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_right gt_stub\">1–vi</th>\n<td headers=\"stub_1_1 b\" class=\"gt_row gt_left\">one</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_right gt_stub\">2–vii</th>\n<td headers=\"stub_1_2 b\" class=\"gt_row gt_left\">two</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_right gt_stub\">3–viii</th>\n<td headers=\"stub_1_3 b\" class=\"gt_row gt_left\">three</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_right gt_stub\">4–ix</th>\n<td headers=\"stub_1_4 b\" class=\"gt_row gt_left\">four</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_right gt_stub\">5–x</th>\n<td headers=\"stub_1_5 b\" class=\"gt_row gt_left\">five</td></tr>\n  </tbody>\n  \n  \n</table>"
+
+---
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"b\">b</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_right gt_stub\">i–6</th>\n<td headers=\"stub_1_1 b\" class=\"gt_row gt_left\">one</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_right gt_stub\">ii–7</th>\n<td headers=\"stub_1_2 b\" class=\"gt_row gt_left\">two</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_right gt_stub\">iii–8</th>\n<td headers=\"stub_1_3 b\" class=\"gt_row gt_left\">three</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_right gt_stub\">iv–9</th>\n<td headers=\"stub_1_4 b\" class=\"gt_row gt_left\">four</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_right gt_stub\">v–10</th>\n<td headers=\"stub_1_5 b\" class=\"gt_row gt_left\">five</td></tr>\n  </tbody>\n  \n  \n</table>"
+
+# the `cols_merge_n_pct()` function works correctly
+
+    Code
+      .
+    Output
+      [1] "<table class=\"gt_table\">\n  \n  <thead class=\"gt_col_headings\">\n    <tr>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"\"></th>\n      <th class=\"gt_col_heading gt_columns_bottom_border gt_left\" rowspan=\"1\" colspan=\"1\" scope=\"col\" id=\"b\">b</th>\n    </tr>\n  </thead>\n  <tbody class=\"gt_table_body\">\n    <tr><th id=\"stub_1_1\" scope=\"row\" class=\"gt_row gt_right gt_stub\">1 (6.00%)</th>\n<td headers=\"stub_1_1 b\" class=\"gt_row gt_left\">A</td></tr>\n    <tr><th id=\"stub_1_2\" scope=\"row\" class=\"gt_row gt_right gt_stub\">2 (7.00%)</th>\n<td headers=\"stub_1_2 b\" class=\"gt_row gt_left\">B</td></tr>\n    <tr><th id=\"stub_1_3\" scope=\"row\" class=\"gt_row gt_right gt_stub\">3 (8.00%)</th>\n<td headers=\"stub_1_3 b\" class=\"gt_row gt_left\">C</td></tr>\n    <tr><th id=\"stub_1_4\" scope=\"row\" class=\"gt_row gt_right gt_stub\">4 (9.00%)</th>\n<td headers=\"stub_1_4 b\" class=\"gt_row gt_left\">D</td></tr>\n    <tr><th id=\"stub_1_5\" scope=\"row\" class=\"gt_row gt_right gt_stub\">5 (10.00%)</th>\n<td headers=\"stub_1_5 b\" class=\"gt_row gt_left\">E</td></tr>\n  </tbody>\n  \n  \n</table>"
+

--- a/tests/testthat/test-cols_merge.R
+++ b/tests/testthat/test-cols_merge.R
@@ -283,6 +283,26 @@ test_that("the `cols_merge_uncert()` function works correctly", {
   expect_s3_class(sep, "AsIs")
   expect_equal(as.character(sep), " +/- ")
   expect_equal(sep, I(" +/- "))
+
+  #
+  # Expect that the column set as the row group can participate
+  # in column merging through `cols_merge_uncert()`
+  #
+
+  tbl <-
+    dplyr::tibble(
+      row = c(2.3, 6.3, 2.5, 2.4, 6.5),
+      a = 6:10 / 100,
+      b = LETTERS[1:5]
+    )
+
+  # Merge the stub column with column `a`
+  gt_tbl_1 <-
+    gt(tbl, rowname_col = "row") %>%
+    cols_merge_uncert(col_val = row, col_uncert = a)
+
+  # Perform snapshot test
+  gt_tbl_1 %>% render_as_html() %>% expect_snapshot()
 })
 
 test_that("the `cols_merge_uncert()` fn works nicely with different error bounds", {
@@ -537,6 +557,54 @@ test_that("the `cols_merge_range()` function works correctly", {
     tbl_html_2 %>% as_raw_html() %>% gsub("id=\"[a-z]*?\"", "", .),
     tbl_html_3 %>% as_raw_html() %>% gsub("id=\"[a-z]*?\"", "", .)
   )
+
+  #
+  # Expect that the column set as the row group can participate
+  # in column merging through `col_merge_range()`
+  #
+
+  tbl <-
+    dplyr::tibble(
+      row = 1:5,
+      a = 6:10,
+      b = c("one", "two", "three", "four", "five")
+    )
+
+  # Merge the stub column with column `a` (has integers)
+  gt_tbl_1 <-
+    gt(tbl, rowname_col = "row") %>%
+    cols_merge_range(col_begin = row, col_end = a)
+
+  # Perform snapshot test
+  gt_tbl_1 %>% render_as_html() %>% expect_snapshot()
+
+  # Merge the stub column with column `b` (has character values)
+  gt_tbl_2 <-
+    gt(tbl, rowname_col = "row") %>%
+    cols_merge_range(col_begin = row, col_end = b)
+
+  # Perform snapshot test
+  gt_tbl_2 %>% render_as_html() %>% expect_snapshot()
+
+  # Merge the stub column with a formatted column `a`
+  # (has lowercase Roman numerals, transformed to character from integer)
+  gt_tbl_3 <-
+    gt(tbl, rowname_col = "row") %>%
+    fmt_roman(columns = "a", case = "lower") %>%
+    cols_merge_range(col_begin = row, col_end = a)
+
+  # Perform snapshot test
+  gt_tbl_3 %>% render_as_html() %>% expect_snapshot()
+
+  # Merge the formatted stub column with column `a`
+  # (has lowercase Roman numerals, transformed to character from integer)
+  gt_tbl_4 <-
+    gt(tbl, rowname_col = "row") %>%
+    fmt_roman(columns = "row", case = "lower") %>%
+    cols_merge_range(col_begin = row, col_end = a)
+
+  # Perform snapshot test
+  gt_tbl_4 %>% render_as_html() %>% expect_snapshot()
 })
 
 test_that("the `cols_merge_n_pct()` function works correctly", {
@@ -596,4 +664,25 @@ test_that("the `cols_merge_n_pct()` function works correctly", {
       "0.0%"
     )
   )
+
+  #
+  # Expect that the column set as the row group can participate
+  # in column merging through `cols_merge_n_pct()`
+  #
+
+  tbl <-
+    dplyr::tibble(
+      row = 1:5,
+      a = 6:10 / 100,
+      b = LETTERS[1:5]
+    )
+
+  # Merge the stub column with column `a` (formatted as percentage values)
+  gt_tbl_1 <-
+    gt(tbl, rowname_col = "row") %>%
+    fmt_percent(columns = a) %>%
+    cols_merge_n_pct(col_n = row, col_pct = a)
+
+  # Perform snapshot test
+  gt_tbl_1 %>% render_as_html() %>% expect_snapshot()
 })

--- a/tests/testthat/test-cols_merge.R
+++ b/tests/testthat/test-cols_merge.R
@@ -115,6 +115,53 @@ test_that("the function `cols_merge()` works correctly", {
         hide_columns = c(wt, carb),
       )
   )
+
+  #
+  # Expect that the column set as the row group can participate
+  # in column merging
+  #
+
+  tbl <-
+    dplyr::tibble(
+      row = "Part",
+      a = 1:5,
+      b = c("one", "two", "three", "four", "five")
+    )
+
+  # Merge the stub column with column `a` (has integers)
+  gt_tbl_1 <-
+    gt(tbl, rowname_col = "row") %>%
+    cols_merge(columns = c(row, a))
+
+  # Perform snapshot test
+  gt_tbl_1 %>% render_as_html() %>% expect_snapshot()
+
+  # Merge the stub column with column `b` (has character values)
+  gt_tbl_2 <-
+    gt(tbl, rowname_col = "row") %>%
+    cols_merge(columns = c(row, b))
+
+  # Perform snapshot test
+  gt_tbl_2 %>% render_as_html() %>% expect_snapshot()
+
+  # Merge the stub column with a formatted column `a`
+  # (has lowercase Roman numerals, transformed to character from integer)
+  gt_tbl_3 <-
+    gt(tbl, rowname_col = "row") %>%
+    fmt_roman(columns = "a", case = "lower") %>%
+    cols_merge(columns = c(row, a))
+
+  # Perform snapshot test
+  gt_tbl_3 %>% render_as_html() %>% expect_snapshot()
+
+  # Ensure that `group` columns don't get the same treatment
+  expect_equal(
+    gt(tbl, groupname_col = "row") %>%
+      render_as_html(),
+    gt(tbl, groupname_col = "row") %>%
+      cols_merge(columns = c(row, a)) %>%
+      render_as_html()
+  )
 })
 
 test_that("the `cols_merge_uncert()` function works correctly", {
@@ -238,7 +285,7 @@ test_that("the `cols_merge_uncert()` function works correctly", {
   expect_equal(sep, I(" +/- "))
 })
 
-test_that("the `cols_merge_uncert()` works nicely with different error bounds", {
+test_that("the `cols_merge_uncert()` fn works nicely with different error bounds", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -491,7 +538,6 @@ test_that("the `cols_merge_range()` function works correctly", {
     tbl_html_3 %>% as_raw_html() %>% gsub("id=\"[a-z]*?\"", "", .)
   )
 })
-
 
 test_that("the `cols_merge_n_pct()` function works correctly", {
 


### PR DESCRIPTION
This PR allows the stub contents to freely merge with other columns (using the `cols_merge*()` functions). With this, the stub won't be accidentally hidden since the logic behind that was altered to exclude the hiding of columns designated as the stub.