### PR TITLE
Add frequency levels to warnings throughout package

### DIFF
--- a/R/data_color.R
+++ b/R/data_color.R
@@ -557,9 +557,9 @@ data_color <- function(
     na_color <- "#808080"
   }
 
-  # Defuse any function supplied to `fn`; if function supplied to `colors`
-  # (previous argument for this purpose) then let that take precent and
-  # provide deprecation warning
+  # Defuse any function supplied to `fn`; if a function is supplied to `colors`
+  # (previous argument for this purpose) then let that take precedent and
+  # provide a deprecation warning
   if (!is.null(colors)) {
 
     fn <- rlang::enquo(colors)
@@ -572,14 +572,20 @@ data_color <- function(
       cli::cli_warn(c(
         "Since gt v0.9.0, the `colors` argument has been deprecated.",
         "*" = "Please use the `palette` argument to define a color palette."
-      ))
+      ),
+      .frequency = "regularly",
+      .frequency_id = "data_color_warning_palette"
+      )
 
     } else {
 
       cli::cli_warn(c(
         "Since gt v0.9.0, the `colors` argument has been deprecated.",
         "*" = "Please use the `fn` argument instead."
-      ))
+      ),
+      .frequency = "regularly",
+      .frequency_id = "data_color_warning_fn"
+      )
     }
 
   } else if (!is.null(fn)) {

--- a/R/data_color.R
+++ b/R/data_color.R
@@ -574,7 +574,7 @@ data_color <- function(
         "*" = "Please use the `palette` argument to define a color palette."
       ),
       .frequency = "regularly",
-      .frequency_id = "data_color_warning_palette"
+      .frequency_id = "data_color_colors_arg_palette"
       )
 
     } else {
@@ -584,7 +584,7 @@ data_color <- function(
         "*" = "Please use the `fn` argument instead."
       ),
       .frequency = "regularly",
-      .frequency_id = "data_color_warning_fn"
+      .frequency_id = "data_color_colors_arg_fn"
       )
     }
 
@@ -816,14 +816,12 @@ data_color <- function(
 
       if (!is.numeric(data_vals) && direction == "row") {
 
-        cli::cli_warn(c(
+        cli::cli_abort(c(
           "The \"numeric\" method with `direction == \"row\"` cannot be used
           when non-numeric columns are included.",
           "*" = "Either specify a collection of numeric columns or use the
           \"factor\" method."
         ))
-
-        return(data)
       }
 
       if (!is.numeric(data_vals)) next

--- a/R/data_color.R
+++ b/R/data_color.R
@@ -1202,7 +1202,6 @@ html_color <- function(colors, alpha = NULL) {
 
   # Stop function if there are any NA values in `colors`
   if (any(is.na(colors))) {
-
     cli::cli_abort("No values supplied in `colors` should be `NA`.")
   }
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -789,9 +789,12 @@ cells_row_groups <- function(groups = everything()) {
 cells_group <- function(groups = everything()) {
 
   cli::cli_warn(c(
-    "The `cells_group()` function is deprecated and will soon be removed.",
-    "*" = "Use the `cells_row_groups()` function instead."
-  ))
+    "Since gt v0.2.0.5, the `cells_group()` function has been deprecated.",
+    "*" = "Please use the `cells_row_groups()` function instead."
+  ),
+  .frequency = "regularly",
+  .frequency_id = "cells_group_fn_deprecation"
+  )
 
   cells_row_groups(groups = {{groups}})
 }

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -1574,9 +1574,13 @@ cols_merge <- function(
 
     if (length(base::setdiff(hide_columns, columns) > 0)) {
       cli::cli_warn(c(
-        "Only the columns supplied in `columns` will be hidden.",
-        "*" = "Use `cols_hide()` to hide any out of scope columns."
-      ))
+        "Only a subset of columns supplied in `columns` will be hidden.",
+        "*" = "Use an additional `cols_hide()` expression to hide any
+        out-of-scope columns."
+      ),
+      .frequency = "regularly",
+      .frequency_id = "cols_merge_hide_columns_scope"
+      )
     }
 
     if (length(hide_columns_from_supplied) > 0) {

--- a/R/substitution.R
+++ b/R/substitution.R
@@ -121,7 +121,10 @@ fmt_missing <- function(
     "Since gt v0.6.0 the `fmt_missing()` function is deprecated and will
     soon be removed.",
     "*" = "Use the `sub_missing()` function instead."
-  ))
+  ),
+  .frequency = "regularly",
+  .frequency_id = "fmt_missing_fn_deprecation"
+  )
 
   sub_missing(
     data = data,

--- a/R/summary_rows.R
+++ b/R/summary_rows.R
@@ -377,7 +377,10 @@ summary_rows <- function(
     cli::cli_warn(c(
       "Since gt v0.9.0, the `formatter` argument (and associated `...`) has been deprecated.",
       "*" = "Please use the `fmt` argument to provide formatting directives."
-    ))
+    ),
+    .frequency = "regularly",
+    .frequency_id = "summary_rows_formatter_arg_deprecated"
+    )
   }
 
   # With `fmt` input, normalize to list of formatting functions

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -677,7 +677,10 @@ tab_row_group <- function(
     cli::cli_warn(c(
       "Since gt v0.3.0 the `group` argument has been deprecated.",
       "*" = "Use the `label` argument to specify the group label."
-    ))
+    ),
+    .frequency = "regularly",
+    .frequency_id = "tab_row_group_group_arg_deprecated"
+    )
   }
 
   # Warn user about `others_label` deprecation
