### PR TITLE
Add 'double' as border style option

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -2075,11 +2075,11 @@ cell_style_to_html.cell_fill <- function(style) {
 #' @param color,style,weight The border color, style, and weight. The `color`
 #'   can be defined with a color name or with a hexadecimal color code. The
 #'   default `color` value is `"#000000"` (black). The `style` can be one of
-#'   either `"solid"` (the default), `"dashed"`, `"dotted"`, or `"hidden"`.
-#'   The `weight` of the border lines is to be given in pixel values (the
-#'   [px()] helper function is useful for this. The default value for `weight`
-#'   is `"1px"`. Borders for any defined `sides` can be removed by supplying
-#'   `NULL` to any of `color`, `style`, or `weight`.
+#'   either `"solid"` (the default), `"dashed"`, `"dotted"`, `"hidden"`, or
+#'   `"double"`. The `weight` of the border lines is to be given in pixel values
+#'   (the [px()] helper function is useful for this. The default value for
+#'   `weight` is `"1px"`. Borders for any defined `sides` can be removed by
+#'   supplying `NULL` to any of `color`, `style`, or `weight`.
 #'
 #' @return A list object of class `cell_styles`.
 #'

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -2226,7 +2226,7 @@ cell_borders <- function(
 
         validate_style_in(
           style_vals, names(style_vals), "style",
-          c("solid", "dashed", "dotted", "hidden")
+          c("solid", "dashed", "dotted", "hidden", "double")
         )
 
         cell_style_structure(

--- a/man/cell_borders.Rd
+++ b/man/cell_borders.Rd
@@ -14,11 +14,11 @@ selected cells, we can use the \code{"all"} option.}
 \item{color, style, weight}{The border color, style, and weight. The \code{color}
 can be defined with a color name or with a hexadecimal color code. The
 default \code{color} value is \code{"#000000"} (black). The \code{style} can be one of
-either \code{"solid"} (the default), \code{"dashed"}, \code{"dotted"}, or \code{"hidden"}.
-The \code{weight} of the border lines is to be given in pixel values (the
-\code{\link[=px]{px()}} helper function is useful for this. The default value for \code{weight}
-is \code{"1px"}. Borders for any defined \code{sides} can be removed by supplying
-\code{NULL} to any of \code{color}, \code{style}, or \code{weight}.}
+either \code{"solid"} (the default), \code{"dashed"}, \code{"dotted"}, \code{"hidden"}, or
+\code{"double"}. The \code{weight} of the border lines is to be given in pixel values
+(the \code{\link[=px]{px()}} helper function is useful for this. The default value for
+\code{weight} is \code{"1px"}. Borders for any defined \code{sides} can be removed by
+supplying \code{NULL} to any of \code{color}, \code{style}, or \code{weight}.}
 }
 \value{
 A list object of class \code{cell_styles}.


### PR DESCRIPTION
This adds the 'double' option as a border option in `cell_borders`.

Fixes: https://github.com/rstudio/gt/issues/1132