### PR TITLE
Remove knitr flags when saving RTF from `gtsave()`

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -276,7 +276,11 @@ gt_save_rtf <- function(
 
   filename <- gtsave_filename(path = path, filename = filename)
 
-  writeLines(as_rtf(data = data), con = filename)
+  rtf_lines <- as_rtf(data = data)
+
+  rtf_lines <- gsub("!!!!!RAW-KNITR-CONTENT|RAW-KNITR-CONTENT!!!!!", "", rtf_lines)
+
+  writeLines(rtf_lines, con = filename)
 }
 
 #' Saving function for a Word (docx) file


### PR DESCRIPTION
This makes is so that using `gtsave()` to export RTF files now generates proper RTF files. Previously, the codepath for generating RTF output inadvertently kept some knitr flags this is now removed just before writing the RTF lines to a file.