@@ -693,7 +696,10 @@ tab_row_group <- function(
       "Since gt v0.3.0 the `others_label` argument has been deprecated.",
       "*" = "Use `tab_options(row_group.default_label = <label>)` to set
       this label."
-    ))
+    ),
+    .frequency = "regularly",
+    .frequency_id = "tab_row_group_others_label_arg_deprecated"
+    )
 
     if (missing(label) && missing(rows) && missing(id)) {
       return(data)

--- a/tests/testthat/test-as_raw_html.R
+++ b/tests/testthat/test-as_raw_html.R
@@ -1,4 +1,4 @@
-test_that("`as_raw_html()` produces the same table every time", {
+test_that("The `as_raw_html()` function produces the same table every time", {
 
   gt_html_1 <-
     gt(exibble) %>%

--- a/tests/testthat/test-color_handling.R
+++ b/tests/testthat/test-color_handling.R
@@ -17,7 +17,7 @@ selection_value <- function(html, key) {
   rvest::html_attr(rvest::html_nodes(html, selection), key)
 }
 
-test_that("the various color utility functions work correctly", {
+test_that("The various color utility functions work correctly", {
 
   # Assign various color vectors that are of different specifications
   c_name <- c("red", "tomato", "palevioletred3", "limegreen", "gray86", "blue", "transparent")
@@ -486,7 +486,7 @@ test_that("the various color utility functions work correctly", {
   expect_error(adjust_luminance(colors = c_hex, steps = +2.1))
 })
 
-test_that("the `cell_fill()` function accepts colors of various types", {
+test_that("The `cell_fill()` function accepts colors of various types", {
 
   # Create a `tbl_html` object by using `tab_style` with
   # the `cell_fill()` helper function and a color name

--- a/tests/testthat/test-cols_align.R
+++ b/tests/testthat/test-cols_align.R
@@ -14,7 +14,7 @@ check_suggests <- function() {
   skip_if_not_installed("xml2")
 }
 
-test_that("the `cols_align()` function works correctly", {
+test_that("The `cols_align()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -125,7 +125,7 @@ test_that("the `cols_align()` function works correctly", {
     expect_equal(c("Date", "Open", "High", "Low", "Close", "Volume"))
 })
 
-test_that("the stub get its alignment set properly with `cols_align()`", {
+test_that("The stub gets its alignment set properly with `cols_align()`", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-cols_label.R
+++ b/tests/testthat/test-cols_label.R
@@ -31,7 +31,7 @@ selection_text <- function(html, selection) {
   rvest::html_text(rvest::html_nodes(html, selection))
 }
 
-test_that("the function `cols_label()` works correctly", {
+test_that("The function `cols_label()` works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-cols_label_with.R
+++ b/tests/testthat/test-cols_label_with.R
@@ -31,7 +31,7 @@ selection_text <- function(html, selection) {
   rvest::html_text(rvest::html_nodes(html, selection))
 }
 
-test_that("the function `cols_label()` works correctly", {
+test_that("The function `cols_label_with()` works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-cols_merge.R
+++ b/tests/testthat/test-cols_merge.R
@@ -34,6 +34,8 @@ check_suggests <- function() {
 
 test_that("the function `cols_merge()` works correctly", {
 
+  local_options("rlib_warning_verbosity" = "verbose")
+
   # Check that specific suggested packages are available
   check_suggests()
 

--- a/tests/testthat/test-cols_merge.R
+++ b/tests/testthat/test-cols_merge.R
@@ -32,7 +32,7 @@ check_suggests <- function() {
   skip_if_not_installed("xml2")
 }
 
-test_that("the function `cols_merge()` works correctly", {
+test_that("The function `cols_merge()` works correctly", {
 
   local_options("rlib_warning_verbosity" = "verbose")
 
@@ -175,7 +175,7 @@ test_that("the function `cols_merge()` works correctly", {
   )
 })
 
-test_that("the secondary pattern language works well in `cols_merge()`", {
+test_that("The secondary pattern language works well in `cols_merge()`", {
 
   # Create a `tbl_html` object with `gt()`
   tbl_gt <- gt(tbl_na)
@@ -250,7 +250,7 @@ test_that("the secondary pattern language works well in `cols_merge()`", {
   )
 })
 
-test_that("the `cols_merge_uncert()` function works correctly", {
+test_that("The `cols_merge_uncert()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -391,7 +391,7 @@ test_that("the `cols_merge_uncert()` function works correctly", {
   gt_tbl_1 %>% render_as_html() %>% expect_snapshot()
 })
 
-test_that("the `cols_merge_uncert()` fn works nicely with different error bounds", {
+test_that("The `cols_merge_uncert()` fn works nicely with different error bounds", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -450,7 +450,7 @@ test_that("the `cols_merge_uncert()` fn works nicely with different error bounds
   )
 })
 
-test_that("the `cols_merge_range()` function works correctly", {
+test_that("The `cols_merge_range()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -693,7 +693,7 @@ test_that("the `cols_merge_range()` function works correctly", {
   gt_tbl_4 %>% render_as_html() %>% expect_snapshot()
 })
 
-test_that("the `cols_merge_n_pct()` function works correctly", {
+test_that("The `cols_merge_n_pct()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-cols_move.R
+++ b/tests/testthat/test-cols_move.R
@@ -7,7 +7,7 @@ check_suggests <- function() {
   skip_if_not_installed("xml2")
 }
 
-test_that("the `cols_move()` function works correctly", {
+test_that("The `cols_move()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -121,7 +121,7 @@ test_that("the `cols_move()` function works correctly", {
   )
 })
 
-test_that("the `cols_move_to_start()` function works correctly", {
+test_that("The `cols_move_to_start()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -193,7 +193,7 @@ test_that("the `cols_move_to_start()` function works correctly", {
   )
 })
 
-test_that("the `cols_move_to_end()` function works correctly", {
+test_that("The `cols_move_to_end()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-cols_width.R
+++ b/tests/testthat/test-cols_width.R
@@ -243,7 +243,7 @@ test_that("The `cols_width()` function stores values correctly", {
   )
 })
 
-test_that("the function `cols_width()` works correctly with a simple table", {
+test_that("The function `cols_width()` works correctly with a simple table", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -598,7 +598,7 @@ test_that("the function `cols_width()` works correctly with a simple table", {
   )
 })
 
-test_that("the function `cols_width()` works correctly with a complex table", {
+test_that("The function `cols_width()` works correctly with a complex table", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-conditional_fmt.R
+++ b/tests/testthat/test-conditional_fmt.R
@@ -28,7 +28,7 @@ time_tbl <-
 # `data_tbl` dataset
 tab_time <- gt(time_tbl)
 
-test_that("the `fmt_number()` function works with conditional `rows`", {
+test_that("The `fmt_number()` function works with conditional `rows`", {
 
   expect_equal(
     (tab %>%
@@ -50,7 +50,7 @@ test_that("the `fmt_number()` function works with conditional `rows`", {
     c("34.0000", "74", "23", "NA", "35", "NA", "NA"))
 })
 
-test_that("the `fmt_scientific()` function works with conditional `rows`", {
+test_that("The `fmt_scientific()` function works with conditional `rows`", {
 
   expect_equal(
     (tab %>%
@@ -83,7 +83,7 @@ test_that("the `fmt_scientific()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_percent()` function works with conditional `rows`", {
+test_that("The `fmt_percent()` function works with conditional `rows`", {
 
   expect_equal(
     (tab %>%
@@ -110,7 +110,7 @@ test_that("the `fmt_percent()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_currency()` function works with conditional `rows`", {
+test_that("The `fmt_currency()` function works with conditional `rows`", {
 
   expect_equal(
     (tab %>%
@@ -136,7 +136,7 @@ test_that("the `fmt_currency()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_date()` function works with conditional `rows`", {
+test_that("The `fmt_date()` function works with conditional `rows`", {
 
   expect_equal(
     (tab_time %>%
@@ -159,7 +159,7 @@ test_that("the `fmt_date()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_time()` function works with conditional `rows`", {
+test_that("The `fmt_time()` function works with conditional `rows`", {
 
   expect_equal(
     (tab_time %>%
@@ -182,7 +182,7 @@ test_that("the `fmt_time()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_datetime()` function works with conditional `rows`", {
+test_that("The `fmt_datetime()` function works with conditional `rows`", {
 
   expect_equal(
     (tab_time %>%
@@ -209,7 +209,7 @@ test_that("the `fmt_datetime()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_passthrough()` function works with conditional `rows`", {
+test_that("The `fmt_passthrough()` function works with conditional `rows`", {
 
   expect_equal(
     (tab_time %>%
@@ -232,7 +232,7 @@ test_that("the `fmt_passthrough()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `sub_missing()` function works with conditional `rows`", {
+test_that("The `sub_missing()` function works with conditional `rows`", {
 
   expect_equal(
     (tab %>%
@@ -245,7 +245,7 @@ test_that("the `sub_missing()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt()` function works with conditional `rows`", {
+test_that("The `fmt()` function works with conditional `rows`", {
 
   expect_equal(
     (tab %>%

--- a/tests/testthat/test-data_color.R
+++ b/tests/testthat/test-data_color.R
@@ -1180,6 +1180,19 @@ test_that("Certain errors can be expected (and some things don't error)", {
   )
 })
 
+test_that("Certain warnings can be expected when using deprecated arguments", {
+
+  # Expect a warning if value is provided to `colors`
+  expect_warning(
+    exibble %>%
+      gt() %>%
+      data_color(
+        method = "numeric",
+        colors = c("red", "green")
+      )
+  )
+})
+
 test_that("The correct color values are obtained when using a color fn", {
 
   # Create a `tbl_html` object by using `data_color` with the

--- a/tests/testthat/test-data_color.R
+++ b/tests/testthat/test-data_color.R
@@ -1193,6 +1193,8 @@ test_that("Certain errors can be expected (and some things don't error)", {
 
 test_that("Certain warnings can be expected when using deprecated arguments", {
 
+  local_options("rlib_warning_verbosity" = "verbose")
+
   # Expect a warning if a palette is provided to `colors`
   expect_warning(
     exibble %>%

--- a/tests/testthat/test-data_color.R
+++ b/tests/testthat/test-data_color.R
@@ -1144,6 +1144,17 @@ test_that("Certain errors can be expected (and some things don't error)", {
       )
   )
 
+  # Expect an error if using `direction = "row"` with a numeric method
+  # when there are non-numeric cells
+  expect_error(
+    exibble %>%
+      gt() %>%
+      data_color(
+        direction = "row",
+        method = "numeric"
+      )
+  )
+
   # Expect an error if using `direction = "row"` when specifying
   # `target_columns`
   expect_error(
@@ -1182,13 +1193,24 @@ test_that("Certain errors can be expected (and some things don't error)", {
 
 test_that("Certain warnings can be expected when using deprecated arguments", {
 
-  # Expect a warning if value is provided to `colors`
+  # Expect a warning if a palette is provided to `colors`
   expect_warning(
     exibble %>%
       gt() %>%
       data_color(
         method = "numeric",
         colors = c("red", "green")
+      )
+  )
+
+  # Expect a warning if a function is provided to `colors`
+  expect_warning(
+    exibble %>%
+      gt() %>%
+      data_color(
+        columns = num,
+        method = "numeric",
+        colors = scales::col_numeric(palette = c("red", "green"), domain = c(0, 1E7))
       )
   )
 })

--- a/tests/testthat/test-fmt_bytes.R
+++ b/tests/testthat/test-fmt_bytes.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_bytes()` function works correctly", {
+test_that("The `fmt_bytes()` function works correctly", {
 
   # Create an input data frame two columns: one
   # character-based and one that is numeric
@@ -343,7 +343,7 @@ test_that("the `fmt_bytes()` function works correctly", {
   )
 })
 
-test_that("the `fmt_bytes()` function format to specified significant figures", {
+test_that("The `fmt_bytes()` function format to specified significant figures", {
 
   # These numbers will be used in tests of formatting
   # correctly to n significant figures

--- a/tests/testthat/test-fmt_currency.R
+++ b/tests/testthat/test-fmt_currency.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_currency()` function works correctly", {
+test_that("The `fmt_currency()` function works correctly", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -300,7 +300,7 @@ test_that("the `fmt_currency()` function works correctly", {
   )
 })
 
-test_that("the `fmt_currency()` function can scale/suffix larger numbers", {
+test_that("The `fmt_currency()` function can scale/suffix larger numbers", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -530,7 +530,7 @@ test_that("the `fmt_currency()` function can scale/suffix larger numbers", {
     "$999.99990")
 })
 
-test_that("the `currency()` helper function works correctly", {
+test_that("The `currency()` helper function works correctly", {
 
   # Expect that the object produced by `currency()` is a
   # list with `gt_currency` class
@@ -690,7 +690,7 @@ test_that("the `currency()` helper function works correctly", {
   )
 })
 
-test_that("the `fmt_currency()` fn can render in the Indian numbering system", {
+test_that("The `fmt_currency()` fn can render in the Indian numbering system", {
 
   # These numbers will be used in tests of formatting
   # values to the Indian numbering system

--- a/tests/testthat/test-fmt_date_time.R
+++ b/tests/testthat/test-fmt_date_time.R
@@ -2,7 +2,7 @@ skip_on_os("linux")
 
 library(lubridate)
 
-test_that("the `fmt_date()` function works correctly", {
+test_that("The `fmt_date()` function works correctly", {
 
   # Create an input tibble frame with a single column
   # that contains dates as character values
@@ -243,7 +243,7 @@ test_that("the `fmt_date()` function works correctly", {
   )
 })
 
-test_that("the `fmt_time()` function works correctly", {
+test_that("The `fmt_time()` function works correctly", {
 
   # Create an input tibble frame with a single column
   # that contains times as character values
@@ -450,7 +450,7 @@ test_that("the `fmt_time()` function works correctly", {
   )
 })
 
-test_that("the `fmt_datetime()` function works correctly", {
+test_that("The `fmt_datetime()` function works correctly", {
 
   # Create an input tibble frame with a single column
   # that contains date-times as character values

--- a/tests/testthat/test-fmt_duration.R
+++ b/tests/testthat/test-fmt_duration.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_duration()` function works correctly with numerical inputs", {
+test_that("The `fmt_duration()` function works correctly with numerical inputs", {
 
   # Create an input tibble with a numeric column
   data_tbl_1 <-
@@ -1352,7 +1352,7 @@ test_that("the `fmt_duration()` function works correctly with numerical inputs",
   )
 })
 
-test_that("specialized handling of the `colon-sep` format works correctly", {
+test_that("Specialized handling of the `colon-sep` format works correctly", {
 
   # Create an input tibble with a numeric column
   data_tbl_1 <-
@@ -1521,7 +1521,7 @@ test_that("specialized handling of the `colon-sep` format works correctly", {
   )
 })
 
-test_that("the `fmt_duration()` function works correctly with difftime inputs", {
+test_that("The `fmt_duration()` function works correctly with difftime inputs", {
 
   dt_1 <- ISOdatetime(year = 2015, month = 6, day = 3:5, hour = 3:5, min = 5:7, sec = 25:27, tz = "GMT")
   dt_2 <- ISOdatetime(year = 2015, month = 6, day = c(5, 8, 12), hour = 5:7, min = 30:32, sec = 0:2, tz = "GMT")
@@ -1590,7 +1590,7 @@ test_that("the `fmt_duration()` function works correctly with difftime inputs", 
   )
 })
 
-test_that("the `fmt_duration()` function works well with mixed numeric/difftime inputs", {
+test_that("The `fmt_duration()` function works well with mixed numeric/difftime inputs", {
 
   dt_1 <- ISOdatetime(year = 2015, month = 6, day = 3:5, hour = 3:5, min = 5:7, sec = 25:27, tz = "GMT")
   dt_2 <- ISOdatetime(year = 2015, month = 6, day = c(5, 8, 12), hour = 5:7, min = 30:32, sec = 0:2, tz = "GMT")
@@ -1633,7 +1633,7 @@ test_that("the `fmt_duration()` function works well with mixed numeric/difftime 
   )
 })
 
-test_that("the `fmt_duration()` function will produce localized outputs", {
+test_that("The `fmt_duration()` function will produce localized outputs", {
 
   # Create an input tibble with a numeric column
   data_tbl_5 <-
@@ -1708,7 +1708,7 @@ test_that("the `fmt_duration()` function will produce localized outputs", {
   tab_wide %>% render_as_html() %>% expect_snapshot()
 })
 
-test_that("the `fmt_duration()` function will error in specific cases", {
+test_that("The `fmt_duration()` function will error in specific cases", {
 
   dt_1 <- ISOdatetime(year = 2015, month = 6, day = 3:5, hour = 3:5, min = 5:7, sec = 25:27, tz = "GMT")
   dt_2 <- ISOdatetime(year = 2015, month = 6, day = c(5, 8, 12), hour = 5:7, min = 30:32, sec = 0:2, tz = "GMT")

--- a/tests/testthat/test-fmt_engineering.R
+++ b/tests/testthat/test-fmt_engineering.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_engineering()` function works correctly", {
+test_that("The `fmt_engineering()` function works correctly", {
 
   # Create an input data frame with a single numeric column
   data_tbl <-
@@ -431,7 +431,7 @@ test_that("the `fmt_engineering()` function works correctly", {
   )
 })
 
-test_that("`fmt_engineering() can handle extremely large and small values", {
+test_that("The `fmt_engineering() fn can handle extremely large and small values", {
 
   # Create an input data frame with very large and very small numbers
   # (both positive and negative)

--- a/tests/testthat/test-fmt_fraction.R
+++ b/tests/testthat/test-fmt_fraction.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_fraction()` function works correctly", {
+test_that("The `fmt_fraction()` function works correctly", {
 
   # Create an input data frame two columns: one
   # character-based and one that is numeric
@@ -427,7 +427,7 @@ test_that("the `fmt_fraction()` function works correctly", {
   )
 })
 
-test_that("the `fmt_fraction()` function produces reproducible results for HTML output", {
+test_that("The `fmt_fraction()` function produces reproducible results for HTML output", {
 
   # Define values
   range_0_1 <- c(0.0001, 0.001, 0.01, 0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9, 0.99, 0.999, 0.9999)
@@ -528,7 +528,7 @@ test_that("the `fmt_fraction()` function produces reproducible results for HTML 
   fraction_tbl_simplified %>% as_rtf() %>% expect_snapshot()
 })
 
-test_that("`fmt_fraction()` can render values in the Indian numbering system", {
+test_that("The `fmt_fraction()` fn can render values in the Indian numbering system", {
 
   # These numbers will be used in tests of formatting
   # values to the Indian numbering system

--- a/tests/testthat/test-fmt_integer.R
+++ b/tests/testthat/test-fmt_integer.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_integer()` function works correctly in the HTML context", {
+test_that("The `fmt_integer()` function works correctly in the HTML context", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -225,7 +225,7 @@ test_that("the `fmt_integer()` function works correctly in the HTML context", {
   )
 })
 
-test_that("the `fmt_integer()` function can scale/suffix larger numbers", {
+test_that("The `fmt_integer()` function can scale/suffix larger numbers", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -320,7 +320,7 @@ test_that("the `fmt_integer()` function can scale/suffix larger numbers", {
   )
 })
 
-test_that("rownames and groupnames aren't included in columns = TRUE", {
+test_that("Rownames and groupnames aren't included in `columns = TRUE`", {
 
   mtcars1 <- cbind(mtcars, chardata = row.names(mtcars))
 
@@ -351,7 +351,7 @@ test_that("rownames and groupnames aren't included in columns = TRUE", {
   )
 })
 
-test_that("the `fmt_integer()` fn can render in the Indian numbering system", {
+test_that("The `fmt_integer()` fn can render in the Indian numbering system", {
 
   # These numbers will be used in tests of formatting
   # values to the Indian numbering system

--- a/tests/testthat/test-fmt_markdown.R
+++ b/tests/testthat/test-fmt_markdown.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_markdown()` function works correctly", {
+test_that("The `fmt_markdown()` function works correctly", {
 
   # Create a few Markdown-based text snippets
   text_1a <- "

--- a/tests/testthat/test-fmt_number.R
+++ b/tests/testthat/test-fmt_number.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_number()` function works correctly in the HTML context", {
+test_that("The `fmt_number()` function works correctly in the HTML context", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -309,7 +309,7 @@ test_that("the `fmt_number()` function works correctly in the HTML context", {
   )
 })
 
-test_that("the `fmt_number()` function can scale/suffix larger numbers", {
+test_that("The `fmt_number()` function can scale/suffix larger numbers", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -531,7 +531,7 @@ test_that("the `fmt_number()` function can scale/suffix larger numbers", {
   )
 })
 
-test_that("the `fmt_number()` function format to specified significant figures", {
+test_that("The `fmt_number()` function format to specified significant figures", {
 
   # These numbers will be used in tests of formatting
   # correctly to n significant figures
@@ -687,7 +687,7 @@ test_that("the `fmt_number()` function format to specified significant figures",
 })
 
 
-test_that("the `drop_trailing_dec_mark` option works in select `fmt_*()` functions", {
+test_that("The `drop_trailing_dec_mark` option works in select `fmt_*()` functions", {
 
   # These numbers will be used in tests with `drop_trailing_dec_mark = FALSE`
   numbers <- c(0.001, 0.01, 0.1, 0, 1, 1.1, 1.12, 50000, -1.5, -5, -500.1)
@@ -842,7 +842,7 @@ test_that("the `drop_trailing_dec_mark` option works in select `fmt_*()` functio
   )
 })
 
-test_that("`fmt_number()` with `suffixing = TRUE` works with small numbers", {
+test_that("The `fmt_number()` fn with `suffixing = TRUE` works with small numbers", {
 
   # Create an input data frame with a single column
   data_tbl <-
@@ -876,7 +876,7 @@ test_that("`fmt_number()` with `suffixing = TRUE` works with small numbers", {
   )
 })
 
-test_that("rownames and groupnames aren't included in columns = TRUE", {
+test_that("Rownames and groupnames aren't included in `columns = TRUE`", {
 
   mtcars1 <- cbind(mtcars, chardata = row.names(mtcars))
 
@@ -907,7 +907,7 @@ test_that("rownames and groupnames aren't included in columns = TRUE", {
   )
 })
 
-test_that("`fmt_number()` can render values in the Indian numbering system", {
+test_that("The `fmt_number()` fn can render values in the Indian numbering system", {
 
   # These numbers will be used in tests of formatting
   # values to the Indian numbering system

--- a/tests/testthat/test-fmt_partsper.R
+++ b/tests/testthat/test-fmt_partsper.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_partsper()` function works correctly", {
+test_that("The `fmt_partsper()` function works correctly", {
 
   # Create an input data frame two columns: one
   # character-based and one that is numeric

--- a/tests/testthat/test-fmt_passthrough.R
+++ b/tests/testthat/test-fmt_passthrough.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_passthrough()` function works correctly", {
+test_that("The `fmt_passthrough()` function works correctly", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric

--- a/tests/testthat/test-fmt_percent.R
+++ b/tests/testthat/test-fmt_percent.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_percent()` function works correctly in the HTML context", {
+test_that("The `fmt_percent()` function works correctly in the HTML context", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -326,7 +326,7 @@ test_that("the `fmt_percent()` function works correctly in the HTML context", {
   )
 })
 
-test_that("the `fmt_percent()` fn can render in the Indian numbering system", {
+test_that("The `fmt_percent()` fn can render in the Indian numbering system", {
 
   # These numbers will be used in tests of formatting
   # values to the Indian numbering system

--- a/tests/testthat/test-fmt_roman.R
+++ b/tests/testthat/test-fmt_roman.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_roman()` function works correctly", {
+test_that("The `fmt_roman()` function works correctly", {
 
   # Create an input data frame two columns: one
   # character-based and one that is numeric

--- a/tests/testthat/test-fmt_scientific.R
+++ b/tests/testthat/test-fmt_scientific.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_scientific()` function works correctly", {
+test_that("The `fmt_scientific()` function works correctly", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -359,7 +359,7 @@ test_that("the `fmt_scientific()` function works correctly", {
   )
 })
 
-test_that("`fmt_scientific()` can handle extremely large and small values", {
+test_that("The `fmt_scientific()` fn can handle extremely large and small values", {
 
   # Create an input data frame with very
   # large and very small numbers (both

--- a/tests/testthat/test-group_column_label.R
+++ b/tests/testthat/test-group_column_label.R
@@ -122,7 +122,7 @@ exibble_test <- function(
   tbl
 }
 
-test_that("group labels as a column work well across many variations", {
+test_that("Group labels as a column work well across many variations", {
 
   # 1: No row groups or row labels (no stub)
   tbl_1 <-

--- a/tests/testthat/test-gt_object.R
+++ b/tests/testthat/test-gt_object.R
@@ -9,7 +9,7 @@ selection_text <- function(html, selection) {
   rvest::html_text(rvest::html_nodes(html, selection))
 }
 
-test_that("a gt table object contains the correct components", {
+test_that("A gt table object contains the correct components", {
 
   # Create a `gt_tbl` object with `gt()`
   tab <- iris %>% gt()
@@ -40,7 +40,7 @@ test_that("a gt table object contains the correct components", {
   #expect_tab(tab, df = iris %>% dplyr::group_by(Species))
 })
 
-test_that("a gt table can be made to use the rownames of a data frame", {
+test_that("A gt table can be made to use the rownames of a data frame", {
 
   # Create a `gt_tbl` object with `gt()` and use the
   # data frame's row names as row names in the stub
@@ -63,7 +63,7 @@ test_that("a gt table can be made to use the rownames of a data frame", {
   )
 })
 
-test_that("a gt table can be made with the stub partially or fully populated", {
+test_that("A gt table can be made with the stub partially or fully populated", {
 
   # Create an input data frame with a `rowname` column
   # and a `value` column
@@ -120,7 +120,7 @@ test_that("a gt table can be made with the stub partially or fully populated", {
   )
 })
 
-test_that("a gt table can be made from a table with no rows", {
+test_that("A gt table can be made from a table with no rows", {
 
   # Create an input data frame based on the exibble
   # dataset, except with no rows
@@ -153,7 +153,7 @@ test_that("a gt table can be made from a table with no rows", {
   expect_tab(tab = tab, df = data_e %>% dplyr::group_by(group))
 })
 
-test_that("a gt table can use UTF-8 chars in any system locale", {
+test_that("A gt table can use UTF-8 chars in any system locale", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -236,7 +236,7 @@ test_that("a gt table can use UTF-8 chars in any system locale", {
   }
 })
 
-test_that("gt table can be made with grouped data -- one group", {
+test_that("A gt table can be made with grouped data -- one group", {
 
   # Use `dplyr::group_by()` to add a group to an
   # incoming table; create the gt object and build
@@ -308,7 +308,7 @@ test_that("gt table can be made with grouped data -- one group", {
     )
 })
 
-test_that("gt table can be made with grouped data - two groups", {
+test_that("A gt table can be made with grouped data - two groups", {
 
   # Use `dplyr::group_by()` to add two groups to an
   # incoming table; create the gt object and build
@@ -796,7 +796,6 @@ test_that("Escapable characters in rownames are handled correctly in each output
     fixed = TRUE
   )
 })
-
 
 test_that("Default locale settings are honored by formatting functions", {
 

--- a/tests/testthat/test-gt_preview.R
+++ b/tests/testthat/test-gt_preview.R
@@ -1,4 +1,4 @@
-test_that("the `gt_preview()` function works correctly", {
+test_that("The `gt_preview()` function works correctly", {
 
   # Ensure that gt objects still work with `gt_preview()`
   expect_equal(

--- a/tests/testthat/test-gtsave.R
+++ b/tests/testthat/test-gtsave.R
@@ -1,7 +1,7 @@
 skip_on_ci()
 skip_on_covr()
 
-test_that("the `gtsave()` function creates an HTML file based on the extension", {
+test_that("The `gtsave()` function creates an HTML file based on the extension", {
 
   # Create a filename with path, having the
   # .html extension
@@ -461,7 +461,7 @@ test_that("HTML saving with `gt_save_html()` with different path defs works", {
   #     fixed = TRUE)
 # })
 
-test_that("the `gtsave()` function stops in some cases", {
+test_that("The `gtsave()` function stops in some cases", {
 
   # Expect an error if the file extension doesn't
   # correspond to a saving function
@@ -471,7 +471,7 @@ test_that("the `gtsave()` function stops in some cases", {
   expect_error(exibble %>% gt() %>% gtsave(filename = "exibble"))
 })
 
-test_that("`gtsave()` create docx as expected",{
+test_that("The `gtsave()` function creates docx files as expected", {
 
   gt_exibble <- exibble %>% gt()
 
@@ -492,7 +492,7 @@ test_that("`gtsave()` create docx as expected",{
     expect_snapshot()
 })
 
-test_that("`gtsave()` create docx as expected - table has special characters",{
+test_that("The `gtsave()` fn creates docx files even when a table has special characters", {
 
   # addresses issue raised in gh issue #121
 

--- a/tests/testthat/test-h_md_html.R
+++ b/tests/testthat/test-h_md_html.R
@@ -2,7 +2,7 @@ tab <-
   exibble %>%
   gt(rowname_col = "row", groupname_col = "group")
 
-test_that("the `tab_header()` function works with `md()`/`html()`", {
+test_that("The `tab_header()` function works with `md()`/`html()`", {
 
   # Expect the rendered title and subtitle to be
   # exactly as provided
@@ -37,7 +37,7 @@ test_that("the `tab_header()` function works with `md()`/`html()`", {
     expect_true()
 })
 
-test_that("the `tab_spanner()` function works with `md()`/`html()`", {
+test_that("The `tab_spanner()` function works with `md()`/`html()`", {
 
   # Expect the rendered spanner label to be
   # exactly as provided
@@ -73,7 +73,7 @@ test_that("the `tab_spanner()` function works with `md()`/`html()`", {
     expect_true()
 })
 
-test_that("the `cols_label()` function works with `md()`/`html()`", {
+test_that("The `cols_label()` function works with `md()`/`html()`", {
 
   # Expect the rendered column labels to be
   # exactly as provided
@@ -163,7 +163,7 @@ test_that("the `cols_label()` function works with `md()`/`html()`", {
     expect_true()
 })
 
-test_that("the `tab_footnote()` function works with `md()`/`html()`", {
+test_that("The `tab_footnote()` function works with `md()`/`html()`", {
 
   # Expect the rendered footnote to be
   # exactly as provided
@@ -199,7 +199,7 @@ test_that("the `tab_footnote()` function works with `md()`/`html()`", {
     expect_true()
 })
 
-test_that("the `tab_source_note()` function works with `md()`/`html()`", {
+test_that("The `tab_source_note()` function works with `md()`/`html()`", {
 
   # Expect the rendered source note to be
   # exactly as provided

--- a/tests/testthat/test-helper_functions.R
+++ b/tests/testthat/test-helper_functions.R
@@ -1,4 +1,4 @@
-test_that("the the `pct()` helper function works correctly", {
+test_that("The `pct()` helper function works correctly", {
 
   # Create a CSS percentage value string
   percentage <- pct(x = 50)
@@ -11,7 +11,7 @@ test_that("the the `pct()` helper function works correctly", {
     pct(x = "50"))
 })
 
-test_that("the the `px()` helper function works correctly", {
+test_that("The `px()` helper function works correctly", {
 
   # Create a CSS pixel value string
   pixels <- px(x = 50)
@@ -22,4 +22,16 @@ test_that("the the `px()` helper function works correctly", {
   # Expect an error if the value supplied is not numeric
   expect_error(
     px(x = "50"))
+})
+
+test_that("The `cells_group()` emits a warning but works correctly", {
+
+  # Expect a warning from the deprecated `cells_group()` function; it
+  # still does return a useful list object
+  expect_warning(
+    out <- cells_group()
+  )
+
+  # Expect that the output from `cells_group()` is a list
+  expect_type(out, "list")
 })

--- a/tests/testthat/test-image.R
+++ b/tests/testthat/test-image.R
@@ -1,6 +1,6 @@
 library(ggplot2)
 
-test_that("the `test_image()` function works correctly", {
+test_that("The `test_image()` function works correctly", {
 
   # Expect that the `test_image()` function returns paths for
   # either a PNG or SVG test image
@@ -8,7 +8,7 @@ test_that("the `test_image()` function works correctly", {
   test_image(type = "svg") %>% expect_match(".*/test_image.svg")
 })
 
-test_that("the `get_mime_type()` function works correctly", {
+test_that("The `get_mime_type()` function works correctly", {
 
   # Expect that the `get_mime_type()` function returns
   # a mime-type string for svg and jpg files
@@ -16,7 +16,7 @@ test_that("the `get_mime_type()` function works correctly", {
   get_mime_type(file = "file.jpg") %>% expect_equal("image/jpeg")
 })
 
-test_that("the `get_image_uri()` function works correctly", {
+test_that("The `get_image_uri()` function works correctly", {
 
   # Expect that the beginning of the PNG-based image URI has the
   # correct MIME and encoding types
@@ -41,7 +41,7 @@ test_that("the `get_image_uri()` function works correctly", {
   expect_snapshot(get_image_uri(file = test_image(type = "png")))
 })
 
-test_that("the `local_image()` function works correctly", {
+test_that("The `local_image()` function works correctly", {
 
   # Expect that the image tags generated for the included test image
   # are correctly formed
@@ -52,7 +52,7 @@ test_that("the `local_image()` function works correctly", {
   expect_snapshot(local_image(filename = rep(test_image(type = "png"), 2)))
 })
 
-test_that("the `web_image()` function works correctly", {
+test_that("The `web_image()` function works correctly", {
 
   # Expect that the image tag is correctly formed
   expect_equal(
@@ -88,7 +88,7 @@ test_that("the `web_image()` function works correctly", {
   )
 })
 
-test_that("the `ggplot_image()` function works correctly", {
+test_that("The `ggplot_image()` function works correctly", {
 
   skip_on_ci()
 

--- a/tests/testthat/test-info_tables.R
+++ b/tests/testthat/test-info_tables.R
@@ -1,4 +1,4 @@
-test_that("the `info_date_style()` function works correctly", {
+test_that("The `info_date_style()` function works correctly", {
 
   # Expect that the `info_date_style()` function produces an
   # information table with certain classes
@@ -14,7 +14,7 @@ test_that("the `info_date_style()` function works correctly", {
   )
 })
 
-test_that("the `info_time_style()` function works correctly", {
+test_that("The `info_time_style()` function works correctly", {
 
   # Expect that the `info_time_style()` function produces an
   # information table with certain classes
@@ -30,7 +30,7 @@ test_that("the `info_time_style()` function works correctly", {
   )
 })
 
-test_that("the `info_google_fonts()` function works correctly", {
+test_that("The `info_google_fonts()` function works correctly", {
 
   # Expect that the `info_google_fonts()` function produces an
   # information table with certain classes

--- a/tests/testthat/test-input_data_validation.R
+++ b/tests/testthat/test-input_data_validation.R
@@ -1,4 +1,4 @@
-test_that("all exported functions validate the incoming `data` object", {
+test_that("All exported functions validate the incoming `data` object", {
 
   regexp_stop <- "The object to `data` is not a `gt_tbl` object"
 
@@ -84,7 +84,7 @@ test_that("all exported functions validate the incoming `data` object", {
   expect_error(exibble %>% extract_cells(), regexp = regexp_stop)
 })
 
-test_that("certain `fmt_*()` functions stop if given incompatible column data", {
+test_that("Certain `fmt_*()` functions stop if given incompatible column data", {
 
   gt_tbl <- exibble %>% gt()
 

--- a/tests/testthat/test-l_cols_align.R
+++ b/tests/testthat/test-l_cols_align.R
@@ -7,7 +7,7 @@ sp500 <-
     system.file("extdata", "sp500.csv", package = "gt"),
     stringsAsFactors = FALSE)
 
-test_that("the `cols_align()` function works correctly", {
+test_that("The `cols_align()` function works correctly", {
 
   # Create a `tbl_latex` object with `gt()`; the `mpg`,
   # `cyl`, and `drat` columns are aligned left

--- a/tests/testthat/test-l_cols_merge.R
+++ b/tests/testthat/test-l_cols_merge.R
@@ -16,7 +16,7 @@ tbl <-
     105.4,  729.8,  962.4,  336.4,
     924.2,  424.6,  740.8,  104.2)
 
-test_that("the function `cols_merge()` works correctly", {
+test_that("The `cols_merge()` function works correctly", {
 
   # Create a `tbl_latex` object with `gt()`; merge two columns
   # with a `pattern`
@@ -93,7 +93,7 @@ test_that("the function `cols_merge()` works correctly", {
     expect_true()
 })
 
-test_that("the `cols_merge_uncert()` function works correctly", {
+test_that("The `cols_merge_uncert()` function works correctly", {
 
   # Create a `tbl_latex` object with `gt()`; merge two columns
   # with `cols_merge_uncert()`
@@ -181,7 +181,7 @@ test_that("the `cols_merge_uncert()` function works correctly", {
     expect_true()
 })
 
-test_that("the `cols_merge_range()` function works correctly", {
+test_that("The `cols_merge_range()` function works correctly", {
 
   # Create a `tbl_latex` object with `gt()`; merge two columns
   # with `cols_merge_range()`

--- a/tests/testthat/test-l_cols_move.R
+++ b/tests/testthat/test-l_cols_move.R
@@ -1,7 +1,7 @@
 # Create a shortened version of `mtcars`
 mtcars_short <- mtcars[1:5, ]
 
-test_that("the `cols_move()` function works correctly", {
+test_that("The `cols_move()` function works correctly", {
 
   # Create a `tbl_latex` object with `gt()`; the `mpg`,
   # `cyl`, and `drat` columns placed after `drat`
@@ -46,7 +46,7 @@ test_that("the `cols_move()` function works correctly", {
     expect_true()
 })
 
-test_that("the `cols_move_to_start()` function works correctly", {
+test_that("The `cols_move_to_start()` function works correctly", {
 
   # Create a `tbl_latex` object with `gt()`; the `gear`,
   # and `carb` columns placed at the start
@@ -77,7 +77,7 @@ test_that("the `cols_move_to_start()` function works correctly", {
     expect_true()
 })
 
-test_that("the `cols_move_to_end()` function works correctly", {
+test_that("The `cols_move_to_end()` function works correctly", {
 
   # Create a `tbl_latex` object with `gt()`; the `gear`,
   # and `carb` columns placed at the end

--- a/tests/testthat/test-l_conditional_fmt.R
+++ b/tests/testthat/test-l_conditional_fmt.R
@@ -28,7 +28,7 @@ time_tbl <-
 # Create a `tbl_latex_time` object with `gt()` and the `data_tbl` dataset
 tbl_latex_time <- gt(time_tbl)
 
-test_that("the `fmt_number()` function works with conditional `rows`", {
+test_that("The `fmt_number()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex %>%
@@ -54,7 +54,7 @@ test_that("the `fmt_number()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_scientific()` function works with conditional `rows`", {
+test_that("The `fmt_scientific()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex %>%
@@ -81,7 +81,7 @@ test_that("the `fmt_scientific()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_percent()` function works with conditional `rows`", {
+test_that("The `fmt_percent()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex %>%
@@ -107,7 +107,7 @@ test_that("the `fmt_percent()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_currency()` function works with conditional `rows`", {
+test_that("The `fmt_currency()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex %>%
@@ -133,7 +133,7 @@ test_that("the `fmt_currency()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_date()` function works with conditional `rows`", {
+test_that("The `fmt_date()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex_time %>%
@@ -156,7 +156,7 @@ test_that("the `fmt_date()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_time()` function works with conditional `rows`", {
+test_that("The `fmt_time()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex_time %>%
@@ -179,7 +179,7 @@ test_that("the `fmt_time()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_datetime()` function works with conditional `rows`", {
+test_that("The `fmt_datetime()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex_time %>%
@@ -210,7 +210,7 @@ test_that("the `fmt_datetime()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt_passthrough()` function works with conditional `rows`", {
+test_that("The `fmt_passthrough()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex_time %>%
@@ -231,7 +231,7 @@ test_that("the `fmt_passthrough()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `sub_missing()` function works with conditional `rows`", {
+test_that("The `sub_missing()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex %>%
@@ -244,7 +244,7 @@ test_that("the `sub_missing()` function works with conditional `rows`", {
   )
 })
 
-test_that("the `fmt()` function works with conditional `rows`", {
+test_that("The `fmt()` function works with conditional `rows`", {
 
   expect_equal(
     (tbl_latex %>%

--- a/tests/testthat/test-l_fmt_currency.R
+++ b/tests/testthat/test-l_fmt_currency.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_currency()` function works correctly", {
+test_that("The `fmt_currency()` function works correctly", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric

--- a/tests/testthat/test-l_fmt_date_time.R
+++ b/tests/testthat/test-l_fmt_date_time.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_date()` function works correctly", {
+test_that("The `fmt_date()` function works correctly", {
 
   # Create an input tibble frame with a single column
   # that contains dates as character values
@@ -269,7 +269,7 @@ test_that("the `fmt_date()` function works correctly", {
   )
 })
 
-test_that("the `fmt_time()` function works correctly", {
+test_that("The `fmt_time()` function works correctly", {
 
   # Create an input tibble frame with a single column
   # that contains times as character values
@@ -321,7 +321,7 @@ test_that("the `fmt_time()` function works correctly", {
   )
 })
 
-test_that("the `fmt_datetime()` function works correctly", {
+test_that("The `fmt_datetime()` function works correctly", {
 
   # Create an input tibble frame with a single column
   # that contains date-times as character values

--- a/tests/testthat/test-l_fmt_engineering.R
+++ b/tests/testthat/test-l_fmt_engineering.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_engineering()` function works correctly in the LaTeX context", {
+test_that("The `fmt_engineering()` function works correctly in the LaTeX context", {
 
   # Create an input data frame with a single numeric column
   data_tbl <-
@@ -251,7 +251,7 @@ test_that("the `fmt_engineering()` function works correctly in the LaTeX context
   )
 })
 
-test_that("`fmt_engineering() can handle extremely large and small values", {
+test_that("The `fmt_engineering() fn can handle extremely large and small values", {
 
   # Create an input data frame with very large and very small numbers
   # (both positive and negative)

--- a/tests/testthat/test-l_fmt_integer.R
+++ b/tests/testthat/test-l_fmt_integer.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_integer()` function works correctly in the LaTeX context", {
+test_that("The `fmt_integer()` function works correctly in the LaTeX context", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric
@@ -184,7 +184,7 @@ test_that("the `fmt_integer()` function works correctly in the LaTeX context", {
   )
 })
 
-test_that("the `fmt_integer()` function can scale/suffix larger numbers", {
+test_that("The `fmt_integer()` function can scale/suffix larger numbers", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric

--- a/tests/testthat/test-l_fmt_markdown.R
+++ b/tests/testthat/test-l_fmt_markdown.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_markdown()` function works correctly", {
+test_that("The `fmt_markdown()` function works correctly", {
 
   # Create a few Markdown-based text snippets
   text_1a <- "

--- a/tests/testthat/test-l_fmt_missing.R
+++ b/tests/testthat/test-l_fmt_missing.R
@@ -1,4 +1,4 @@
-test_that("the `sub_missing()` function works correctly", {
+test_that("The `sub_missing()` function works correctly", {
 
   # Create an input data frame with two columns, both numeric
   data_tbl <-

--- a/tests/testthat/test-l_fmt_number.R
+++ b/tests/testthat/test-l_fmt_number.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_number()` function works correctly in the LaTeX context", {
+test_that("The `fmt_number()` function works correctly in the LaTeX context", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric

--- a/tests/testthat/test-l_fmt_passthrough.R
+++ b/tests/testthat/test-l_fmt_passthrough.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_passthrough()` function works correctly", {
+test_that("The `fmt_passthrough()` function works correctly", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric

--- a/tests/testthat/test-l_fmt_percent.R
+++ b/tests/testthat/test-l_fmt_percent.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_percent()` function works correctly in the LaTeX context", {
+test_that("The `fmt_percent()` function works correctly in the LaTeX context", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric

--- a/tests/testthat/test-l_fmt_scientific.R
+++ b/tests/testthat/test-l_fmt_scientific.R
@@ -1,4 +1,4 @@
-test_that("the `fmt_scientific()` function works correctly", {
+test_that("The `fmt_scientific()` function works correctly", {
 
   # Create an input data frame four columns: two
   # character-based and two that are numeric

--- a/tests/testthat/test-l_row_group_order.R
+++ b/tests/testthat/test-l_row_group_order.R
@@ -1,4 +1,4 @@
-test_that("the `row_group_order()` function works correctly", {
+test_that("The `row_group_order()` function works correctly", {
 
   # Create a table with group names, rownames, and four columns of values
   tbl <-

--- a/tests/testthat/test-l_tab_spanner_delim.R
+++ b/tests/testthat/test-l_tab_spanner_delim.R
@@ -1,7 +1,7 @@
 # Create a shortened version of `iris`
 iris_short <- iris[1:5, ]
 
-test_that("the `tab_spanner_delim()` function works correctly", {
+test_that("The `tab_spanner_delim()` function works correctly", {
 
   # Create a `tbl_latex` object with `gt()`; split the column
   # names into spanner headings and column labels

--- a/tests/testthat/test-l_table_parts.R
+++ b/tests/testthat/test-l_table_parts.R
@@ -1,7 +1,7 @@
 # Create a shorter version of `mtcars`
 mtcars_short <- mtcars[1:5, ]
 
-test_that("a gt table contains the expected heading components", {
+test_that("A gt table contains the expected heading components", {
 
   # Create a `tbl_latex` object with `gt()`; this table contains a title
   tbl_latex <-
@@ -70,7 +70,7 @@ test_that("a gt table contains the expected heading components", {
     expect_snapshot()
 })
 
-test_that("a gt table contains the expected stubhead label", {
+test_that("A gt table contains the expected stubhead label", {
 
   # Create a `tbl_latex` object with `gt()`; this table
   # contains a stub and a stubhead caption
@@ -88,7 +88,7 @@ test_that("a gt table contains the expected stubhead label", {
     expect_true()
 })
 
-test_that("a gt table contains the expected column spanner labels", {
+test_that("A gt table contains the expected column spanner labels", {
 
   # Create a `tbl_latex` object with `gt()`; this table
   # contains the spanner heading `perimeter` over the
@@ -206,7 +206,7 @@ test_that("a gt table contains the expected column spanner labels", {
     expect_snapshot()
 })
 
-test_that("a gt table contains the expected source note", {
+test_that("A gt table contains the expected source note", {
 
   # Create a `tbl_latex` object with `gt()`; this table
   # contains a source note
@@ -241,7 +241,7 @@ test_that("a gt table contains the expected source note", {
     expect_snapshot()
 })
 
-test_that("a gt table contains the correct placement of row groups", {
+test_that("A gt table contains the correct placement of row groups", {
 
   # Create a `tbl_latex` object with `gt()`; this table
   # contains a row groups in a specified order

--- a/tests/testthat/test-location_cells.R
+++ b/tests/testthat/test-location_cells.R
@@ -44,7 +44,7 @@ selection_value <- function(html, key) {
   rvest::html_attr(rvest::html_nodes(html, selection), key)
 }
 
-test_that("the `cells_title()` function works correctly", {
+test_that("The `cells_title()` function works correctly", {
 
   # Create a `cells_title` object with the `title` option
   helper_cells_title <- cells_title(groups = "title")
@@ -101,7 +101,7 @@ test_that("the `cells_title()` function works correctly", {
   expect_error(cells_title(groups = character(0)))
 })
 
-test_that("the `cells_column_labels()` function works correctly", {
+test_that("The `cells_column_labels()` function works correctly", {
 
   # Create a `cells_column_labels` object with names provided to `columns`
   helper_cells_column_labels <-
@@ -159,7 +159,7 @@ test_that("the `cells_column_labels()` function works correctly", {
     expect_equal(c("group_1", "group_2"))
 })
 
-test_that("the `cells_row_groups()` function works correctly", {
+test_that("The `cells_row_groups()` function works correctly", {
 
   # Create a `cells_row_groups` object with names provided to `groups`
   helper_cells_row_groups <- cells_row_groups(groups = c("group_1", "group_2"))
@@ -187,7 +187,7 @@ test_that("the `cells_row_groups()` function works correctly", {
     expect_equal(c("group_1", "group_2"))
 })
 
-test_that("the `cells_stub()` function works correctly", {
+test_that("The `cells_stub()` function works correctly", {
 
   # Create a `cells_stub` object with names provided to `rows`
   helper_cells_stub <- cells_stub(rows = c("row_1", "row_2"))
@@ -215,7 +215,7 @@ test_that("the `cells_stub()` function works correctly", {
     expect_equal(c("row_1", "row_2"))
 })
 
-test_that("the `cells_body()` function works correctly", {
+test_that("The `cells_body()` function works correctly", {
 
   # Create a `cells_body` object with names provided to `columns`
   helper_cells_body <- cells_body(columns = c("col_1", "col_2"))
@@ -281,7 +281,7 @@ test_that("the `cells_body()` function works correctly", {
     expect_equal(c("row_1", "row_2"))
 })
 
-test_that("the `cells_summary()` function works correctly", {
+test_that("The `cells_summary()` function works correctly", {
 
   # Create a `cells_summary` object with names provided to `columns`
   helper_cells_summary <-
@@ -334,7 +334,7 @@ test_that("the `cells_summary()` function works correctly", {
     )
 })
 
-test_that("the `cells_grand_summary()` function works correctly", {
+test_that("The `cells_grand_summary()` function works correctly", {
 
   # Create a `cells_grand_summary` object with names provided to `columns`
   helper_cells_grand_summary <-
@@ -376,7 +376,7 @@ test_that("the `cells_grand_summary()` function works correctly", {
     )
 })
 
-test_that("the `cells_stubhead()` function works correctly", {
+test_that("The `cells_stubhead()` function works correctly", {
 
   # Create a `cells_stubhead` object
   helper_cells_stubhead <- cells_stubhead()
@@ -403,7 +403,7 @@ test_that("the `cells_stubhead()` function works correctly", {
     expect_equal("stubhead")
 })
 
-test_that("styles are correctly applied to HTML output with location functions", {
+test_that("Styles are correctly applied to HTML output with location functions", {
 
   check_suggests()
 

--- a/tests/testthat/test-r_table_parts.R
+++ b/tests/testthat/test-r_table_parts.R
@@ -1,4 +1,4 @@
-test_that("a gt table contains the expected column spanner labels", {
+test_that("A gt table contains the expected column spanner labels", {
 
   skip_on_ci()
 

--- a/tests/testthat/test-resolver.R
+++ b/tests/testthat/test-resolver.R
@@ -1,4 +1,4 @@
-test_that("`resolve_cols_i()` and `resolve_cols_c()` both work", {
+test_that("The `resolve_cols_i()` and `resolve_cols_c()` fns both work", {
 
   all_cols <- setNames(seq_along(names(exibble)), names(exibble))
   no_cols <- setNames(integer(0), character(0))
@@ -33,7 +33,7 @@ test_that("`resolve_cols_i()` and `resolve_cols_c()` both work", {
   expect_resolve_cols(100L, no_cols, strict = FALSE)
 })
 
-test_that("`resolve_rows_l()` and `resolve_rows_i()` both work", {
+test_that("The `resolve_rows_l()` and `resolve_rows_i()` fns both work", {
 
   mtcars_gt <- gt(mtcars, rownames_to_stub = TRUE)
   iris_gt <- gt(iris, rownames_to_stub = TRUE)
@@ -162,7 +162,7 @@ test_that("`resolve_rows_l()` and `resolve_rows_i()` both work", {
 })
 
 
-test_that("`resolve_vector_l()` and `resolve_vector_i()` both work", {
+test_that("The `resolve_vector_l()` and `resolve_vector_i()` fns both work", {
 
   vector_x <- c(colnames(exibble), NA_character_, "", colnames(exibble)[1:2])
 

--- a/tests/testthat/test-row_group_order.R
+++ b/tests/testthat/test-row_group_order.R
@@ -27,7 +27,7 @@ selection_value <- function(html, key) {
   rvest::html_attr(rvest::html_nodes(html, selection), key)
 }
 
-test_that("the `row_group_order()` function works correctly", {
+test_that("The `row_group_order()` function works correctly", {
 
   # Create a `tbl_html` that arranges the groups by the
   # latter calendar date first
@@ -57,7 +57,7 @@ test_that("the `row_group_order()` function works correctly", {
   )
 })
 
-test_that("styling at various locations is kept when using `row_group_order()`", {
+test_that("Styling at various locations is kept when using `row_group_order()`", {
 
   # Generate a summary table from `tbl`
   summary_tbl <-

--- a/tests/testthat/test-rtf_page_options.R
+++ b/tests/testthat/test-rtf_page_options.R
@@ -1,6 +1,6 @@
 skip_on_os("linux")
 
-test_that("page options can used for RTF output", {
+test_that("Page options can used for RTF output", {
 
   # Create a one-row table for these tests
   exibble_min <- exibble[1, 1:4]

--- a/tests/testthat/test-substitution.R
+++ b/tests/testthat/test-substitution.R
@@ -1,4 +1,4 @@
-test_that("the `sub_missing()` function works correctly", {
+test_that("The `sub_missing()` function works correctly", {
 
   # Create an input table with two columns, both numeric
   data_tbl <-
@@ -269,7 +269,7 @@ test_that("the `sub_missing()` function works correctly", {
   )
 })
 
-test_that("the `sub_zero()` function works correctly", {
+test_that("The `sub_zero()` function works correctly", {
 
   # Create an input data frame with two columns: one numeric, one character
   data_tbl <-
@@ -368,7 +368,7 @@ test_that("the `sub_zero()` function works correctly", {
   )
 })
 
-test_that("the `sub_small_vals()` function works correctly", {
+test_that("The `sub_small_vals()` function works correctly", {
 
   # Create an input table with three columns
   data_tbl <-
@@ -573,7 +573,7 @@ test_that("the `sub_small_vals()` function works correctly", {
   expect_error(tab %>% sub_small_vals(columns = "num_1", sign = "?"))
 })
 
-test_that("the `sub_large_vals()` function works correctly", {
+test_that("The `sub_large_vals()` function works correctly", {
 
   # Create an input table with three columns
   data_tbl <-
@@ -760,7 +760,7 @@ test_that("the `sub_large_vals()` function works correctly", {
   expect_error(tab %>% sub_large_vals(columns = "num_1", sign = "?"))
 })
 
-test_that("the `sub_values()` function works correctly", {
+test_that("The `sub_values()` function works correctly", {
 
   # Create an input table with three columns
   data_tbl <-

--- a/tests/testthat/test-summary_rows.R
+++ b/tests/testthat/test-summary_rows.R
@@ -1092,6 +1092,8 @@ test_that("Summary row labels are added in narrow and wide tables", {
 
 test_that("Multiple ways of expressing formatting work equivalently", {
 
+  local_options("rlib_warning_verbosity" = "verbose")
+
   expect_warning(
     gt_tbl_1 <-
       tbl %>%
@@ -2227,6 +2229,8 @@ test_that("The `normalize_summary_fns()` function works with a variety of inputs
 })
 
 test_that("The deprecated `formatter` arg and `...` still function properly", {
+
+  local_options("rlib_warning_verbosity" = "verbose")
 
   # Generate summary rows and use a formatting function in the deprecated
   # `formatter` arg; this yields a warning but works so long as `fmt = NULL`

--- a/tests/testthat/test-tab_caption.R
+++ b/tests/testthat/test-tab_caption.R
@@ -12,7 +12,7 @@ expect_caption_eq <- function(caption, expected) {
   )
 }
 
-test_that("a caption can be added/removed with `tab_caption()`/`rm_caption()`", {
+test_that("A caption can be added/removed with `tab_caption()`/`rm_caption()`", {
 
   # Create a table and add a caption
   tbl_1 <-

--- a/tests/testthat/test-tab_footnote.R
+++ b/tests/testthat/test-tab_footnote.R
@@ -170,7 +170,7 @@ selection_text <- function(html, selection) {
   rvest::html_text(rvest::html_nodes(html, selection))
 }
 
-test_that("the `tab_footnote()` function works correctly", {
+test_that("The `tab_footnote()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -675,7 +675,7 @@ test_that("the `tab_footnote()` function works correctly", {
     expect_equal(rep(as.character(1:4), 2))
 })
 
-test_that("the footnotes table is structured correctly", {
+test_that("The footnotes table is structured correctly", {
 
   # Extract `footnotes_resolved` and `list_of_summaries`
   footnotes_tbl <- dt_footnotes_get(data = data_3)
@@ -762,7 +762,7 @@ test_that("the footnotes table is structured correctly", {
     expect_equal("Open and Close Values2")
 })
 
-test_that("the `list_of_summaries` table is structured correctly", {
+test_that("The `list_of_summaries` table is structured correctly", {
 
   gtcars_built <-
     gtcars %>%
@@ -837,7 +837,7 @@ test_that("the `list_of_summaries` table is structured correctly", {
   )
 })
 
-test_that("footnotes with no location are rendered correctly", {
+test_that("Footnotes with no location are rendered correctly", {
 
   gt_tbl <- gt(data = exibble[1, ])
 

--- a/tests/testthat/test-tab_info.R
+++ b/tests/testthat/test-tab_info.R
@@ -60,7 +60,7 @@ exibble_minitest <- function(
   tbl
 }
 
-test_that("the `tab_info()` function generates a gt table from a gt table", {
+test_that("The `tab_info()` function generates a gt table from a gt table", {
 
   expect_true(
     exibble_minitest() %>% tab_info() %>% is_gt()

--- a/tests/testthat/test-tab_options.R
+++ b/tests/testthat/test-tab_options.R
@@ -68,7 +68,7 @@ selection_text <- function(html, selection) {
   rvest::html_text(rvest::html_nodes(html, selection))
 }
 
-test_that("the internal `opts_df` table can be correctly modified", {
+test_that("The internal `opts_df` table can be correctly modified", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -1440,7 +1440,7 @@ test_that("the internal `opts_df` table can be correctly modified", {
     expect_equal(c(" ", "  "))
 })
 
-test_that("the `opts_df` getter/setter functions properly", {
+test_that("The `opts_df` getter/setter functions properly", {
 
   # Obtain a local copy of the internal `_options` table
   dt_options_get(data = data) %>% expect_s3_class("tbl_df")
@@ -1459,7 +1459,7 @@ test_that("the `opts_df` getter/setter functions properly", {
     expect_equal("60%")
 })
 
-test_that("all column labels can be entirely hidden from view", {
+test_that("All column labels can be entirely hidden from view", {
 
   # Expect that the option `column_labels.hidden = TRUE` will
   # remove the expected node with the classes of `gt_col_heading`
@@ -1486,7 +1486,7 @@ test_that("all column labels can be entirely hidden from view", {
     4)
 })
 
-test_that("the row striping options work correctly", {
+test_that("The row striping options work correctly", {
 
   # Expect that the option `row.striping.include_stub = FALSE`
   # will result in no CSS class combinations of `gt_stub` and
@@ -1580,7 +1580,7 @@ test_that("the row striping options work correctly", {
   )
 })
 
-test_that("certain X11 color names are replaced in HTML tables", {
+test_that("Certain X11 color names are replaced in HTML tables", {
 
   # Here, the `gray85` color supplied to `heading.background.color`
   # is transformed to the #D9D9D9 color and it appears in the rule:
@@ -1793,7 +1793,7 @@ test_that("certain X11 color names are replaced in HTML tables", {
   )
 })
 
-test_that("vertical padding across several table parts can be applied", {
+test_that("Vertical padding across several table parts can be applied", {
 
   snap_padded_tbl <- function(padding_px) {
 

--- a/tests/testthat/test-tab_spanner.R
+++ b/tests/testthat/test-tab_spanner.R
@@ -15,7 +15,7 @@ selection_text <- function(html, selection) {
   rvest::html_text(rvest::html_nodes(html, selection))
 }
 
-test_that("a gt table contains the expected spanner column labels", {
+test_that("A gt table contains the expected spanner column labels", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -254,7 +254,7 @@ test_that("`tab_spanner()` works even when columns are forcibly moved", {
     )
 })
 
-test_that("the `dt_spanners_print_matrix()` util function works well", {
+test_that("The `dt_spanners_print_matrix()` util function works well", {
 
   # Expect that a table with no spanners declared will generate
   # a spanner matrix that only has column names

--- a/tests/testthat/test-tab_spanner_delim.R
+++ b/tests/testthat/test-tab_spanner_delim.R
@@ -7,7 +7,7 @@ check_suggests <- function() {
   skip_if_not_installed("xml2")
 }
 
-test_that("the `tab_spanner_delim()` function works correctly", {
+test_that("The `tab_spanner_delim()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-tab_stub_indent.R
+++ b/tests/testthat/test-tab_stub_indent.R
@@ -1,4 +1,4 @@
-test_that("a gt table can contain indentation in the stub", {
+test_that("A gt table can contain indentation in the stub", {
 
   # Create a table with a stub that has rownames; indent the first
   # three row labels in the stub at level 1

--- a/tests/testthat/test-tab_style.R
+++ b/tests/testthat/test-tab_style.R
@@ -60,7 +60,7 @@ selection_text <- function(html, selection) {
   rvest::html_text(rvest::html_nodes(html, selection))
 }
 
-test_that("a gt table can store the correct style statements", {
+test_that("A gt table can store the correct style statements", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -423,7 +423,7 @@ test_that("a gt table can store the correct style statements", {
   expect_warning(data %>% tab_row_group(others_label = "Others1"))
 })
 
-test_that("using fonts in `cell_text()` works", {
+test_that("Using fonts in `cell_text()` works", {
 
   # Prepare a small gt table for all tests
   tbl <- exibble %>% dplyr::select(char, time) %>% gt()
@@ -553,7 +553,7 @@ test_that("using fonts in `cell_text()` works", {
   )
 })
 
-test_that("setting white-space options in `cell_text()` works", {
+test_that("Setting white-space options in `cell_text()` works", {
 
   tbl_ws <-
     dplyr::tibble(
@@ -574,7 +574,7 @@ test_that("setting white-space options in `cell_text()` works", {
     )
 })
 
-test_that("hiding columns that have styles does not result in errors/warnings", {
+test_that("Hiding columns that have styles does not result in errors/warnings", {
 
   expect_error(
     regexp = NA,

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -25,7 +25,7 @@ get_row_group_text <- function(tbl_html) {
     gsub("\n\\s+", "", .)
 }
 
-test_that("a gt table contains the expected heading components", {
+test_that("A gt table contains the expected heading components", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -113,7 +113,7 @@ test_that("a gt table contains the expected heading components", {
   )
 })
 
-test_that("a gt table contains the expected stubhead label", {
+test_that("A gt table contains the expected stubhead label", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -133,7 +133,7 @@ test_that("a gt table contains the expected stubhead label", {
     expect_equal("the mtcars")
 })
 
-test_that("a gt table contains the expected source note", {
+test_that("A gt table contains the expected source note", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -175,7 +175,7 @@ test_that("a gt table contains the expected source note", {
     ))
 })
 
-test_that("row groups can be successfully generated with `tab_row_group()", {
+test_that("Row groups can be successfully generated with `tab_row_group()", {
 
   local_options("rlib_warning_verbosity" = "verbose")
 
@@ -470,7 +470,7 @@ test_that("A default row group name can be modified with `tab_options()`", {
   )
 })
 
-test_that("a gt table's row group labels are HTML escaped", {
+test_that("A gt table's row group labels are HTML escaped", {
 
   # Create a `tbl_html` object with `gt()`; this table
   # contains a row group with characters that require
@@ -510,7 +510,7 @@ test_that("a gt table's row group labels are HTML escaped", {
     "x > 301")
 })
 
-test_that("a gt table contains custom styles at the correct locations", {
+test_that("A gt table contains custom styles at the correct locations", {
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -737,7 +737,7 @@ test_that("a gt table contains custom styles at the correct locations", {
     expect_equal("Subtitle")
 })
 
-test_that("columns can be hidden and then made visible", {
+test_that("Columns can be hidden and then made visible", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -169,12 +169,15 @@ test_that("a gt table contains the expected source note", {
   # is available
   tbl_html %>%
     selection_text("[class='gt_sourcenote']") %>%
-    expect_equal(
-      c("Henderson and Velleman (1981).",
-        "This was in Motor Trend magazine, hence the `mt`."))
+    expect_equal(c(
+      "Henderson and Velleman (1981).",
+      "This was in Motor Trend magazine, hence the `mt`."
+    ))
 })
 
 test_that("row groups can be successfully generated with `tab_row_group()", {
+
+  local_options("rlib_warning_verbosity" = "verbose")
 
   # Check that specific suggested packages are available
   check_suggests()
@@ -329,7 +332,11 @@ test_that("row groups can be successfully generated with `tab_row_group()", {
   expect_warning(
     gt_tbl <-
       gt(exibble, rowname_col = "row") %>%
-      tab_row_group(label = "group_prioritized", group = "group", rows = 1:3)
+      tab_row_group(
+        label = "group_prioritized",
+        group = "group",
+        rows = 1:3
+      )
   )
 
   # Expect that the label text specified in `label` was used over the

--- a/tests/testthat/test-text_transform.R
+++ b/tests/testthat/test-text_transform.R
@@ -18,7 +18,7 @@ selection_text <- function(html, selection) {
   rvest::html_text(rvest::html_nodes(html, selection))
 }
 
-test_that("the `text_transform()` function works correctly", {
+test_that("The `text_transform()` function works correctly", {
 
   # Check that specific suggested packages are available
   check_suggests()

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -6,7 +6,7 @@ rtf_with <- function(open, text, close = paste0(open, "0")) {
   paste0("\\", open, " ", text, "\\", close, " ")
 }
 
-test_that("basic markdown_to_rtf works", {
+test_that("Basic markdown_to_rtf works", {
 
   # list
   md_rtf(


### PR DESCRIPTION
This uses the `.frequency` arg in `cli::cli_warn()` to limit the frequency of warnings given to users.

Fixes: https://github.com/rstudio/gt/issues/1160