### PR TITLE
Fix for multiword font-family values and `as_raw_html(inline_css = TRUE)`

### DIFF
--- a/R/render_as_html.R
+++ b/R/render_as_html.R
@@ -37,22 +37,35 @@ render_as_html <- function(data) {
   table_defs <- get_table_defs(data = data)
 
   # Compose the HTML table
+  finalize_html_table(
+    class = "gt_table",
+    style = table_defs$table_style,
+    caption_component,
+    table_defs$table_colgroups,
+    heading_component,
+    columns_component,
+    body_component,
+    source_notes_component,
+    footnotes_component
+  )
+}
+
+finalize_html_table <- function(
+    class,
+    style,
+    ...) {
+
   html_tbl <-
     as.character(
       htmltools::tags$table(
         class = "gt_table",
-        style = table_defs$table_style,
-        caption_component,
-        table_defs$table_colgroups,
-        heading_component,
-        columns_component,
-        body_component,
-        source_notes_component,
-        footnotes_component
+        style = style,
+        ...
       )
     )
 
-  # Unescape single quotes that are present as HTML entities
+  # Unescape single quotes that may present as HTML entities (this is
+  # needed since the CSS inliner cannot parse "&#39;")
   html_tbl <- gsub("&#39;", "'", html_tbl)
 
   html_tbl

--- a/R/render_as_html.R
+++ b/R/render_as_html.R
@@ -37,17 +37,23 @@ render_as_html <- function(data) {
   table_defs <- get_table_defs(data = data)
 
   # Compose the HTML table
-  as.character(
-    htmltools::tags$table(
-      class = "gt_table",
-      style = table_defs$table_style,
-      caption_component,
-      table_defs$table_colgroups,
-      heading_component,
-      columns_component,
-      body_component,
-      source_notes_component,
-      footnotes_component
+  html_tbl <-
+    as.character(
+      htmltools::tags$table(
+        class = "gt_table",
+        style = table_defs$table_style,
+        caption_component,
+        table_defs$table_colgroups,
+        heading_component,
+        columns_component,
+        body_component,
+        source_notes_component,
+        footnotes_component
+      )
     )
-  )
+
+  # Unescape single quotes that are present as HTML entities
+  html_tbl <- gsub("&#39;", "'", html_tbl)
+
+  html_tbl
 }

--- a/tests/testthat/test-as_raw_html.R
+++ b/tests/testthat/test-as_raw_html.R
@@ -114,4 +114,15 @@ test_that("`as_raw_html()` produces the same table every time", {
 
   gt_html_2_sha1 <- digest::sha1(gt_html_2)
   expect_equal(gt_html_2_sha1, "ead3b201f06d98f304d23d9c04a2eba0b18bbdf5")
+
+  # Expect that font family values with multiple words (i.e., have a space
+  # character) added with `tab_style()` preserve single-quote characters
+  expect_match(
+    exibble[1, ] %>%
+      gt() %>%
+      tab_header(title = "Title") %>%
+      tab_style(style = cell_text(font = "Two Words"), locations = cells_title()) %>%
+      as_raw_html(),
+    "font-family: 'Two Words';"
+  )
 })

--- a/tests/testthat/test-as_raw_html.R
+++ b/tests/testthat/test-as_raw_html.R
@@ -125,4 +125,16 @@ test_that("`as_raw_html()` produces the same table every time", {
       as_raw_html(),
     "font-family: 'Two Words';"
   )
+
+  expect_match(
+    exibble[1, ] %>%
+      gt() %>%
+      tab_header(title = "Title") %>%
+      tab_style(
+        style = cell_text(font = c("Fira Sans", "Droid Sans", "Arial", "sans-serif")),
+        locations = cells_title()
+      ) %>%
+      as_raw_html(),
+    "font-family: 'Fira Sans', 'Droid Sans', Arial, sans-serif;"
+  )
 })

--- a/tests/testthat/test-r_table_parts.R
+++ b/tests/testthat/test-r_table_parts.R
@@ -18,7 +18,7 @@ test_that("a gt table contains the expected column spanner labels", {
       ".*.trowd.trrh0.trhdr.*",
       ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".intbl \\{.f0 \\{.f0.fs20 perimeter\\}\\}.cell.*",
-      ".intbl \\{.f0 \\{.f0.fs20 perimeter\\}\\}.cell.*",
+      ".intbl \\{.f0 \\{.f0.fs20 }\\}.cell.*",
       ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".*area.*peri.*shape.*perm",
       ".*"
@@ -53,9 +53,9 @@ test_that("a gt table contains the expected column spanner labels", {
       ".*.trowd.trrh0.trhdr.*",
       ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".intbl \\{.f0 \\{.f0.fs20 v_1_2\\}\\}.cell.*",
-      ".intbl \\{.f0 \\{.f0.fs20 v_1_2\\}\\}.cell.*",
+      ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".intbl \\{.f0 \\{.f0.fs20 v_4_5\\}\\}.cell.*",
-      ".intbl \\{.f0 \\{.f0.fs20 v_4_5\\}\\}.cell.*",
+      ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".row.*",
       ".*v_3.*v_1.*v_2.*v_4.*v_5",
       ".*"
@@ -104,9 +104,9 @@ test_that("a gt table contains the expected column spanner labels", {
     paste0(
       ".*.trowd.trrh0.trhdr.*",
       ".intbl \\{.f0 \\{.f0.fs20 A\\{.super .i 1\\}\\}\\}.cell.*",
-      ".intbl \\{.f0 \\{.f0.fs20 A\\{.super .i 1\\}\\}\\}.cell.*",
+      ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".intbl \\{.f0 \\{.f0.fs20 A\\}\\}.cell.*",
-      ".intbl \\{.f0 \\{.f0.fs20 A\\}\\}.cell.*",
+      ".intbl \\{.f0 \\{.f0.fs20 }\\}.cell.*",
       ".row.*",
       ".*A_X.*A_Y.*B_X.*B_Y",
       ".*"
@@ -130,7 +130,7 @@ test_that("a gt table contains the expected column spanner labels", {
     paste0(
       ".*.trowd.trrh0.trhdr.*",
       ".intbl \\{.f0 \\{.f0.fs20 Sepal\\}\\}.cell.*",
-      ".intbl \\{.f0 \\{.f0.fs20 Sepal\\}\\}.cell.*",
+      ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",
       ".intbl \\{.f0 \\{.f0.fs20 \\}\\}.cell.*",


### PR DESCRIPTION
This PR fixes an issue where font names containing spaces (i.e., require single quotes as CSS values) are transformed to HTML entity values by htmltools (unavoidable) and cannot be parsed by the CSS inliner when using `as_raw_html(inline_css = TRUE)`. This change unescapes single quotes and adds several testthat tests.

Fixes: https://github.com/rstudio/gt/issues/1123