### PR TITLE
Enhancements to `fmt_scientific()` and `fmt_engineering()`

### DIFF
--- a/R/dt_summary.R
+++ b/R/dt_summary.R
@@ -360,7 +360,7 @@ dt_summary_build <- function(data, context) {
 
             # Ensure that the expression is reconstructed as a formula and then
             # transformed to a closure
-            format_fn_grp <- rlang::as_closure(as.formula(paste0("~", format_fn_grp)))
+            format_fn_grp <- rlang::as_closure(stats::as.formula(paste0("~", format_fn_grp)))
 
             # Perform the formatting on this gt table with closure
             summary_dfs_display_gt <- format_fn_grp(summary_dfs_display_gt)

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -540,8 +540,10 @@ fmt_integer <- function(
 #' @param scale_by A value to scale the input. The default is `1.0`. All numeric
 #'   values will be multiplied by this value first before undergoing formatting.
 #' @param exp_style Style of formatting to use for the scientific notation
-#'   formatting. By default this is `"x10n"` but other options include `"e"`,
-#'   `"E"`, `"slash"`, and `"starslash"`.
+#'   formatting. By default this is `"x10n"` but other options include using
+#'   a single letter (e.g., `"e"`, `"E"`, etc.), a letter followed by a `"1"` to
+#'   signal a minimum digit width of one, or `"low-ten"` for using a stylized
+#'   `"10"` marker.
 #' @param force_sign_m,force_sign_n Should the plus sign be shown for positive
 #'   values of the mantissa (first component) or the exponent? This would
 #'   effectively show a sign for all values except zero on either of those
@@ -837,9 +839,11 @@ fmt_scientific <- function(
 #' @inheritParams fmt_number
 #' @param scale_by A value to scale the input. The default is `1.0`. All numeric
 #'   values will be multiplied by this value first before undergoing formatting.
-#' @param exp_style Style of formatting to use for the engineering notation
-#'   formatting. By default this is `"x10n"` but other options include `"e"`,
-#'   `"E"`, `"slash"`, and `"starslash"`.
+#' @param exp_style Style of formatting to use for the scientific notation
+#'   formatting. By default this is `"x10n"` but other options include using
+#'   a single letter (e.g., `"e"`, `"E"`, etc.), a letter followed by a `"1"` to
+#'   signal a minimum digit width of one, or `"low-ten"` for using a stylized
+#'   `"10"` marker.
 #' @param force_sign_m,force_sign_n Should the plus sign be shown for positive
 #'   values of the mantissa (first component) or the exponent? This would
 #'   effectively show a sign for all values except zero on either of those

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -517,8 +517,16 @@ fmt_integer <- function(
 #' @description
 #'
 #' With numeric values in a **gt** table, we can perform formatting so that the
-#' targeted values are rendered in scientific notation. Furthermore, there is
-#' fine control with the following options:
+#' targeted values are rendered in scientific notation, where extremely large or
+#' very small numbers can be expressed in a more practical fashion. It entails
+#' putting a number in the form of a power of ten and a coefficient, which is a
+#' number between 1 and 10. For instance, 2.5 x 10^9 can be used to represent
+#' the value 2,500,000,000 in scientific notation. In a similar way, 0.00000012
+#' can be expressed as 1.2 x 10^-7. Due to its ability to describe numbers more
+#' succinctly and ease of calculation, scientific notation is widely employed in
+#' scientific and technical domains.
+#'
+#' We have fine control over the formatting task, with the following options:
 #'
 #' - decimals: choice of the number of decimal places, option to drop
 #' trailing zeros, and a choice of the decimal symbol

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -518,13 +518,14 @@ fmt_integer <- function(
 #'
 #' With numeric values in a **gt** table, we can perform formatting so that the
 #' targeted values are rendered in scientific notation, where extremely large or
-#' very small numbers can be expressed in a more practical fashion. It entails
-#' putting a number in the form of a power of ten and a coefficient, which is a
-#' number between 1 and 10. For instance, 2.5 x 10^9 can be used to represent
-#' the value 2,500,000,000 in scientific notation. In a similar way, 0.00000012
-#' can be expressed as 1.2 x 10^-7. Due to its ability to describe numbers more
-#' succinctly and ease of calculation, scientific notation is widely employed in
-#' scientific and technical domains.
+#' very small numbers can be expressed in a more practical fashion. Here,
+#' numbers are written in the form of a mantissa (`m`) and an exponent (`n`)
+#' with the construction *m* x 10^*n* or *m*E*n*. The mantissa component is a
+#' number between `1` and `10`. For instance, `2.5 x 10^9` can be used to
+#' represent the value 2,500,000,000 in scientific notation. In a similar way,
+#' 0.00000012 can be expressed as `1.2 x 10^-7`. Due to its ability to describe
+#' numbers more succinctly and its ease of calculation, scientific notation is
+#' widely employed in scientific and technical domains.
 #'
 #' We have fine control over the formatting task, with the following options:
 #'
@@ -879,11 +880,12 @@ fmt_scientific <- function(
 #'
 #' With numeric values in a **gt** table, we can perform formatting so that the
 #' targeted values are rendered in engineering notation, where numbers are
-#' written in the form of a mantissa and an exponent. The mantissa is a number
-#' between 1 and 1000 and the exponent is a multiple of 3. For example, the
-#' number 0.00000345 can be written in engineering notation as 3.45 x 10^-6.
-#' This notation helps to simplify calculations and make it easier to compare
-#' numbers that are on very different scales.
+#' written in the form of a mantissa (`m`) and an exponent (`n`). When combined
+#' the construction is either of the form *m* x 10^*n* or *m*E*n*. The mantissa
+#' is a number between `1` and `1000` and the exponent is a multiple of `3`. For
+#' example, the number 0.0000345 can be written in engineering notation as
+#' `34.50 x 10^-6`. This notation helps to simplify calculations and make it
+#' easier to compare numbers that are on very different scales.
 #'
 #' We have fine control over the formatting task, with the following options:
 #'
@@ -898,7 +900,7 @@ fmt_scientific <- function(
 #' @inheritParams fmt_number
 #' @param scale_by A value to scale the input. The default is `1.0`. All numeric
 #'   values will be multiplied by this value first before undergoing formatting.
-#' @param exp_style Style of formatting to use for the scientific notation
+#' @param exp_style Style of formatting to use for the engineering notation
 #'   formatting. By default this is `"x10n"` but other options include using
 #'   a single letter (e.g., `"e"`, `"E"`, etc.), a letter followed by a `"1"` to
 #'   signal a minimum digit width of one, or `"low-ten"` for using a stylized

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -366,9 +366,18 @@ vec_fmt_integer <- function(
 #'
 #' @description
 #'
-#' With numeric values in a vector, we can perform formatting so that the input
-#' values are rendered into scientific notation within the output character
-#' vector. The following major options are available:
+#' With numeric values in a vector, we can perform formatting so that the
+#' targeted values are rendered in scientific notation, where extremely large or
+#' very small numbers can be expressed in a more practical fashion. Here,
+#' numbers are written in the form of a mantissa (`m`) and an exponent (`n`)
+#' with the construction *m* x 10^*n* or *m*E*n*. The mantissa component is a
+#' number between `1` and `10`. For instance, `2.5 x 10^9` can be used to
+#' represent the value 2,500,000,000 in scientific notation. In a similar way,
+#' 0.00000012 can be expressed as `1.2 x 10^-7`. Due to its ability to describe
+#' numbers more succinctly and its ease of calculation, scientific notation is
+#' widely employed in scientific and technical domains.
+#'
+#' We have fine control over the formatting task, with the following options:
 #'
 #' - decimals: choice of the number of decimal places, option to drop
 #' trailing zeros, and a choice of the decimal symbol
@@ -518,13 +527,19 @@ vec_fmt_scientific <- function(
 #'
 #' @description
 #'
-#' With numeric values in a vector, we can perform formatting so that the input
-#' values are rendered into engineering notation within the output character
-#' vector. The following major options are available:
+#' With numeric values in a vector, we can perform formatting so that the
+#' targeted values are rendered in engineering notation, where numbers are
+#' written in the form of a mantissa (`m`) and an exponent (`n`). When combined
+#' the construction is either of the form *m* x 10^*n* or *m*E*n*. The mantissa
+#' is a number between `1` and `1000` and the exponent is a multiple of `3`. For
+#' example, the number 0.0000345 can be written in engineering notation as
+#' `34.50 x 10^-6`. This notation helps to simplify calculations and make it
+#' easier to compare numbers that are on very different scales.
+#'
+#' We have fine control over the formatting task, with the following options:
 #'
 #' - decimals: choice of the number of decimal places, option to drop
 #' trailing zeros, and a choice of the decimal symbol
-#' - digit grouping separators: choice of separator symbol
 #' - scaling: we can choose to scale targeted values by a multiplier value
 #' - pattern: option to use a text pattern for decoration of the formatted
 #' values
@@ -534,7 +549,7 @@ vec_fmt_scientific <- function(
 #' @inheritParams vec_fmt_number
 #' @param scale_by A value to scale the input. The default is `1.0`. All numeric
 #'   values will be multiplied by this value first before undergoing formatting.
-#' @param exp_style Style of formatting to use for the scientific notation
+#' @param exp_style Style of formatting to use for the engineering notation
 #'   formatting. By default this is `"x10n"` but other options include using
 #'   a single letter (e.g., `"e"`, `"E"`, etc.), a letter followed by a `"1"` to
 #'   signal a minimum digit width of one, or `"low-ten"` for using a stylized

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -381,10 +381,12 @@ vec_fmt_integer <- function(
 #' @inheritParams vec_fmt_number
 #' @param scale_by A value to scale the input. The default is `1.0`. All numeric
 #'   values will be multiplied by this value first before undergoing formatting.
-#' @param force_sign Should the positive sign be shown for positive values
-#'   (effectively showing a sign for all values except zero)? If so, use `TRUE`
-#'   for this option. The default is `FALSE`, where only negative numbers will
-#'   display a minus sign.
+#' @param force_sign_m,force_sign_n Should the plus sign be shown for positive
+#'   values of the mantissa (first component) or the exponent? This would
+#'   effectively show a sign for all values except zero on either of those
+#'   numeric components of the notation. If so, use `TRUE` for either one of
+#'   these options. The default for both is `FALSE`, where only negative numbers
+#'   will display a sign.
 #'
 #' @return A character vector.
 #'
@@ -460,10 +462,12 @@ vec_fmt_scientific <- function(
     decimals = 2,
     drop_trailing_zeros = FALSE,
     scale_by = 1.0,
+    exp_style = "x10n",
     pattern = "{x}",
     sep_mark = ",",
     dec_mark = ".",
-    force_sign = FALSE,
+    force_sign_m = FALSE,
+    force_sign_n = FALSE,
     locale = NULL,
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
@@ -493,10 +497,12 @@ vec_fmt_scientific <- function(
       decimals = decimals,
       drop_trailing_zeros = drop_trailing_zeros,
       scale_by = scale_by,
+      exp_style = exp_style,
       pattern = pattern,
       sep_mark = sep_mark,
       dec_mark = dec_mark,
-      force_sign = force_sign,
+      force_sign_m = force_sign_m,
+      force_sign_n = force_sign_n,
       locale = locale
     ),
     output = output
@@ -523,10 +529,15 @@ vec_fmt_scientific <- function(
 #' @inheritParams vec_fmt_number
 #' @param scale_by A value to scale the input. The default is `1.0`. All numeric
 #'   values will be multiplied by this value first before undergoing formatting.
-#' @param force_sign Should the positive sign be shown for positive values
-#'   (effectively showing a sign for all values except zero)? If so, use `TRUE`
-#'   for this option. The default is `FALSE`, where only negative numbers will
-#'   display a minus sign.
+#' @param exp_style Style of formatting to use for the engineering notation
+#'   formatting. By default this is `"x10n"` but other options include `"e"`,
+#'   `"E"`, `"slash"`, and `"starslash"`.
+#' @param force_sign_m,force_sign_n Should the plus sign be shown for positive
+#'   values of the mantissa (first component) or the exponent? This would
+#'   effectively show a sign for all values except zero on either of those
+#'   numeric components of the notation. If so, use `TRUE` for either one of
+#'   these options. The default for both is `FALSE`, where only negative numbers
+#'   will display a sign.
 #'
 #' @return A character vector.
 #'
@@ -602,10 +613,12 @@ vec_fmt_engineering <- function(
     decimals = 2,
     drop_trailing_zeros = FALSE,
     scale_by = 1.0,
+    exp_style = "x10n",
     pattern = "{x}",
     sep_mark = ",",
     dec_mark = ".",
-    force_sign = FALSE,
+    force_sign_m = FALSE,
+    force_sign_n = FALSE,
     locale = NULL,
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
@@ -635,10 +648,12 @@ vec_fmt_engineering <- function(
       decimals = decimals,
       drop_trailing_zeros = drop_trailing_zeros,
       scale_by = scale_by,
+      exp_style = exp_style,
       pattern = pattern,
       sep_mark = sep_mark,
       dec_mark = dec_mark,
-      force_sign = force_sign,
+      force_sign_m = force_sign_m,
+      force_sign_n = force_sign_n,
       locale = locale
     ),
     output = output

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -381,6 +381,11 @@ vec_fmt_integer <- function(
 #' @inheritParams vec_fmt_number
 #' @param scale_by A value to scale the input. The default is `1.0`. All numeric
 #'   values will be multiplied by this value first before undergoing formatting.
+#' @param exp_style Style of formatting to use for the scientific notation
+#'   formatting. By default this is `"x10n"` but other options include using
+#'   a single letter (e.g., `"e"`, `"E"`, etc.), a letter followed by a `"1"` to
+#'   signal a minimum digit width of one, or `"low-ten"` for using a stylized
+#'   `"10"` marker.
 #' @param force_sign_m,force_sign_n Should the plus sign be shown for positive
 #'   values of the mantissa (first component) or the exponent? This would
 #'   effectively show a sign for all values except zero on either of those
@@ -529,9 +534,11 @@ vec_fmt_scientific <- function(
 #' @inheritParams vec_fmt_number
 #' @param scale_by A value to scale the input. The default is `1.0`. All numeric
 #'   values will be multiplied by this value first before undergoing formatting.
-#' @param exp_style Style of formatting to use for the engineering notation
-#'   formatting. By default this is `"x10n"` but other options include `"e"`,
-#'   `"E"`, `"slash"`, and `"starslash"`.
+#' @param exp_style Style of formatting to use for the scientific notation
+#'   formatting. By default this is `"x10n"` but other options include using
+#'   a single letter (e.g., `"e"`, `"E"`, etc.), a letter followed by a `"1"` to
+#'   signal a minimum digit width of one, or `"low-ten"` for using a stylized
+#'   `"10"` marker.
 #' @param force_sign_m,force_sign_n Should the plus sign be shown for positive
 #'   values of the mantissa (first component) or the exponent? This would
 #'   effectively show a sign for all values except zero on either of those

--- a/R/summary_rows.R
+++ b/R/summary_rows.R
@@ -371,7 +371,7 @@ summary_rows <- function(
 
     formatter_formula <- paste0("~ ", formatter_name, "(", fmt_args, ")")
 
-    fmt <- list(as.formula(formatter_formula))
+    fmt <- list(stats::as.formula(formatter_formula))
 
     # Provide deprecation warning
     cli::cli_warn(c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -350,12 +350,13 @@ get_alignment_at_body_cell <- function(
   # Return the value of the last `text-align` property, if present
   if (!is.null(cell_style) && grepl("text-align", cell_style)) {
 
-    m <- gregexec("(?:^|;)\\s*text-align\\s*:\\s*([\\w-]+)\\s*(!important)?", cell_style, perl = TRUE)
+    m <- regexec_gt("(?:^|;)\\s*text-align\\s*:\\s*([\\w-]+)\\s*(!important)?", cell_style, perl = TRUE)
+
     cell_style_match_mat <- regmatches(cell_style, m)[[1]]
 
     is_important <- grepl("!important", cell_style_match_mat[1, ], fixed = TRUE)
 
-    # Pick last !important, or if no !important, then last anything
+    # Pick last '!important', or if no '!important', then last anything
     if (any(is_important)) {
       cell_alignment <- cell_style_match_mat[2, max(which(is_important))]
     } else {

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -635,8 +635,11 @@ context_exp_marks <- function(context) {
 
 context_exp_str <- function(context, exp_style) {
 
+  # Set default value for `exp_str`
   exp_str <- "E"
 
+  # For the 'low-ten' style, a different `exp_str` value will be obtained
+  # depending on the `context`
   if (exp_style == "low-ten") {
 
     exp_str <-
@@ -650,8 +653,10 @@ context_exp_str <- function(context, exp_style) {
       )
   }
 
-  if (exp_style %in% c(letters, LETTERS)) {
-    exp_str <- exp_style
+  # If there is a single letter (or a letter and a '1') then
+  # used that letter as the `exp_str` value
+  if (grepl("^[a-zA-Z]{1}1?$", exp_style)) {
+    exp_str <- substr(exp_style, 1, 1)
   }
 
   exp_str

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -633,6 +633,12 @@ context_exp_marks <- function(context) {
   )
 }
 
+#' Obtain the contextually correct string for scientific or engineering notation
+#' where the default style (`"x10n"`) is not used.
+#'
+#' @param context The output context.
+#' @param exp_style The style of formatting to use for the exponential notation.
+#' @noRd
 context_exp_str <- function(context, exp_style) {
 
   # Set default value for `exp_str`
@@ -661,7 +667,6 @@ context_exp_str <- function(context, exp_style) {
 
   exp_str
 }
-
 
 #' Obtain the contextually correct symbol string
 #'

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -633,6 +633,30 @@ context_exp_marks <- function(context) {
   )
 }
 
+context_exp_str <- function(context, exp_style) {
+
+  exp_str <- "E"
+
+  if (exp_style == "low-ten") {
+
+    exp_str <-
+      switch(
+        context,
+        html = c("<sub style='font-size: 65%;'>10</sub>"),
+        latex = c("{}_10"),
+        rtf = c("{\\sub 10}"),
+        word = c("10^"),
+        "E"
+      )
+  }
+
+  if (exp_style %in% c(letters, LETTERS)) {
+    exp_str <- exp_style
+  }
+
+  exp_str
+}
+
 
 #' Obtain the contextually correct symbol string
 #'

--- a/R/utils_general_str_formatting.R
+++ b/R/utils_general_str_formatting.R
@@ -525,7 +525,7 @@ regexec_gt <- function(pattern, text, perl = FALSE) {
 
   if (is.factor(text) && length(levels(text)) < length(text)) {
 
-    out <- gregexec_knitr(pattern, c(levels(text), NA_character_), perl)
+    out <- regexec_gt(pattern, c(levels(text), NA_character_), perl)
     outna <- out[length(out)]
     out <- out[text]
     out[is.na(text)] <- outna

--- a/R/utils_general_str_formatting.R
+++ b/R/utils_general_str_formatting.R
@@ -520,3 +520,64 @@ create_unique_id_vals <- function(
 glue_gt <- function(.x, ...) {
   glue::glue_data(.x, ..., .transformer = get, .envir = emptyenv())
 }
+
+regexec_gt <- function(pattern, text, perl = FALSE) {
+
+  if (is.factor(text) && length(levels(text)) < length(text)) {
+
+    out <- gregexec_knitr(pattern, c(levels(text), NA_character_), perl)
+    outna <- out[length(out)]
+    out <- out[text]
+    out[is.na(text)] <- outna
+    return(out)
+  }
+
+  dat <- gregexpr(pattern = pattern, text = text, perl = perl)
+
+  if (perl) {
+
+    capt.attr <- c('capture.start', 'capture.length', 'capture.names')
+    process <- function(x) {
+
+      if (anyNA(x) || any(x < 0)) {
+
+        y <- x
+
+      } else {
+
+        y <- t(cbind(x, attr(x, "capture.start")))
+        attributes(y)[names(attributes(x))] <- attributes(x)
+        ml <- t(cbind(attr(x, "match.length"), attr(x, "capture.length")))
+        nm <- attr(x, 'capture.names')
+        dimnames(ml) <- dimnames(y) <- if (any(nzchar(nm))) list(c("", nm), NULL)
+        attr(y, "match.length") <- ml
+        y
+      }
+      attributes(y)[capt.attr] <- NULL
+      y
+    }
+    lapply(dat, process)
+
+  } else {
+
+    m1 <- lapply(regmatches(text, dat), regexec, pattern = pattern, perl = perl)
+    mlen <- lengths(m1)
+    res <- vector("list", length(m1))
+    im <- mlen > 0
+    res[!im] <- dat[!im]
+    res[im] <-
+      Map(
+        function(outer, inner) {
+          tmp <- do.call(cbind, inner)
+          attributes(tmp)[names(attributes(inner))] <- attributes(inner)
+          attr(tmp, 'match.length') <- do.call(cbind, lapply(inner, `attr`, 'match.length'))
+          attr(tmp, 'useBytes') <- attr(outer, 'useBytes')
+          attr(tmp, 'index.type') <- attr(outer, 'index.type')
+          tmp + rep(outer - 1L, each <- nrow(tmp))
+        },
+        dat[im],
+        m1[im]
+      )
+    res
+  }
+}

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -11,10 +11,12 @@ fmt_engineering(
   decimals = 2,
   drop_trailing_zeros = FALSE,
   scale_by = 1,
+  exp_style = "x10n",
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
-  force_sign = FALSE,
+  force_sign_m = FALSE,
+  force_sign_n = FALSE,
   locale = NULL
 )
 }
@@ -45,6 +47,10 @@ trailing zeros (those redundant zeros after the decimal mark).}
 \item{scale_by}{A value to scale the input. The default is \code{1.0}. All numeric
 values will be multiplied by this value first before undergoing formatting.}
 
+\item{exp_style}{Style of formatting to use for the engineering notation
+formatting. By default this is \code{"x10n"} but other options include \code{"e"},
+\code{"E"}, \code{"slash"}, and \code{"starslash"}.}
+
 \item{pattern}{A formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all other
 characters are taken to be string literals.}
@@ -55,10 +61,12 @@ of \verb{1,000}).}
 
 \item{dec_mark}{The character to use as a decimal mark (e.g., using \code{dec_mark = ","} with \code{0.152} would result in a formatted value of \verb{0,152}).}
 
-\item{force_sign}{Should the positive sign be shown for positive values
-(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
-for this option. The default is \code{FALSE}, where only negative numbers will
-display a minus sign.}
+\item{force_sign_m, force_sign_n}{Should the plus sign be shown for positive
+values of the mantissa (first component) or the exponent? This would
+effectively show a sign for all values except zero on either of those
+numeric components of the notation. If so, use \code{TRUE} for either one of
+these options. The default for both is \code{FALSE}, where only negative numbers
+will display a sign.}
 
 \item{locale}{An optional locale ID that can be used for formatting values
 according to the locale's rules.}

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -47,9 +47,11 @@ trailing zeros (those redundant zeros after the decimal mark).}
 \item{scale_by}{A value to scale the input. The default is \code{1.0}. All numeric
 values will be multiplied by this value first before undergoing formatting.}
 
-\item{exp_style}{Style of formatting to use for the engineering notation
-formatting. By default this is \code{"x10n"} but other options include \code{"e"},
-\code{"E"}, \code{"slash"}, and \code{"starslash"}.}
+\item{exp_style}{Style of formatting to use for the scientific notation
+formatting. By default this is \code{"x10n"} but other options include using
+a single letter (e.g., \code{"e"}, \code{"E"}, etc.), a letter followed by a \code{"1"} to
+signal a minimum digit width of one, or \code{"low-ten"} for using a stylized
+\code{"10"} marker.}
 
 \item{pattern}{A formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all other

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -76,14 +76,17 @@ An object of class \code{gt_tbl}.
 }
 \description{
 With numeric values in a \strong{gt} table, we can perform formatting so that the
-targeted values are rendered in engineering notation.
+targeted values are rendered in engineering notation, where numbers are
+written in the form of a mantissa and an exponent. The mantissa is a number
+between 1 and 1000 and the exponent is a multiple of 3. For example, the
+number 0.00000345 can be written in engineering notation as 3.45 x 10^-6.
+This notation helps to simplify calculations and make it easier to compare
+numbers that are on very different scales.
 
-With this function, there is fine control over the formatted values with the
-following options:
+We have fine control over the formatting task, with the following options:
 \itemize{
 \item decimals: choice of the number of decimal places, option to drop
 trailing zeros, and a choice of the decimal symbol
-\item digit grouping separators: choice of separator symbol
 \item scaling: we can choose to scale targeted values by a multiplier value
 \item pattern: option to use a text pattern for decoration of the formatted
 values

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -47,7 +47,7 @@ trailing zeros (those redundant zeros after the decimal mark).}
 \item{scale_by}{A value to scale the input. The default is \code{1.0}. All numeric
 values will be multiplied by this value first before undergoing formatting.}
 
-\item{exp_style}{Style of formatting to use for the scientific notation
+\item{exp_style}{Style of formatting to use for the engineering notation
 formatting. By default this is \code{"x10n"} but other options include using
 a single letter (e.g., \code{"e"}, \code{"E"}, etc.), a letter followed by a \code{"1"} to
 signal a minimum digit width of one, or \code{"low-ten"} for using a stylized
@@ -79,11 +79,12 @@ An object of class \code{gt_tbl}.
 \description{
 With numeric values in a \strong{gt} table, we can perform formatting so that the
 targeted values are rendered in engineering notation, where numbers are
-written in the form of a mantissa and an exponent. The mantissa is a number
-between 1 and 1000 and the exponent is a multiple of 3. For example, the
-number 0.00000345 can be written in engineering notation as 3.45 x 10^-6.
-This notation helps to simplify calculations and make it easier to compare
-numbers that are on very different scales.
+written in the form of a mantissa (\code{m}) and an exponent (\code{n}). When combined
+the construction is either of the form \emph{m} x 10^\emph{n} or \emph{m}E\emph{n}. The mantissa
+is a number between \code{1} and \code{1000} and the exponent is a multiple of \code{3}. For
+example, the number 0.0000345 can be written in engineering notation as
+\verb{34.50 x 10^-6}. This notation helps to simplify calculations and make it
+easier to compare numbers that are on very different scales.
 
 We have fine control over the formatting task, with the following options:
 \itemize{

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -76,8 +76,16 @@ An object of class \code{gt_tbl}.
 }
 \description{
 With numeric values in a \strong{gt} table, we can perform formatting so that the
-targeted values are rendered in scientific notation. Furthermore, there is
-fine control with the following options:
+targeted values are rendered in scientific notation, where extremely large or
+very small numbers can be expressed in a more practical fashion. It entails
+putting a number in the form of a power of ten and a coefficient, which is a
+number between 1 and 10. For instance, 2.5 x 10^9 can be used to represent
+the value 2,500,000,000 in scientific notation. In a similar way, 0.00000012
+can be expressed as 1.2 x 10^-7. Due to its ability to describe numbers more
+succinctly and ease of calculation, scientific notation is widely employed in
+scientific and technical domains.
+
+We have fine control over the formatting task, with the following options:
 \itemize{
 \item decimals: choice of the number of decimal places, option to drop
 trailing zeros, and a choice of the decimal symbol

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -79,13 +79,14 @@ An object of class \code{gt_tbl}.
 \description{
 With numeric values in a \strong{gt} table, we can perform formatting so that the
 targeted values are rendered in scientific notation, where extremely large or
-very small numbers can be expressed in a more practical fashion. It entails
-putting a number in the form of a power of ten and a coefficient, which is a
-number between 1 and 10. For instance, 2.5 x 10^9 can be used to represent
-the value 2,500,000,000 in scientific notation. In a similar way, 0.00000012
-can be expressed as 1.2 x 10^-7. Due to its ability to describe numbers more
-succinctly and ease of calculation, scientific notation is widely employed in
-scientific and technical domains.
+very small numbers can be expressed in a more practical fashion. Here,
+numbers are written in the form of a mantissa (\code{m}) and an exponent (\code{n})
+with the construction \emph{m} x 10^\emph{n} or \emph{m}E\emph{n}. The mantissa component is a
+number between \code{1} and \code{10}. For instance, \verb{2.5 x 10^9} can be used to
+represent the value 2,500,000,000 in scientific notation. In a similar way,
+0.00000012 can be expressed as \verb{1.2 x 10^-7}. Due to its ability to describe
+numbers more succinctly and its ease of calculation, scientific notation is
+widely employed in scientific and technical domains.
 
 We have fine control over the formatting task, with the following options:
 \itemize{

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -11,10 +11,12 @@ fmt_scientific(
   decimals = 2,
   drop_trailing_zeros = FALSE,
   scale_by = 1,
+  exp_style = "x10n",
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
-  force_sign = FALSE,
+  force_sign_m = FALSE,
+  force_sign_n = FALSE,
   locale = NULL
 )
 }
@@ -45,6 +47,10 @@ trailing zeros (those redundant zeros after the decimal mark).}
 \item{scale_by}{A value to scale the input. The default is \code{1.0}. All numeric
 values will be multiplied by this value first before undergoing formatting.}
 
+\item{exp_style}{Style of formatting to use for the scientific notation
+formatting. By default this is \code{"x10n"} but other options include \code{"e"},
+\code{"E"}, \code{"slash"}, and \code{"starslash"}.}
+
 \item{pattern}{A formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all other
 characters are taken to be string literals.}
@@ -55,10 +61,12 @@ of \verb{1,000}).}
 
 \item{dec_mark}{The character to use as a decimal mark (e.g., using \code{dec_mark = ","} with \code{0.152} would result in a formatted value of \verb{0,152}).}
 
-\item{force_sign}{Should the positive sign be shown for positive values
-(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
-for this option. The default is \code{FALSE}, where only negative numbers will
-display a minus sign.}
+\item{force_sign_m, force_sign_n}{Should the plus sign be shown for positive
+values of the mantissa (first component) or the exponent? This would
+effectively show a sign for all values except zero on either of those
+numeric components of the notation. If so, use \code{TRUE} for either one of
+these options. The default for both is \code{FALSE}, where only negative numbers
+will display a sign.}
 
 \item{locale}{An optional locale ID that can be used for formatting values
 according to the locale's rules.}

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -48,8 +48,10 @@ trailing zeros (those redundant zeros after the decimal mark).}
 values will be multiplied by this value first before undergoing formatting.}
 
 \item{exp_style}{Style of formatting to use for the scientific notation
-formatting. By default this is \code{"x10n"} but other options include \code{"e"},
-\code{"E"}, \code{"slash"}, and \code{"starslash"}.}
+formatting. By default this is \code{"x10n"} but other options include using
+a single letter (e.g., \code{"e"}, \code{"E"}, etc.), a letter followed by a \code{"1"} to
+signal a minimum digit width of one, or \code{"low-ten"} for using a stylized
+\code{"10"} marker.}
 
 \item{pattern}{A formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all other

--- a/man/vec_fmt_engineering.Rd
+++ b/man/vec_fmt_engineering.Rd
@@ -9,10 +9,12 @@ vec_fmt_engineering(
   decimals = 2,
   drop_trailing_zeros = FALSE,
   scale_by = 1,
+  exp_style = "x10n",
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
-  force_sign = FALSE,
+  force_sign_m = FALSE,
+  force_sign_n = FALSE,
   locale = NULL,
   output = c("auto", "plain", "html", "latex", "rtf", "word")
 )
@@ -29,6 +31,10 @@ trailing zeros (those redundant zeros after the decimal mark).}
 \item{scale_by}{A value to scale the input. The default is \code{1.0}. All numeric
 values will be multiplied by this value first before undergoing formatting.}
 
+\item{exp_style}{Style of formatting to use for the engineering notation
+formatting. By default this is \code{"x10n"} but other options include \code{"e"},
+\code{"E"}, \code{"slash"}, and \code{"starslash"}.}
+
 \item{pattern}{A formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all other
 characters are taken to be string literals.}
@@ -41,10 +47,12 @@ of \verb{1,000}).}
 \code{dec_mark = ","} with \code{0.152} would result in a formatted value of
 \verb{0,152}).}
 
-\item{force_sign}{Should the positive sign be shown for positive values
-(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
-for this option. The default is \code{FALSE}, where only negative numbers will
-display a minus sign.}
+\item{force_sign_m, force_sign_n}{Should the plus sign be shown for positive
+values of the mantissa (first component) or the exponent? This would
+effectively show a sign for all values except zero on either of those
+numeric components of the notation. If so, use \code{TRUE} for either one of
+these options. The default for both is \code{FALSE}, where only negative numbers
+will display a sign.}
 
 \item{locale}{An optional locale ID that can be used for formatting the value
 according the locale's rules. Examples include \code{"en"} for English (United

--- a/man/vec_fmt_engineering.Rd
+++ b/man/vec_fmt_engineering.Rd
@@ -31,7 +31,7 @@ trailing zeros (those redundant zeros after the decimal mark).}
 \item{scale_by}{A value to scale the input. The default is \code{1.0}. All numeric
 values will be multiplied by this value first before undergoing formatting.}
 
-\item{exp_style}{Style of formatting to use for the scientific notation
+\item{exp_style}{Style of formatting to use for the engineering notation
 formatting. By default this is \code{"x10n"} but other options include using
 a single letter (e.g., \code{"e"}, \code{"E"}, etc.), a letter followed by a \code{"1"} to
 signal a minimum digit width of one, or \code{"low-ten"} for using a stylized
@@ -72,13 +72,19 @@ or \code{"word"}. In \strong{knitr} rendering (i.e., Quarto or R Markdown), the
 A character vector.
 }
 \description{
-With numeric values in a vector, we can perform formatting so that the input
-values are rendered into engineering notation within the output character
-vector. The following major options are available:
+With numeric values in a vector, we can perform formatting so that the
+targeted values are rendered in engineering notation, where numbers are
+written in the form of a mantissa (\code{m}) and an exponent (\code{n}). When combined
+the construction is either of the form \emph{m} x 10^\emph{n} or \emph{m}E\emph{n}. The mantissa
+is a number between \code{1} and \code{1000} and the exponent is a multiple of \code{3}. For
+example, the number 0.0000345 can be written in engineering notation as
+\verb{34.50 x 10^-6}. This notation helps to simplify calculations and make it
+easier to compare numbers that are on very different scales.
+
+We have fine control over the formatting task, with the following options:
 \itemize{
 \item decimals: choice of the number of decimal places, option to drop
 trailing zeros, and a choice of the decimal symbol
-\item digit grouping separators: choice of separator symbol
 \item scaling: we can choose to scale targeted values by a multiplier value
 \item pattern: option to use a text pattern for decoration of the formatted
 values

--- a/man/vec_fmt_engineering.Rd
+++ b/man/vec_fmt_engineering.Rd
@@ -31,9 +31,11 @@ trailing zeros (those redundant zeros after the decimal mark).}
 \item{scale_by}{A value to scale the input. The default is \code{1.0}. All numeric
 values will be multiplied by this value first before undergoing formatting.}
 
-\item{exp_style}{Style of formatting to use for the engineering notation
-formatting. By default this is \code{"x10n"} but other options include \code{"e"},
-\code{"E"}, \code{"slash"}, and \code{"starslash"}.}
+\item{exp_style}{Style of formatting to use for the scientific notation
+formatting. By default this is \code{"x10n"} but other options include using
+a single letter (e.g., \code{"e"}, \code{"E"}, etc.), a letter followed by a \code{"1"} to
+signal a minimum digit width of one, or \code{"low-ten"} for using a stylized
+\code{"10"} marker.}
 
 \item{pattern}{A formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all other

--- a/man/vec_fmt_scientific.Rd
+++ b/man/vec_fmt_scientific.Rd
@@ -72,9 +72,18 @@ or \code{"word"}. In \strong{knitr} rendering (i.e., Quarto or R Markdown), the
 A character vector.
 }
 \description{
-With numeric values in a vector, we can perform formatting so that the input
-values are rendered into scientific notation within the output character
-vector. The following major options are available:
+With numeric values in a vector, we can perform formatting so that the
+targeted values are rendered in scientific notation, where extremely large or
+very small numbers can be expressed in a more practical fashion. Here,
+numbers are written in the form of a mantissa (\code{m}) and an exponent (\code{n})
+with the construction \emph{m} x 10^\emph{n} or \emph{m}E\emph{n}. The mantissa component is a
+number between \code{1} and \code{10}. For instance, \verb{2.5 x 10^9} can be used to
+represent the value 2,500,000,000 in scientific notation. In a similar way,
+0.00000012 can be expressed as \verb{1.2 x 10^-7}. Due to its ability to describe
+numbers more succinctly and its ease of calculation, scientific notation is
+widely employed in scientific and technical domains.
+
+We have fine control over the formatting task, with the following options:
 \itemize{
 \item decimals: choice of the number of decimal places, option to drop
 trailing zeros, and a choice of the decimal symbol

--- a/man/vec_fmt_scientific.Rd
+++ b/man/vec_fmt_scientific.Rd
@@ -31,6 +31,12 @@ trailing zeros (those redundant zeros after the decimal mark).}
 \item{scale_by}{A value to scale the input. The default is \code{1.0}. All numeric
 values will be multiplied by this value first before undergoing formatting.}
 
+\item{exp_style}{Style of formatting to use for the scientific notation
+formatting. By default this is \code{"x10n"} but other options include using
+a single letter (e.g., \code{"e"}, \code{"E"}, etc.), a letter followed by a \code{"1"} to
+signal a minimum digit width of one, or \code{"low-ten"} for using a stylized
+\code{"10"} marker.}
+
 \item{pattern}{A formatting pattern that allows for decoration of the
 formatted value. The value itself is represented by \code{{x}} and all other
 characters are taken to be string literals.}

--- a/man/vec_fmt_scientific.Rd
+++ b/man/vec_fmt_scientific.Rd
@@ -9,10 +9,12 @@ vec_fmt_scientific(
   decimals = 2,
   drop_trailing_zeros = FALSE,
   scale_by = 1,
+  exp_style = "x10n",
   pattern = "{x}",
   sep_mark = ",",
   dec_mark = ".",
-  force_sign = FALSE,
+  force_sign_m = FALSE,
+  force_sign_n = FALSE,
   locale = NULL,
   output = c("auto", "plain", "html", "latex", "rtf", "word")
 )
@@ -41,10 +43,12 @@ of \verb{1,000}).}
 \code{dec_mark = ","} with \code{0.152} would result in a formatted value of
 \verb{0,152}).}
 
-\item{force_sign}{Should the positive sign be shown for positive values
-(effectively showing a sign for all values except zero)? If so, use \code{TRUE}
-for this option. The default is \code{FALSE}, where only negative numbers will
-display a minus sign.}
+\item{force_sign_m, force_sign_n}{Should the plus sign be shown for positive
+values of the mantissa (first component) or the exponent? This would
+effectively show a sign for all values except zero on either of those
+numeric components of the notation. If so, use \code{TRUE} for either one of
+these options. The default for both is \code{FALSE}, where only negative numbers
+will display a sign.}
 
 \item{locale}{An optional locale ID that can be used for formatting the value
 according the locale's rules. Examples include \code{"en"} for English (United

--- a/tests/testthat/test-fmt_engineering.R
+++ b/tests/testthat/test-fmt_engineering.R
@@ -285,7 +285,7 @@ test_that("The `fmt_engineering()` function works correctly", {
   expect_equal(
     (tab %>%
        fmt_engineering(
-         columns = "num", decimals = 3, force_sign = TRUE) %>%
+         columns = "num", decimals = 3, force_sign_m = TRUE) %>%
        render_formats_test("html"))[["num"]],
     c(
       paste0("+82.030 ", "\U000D7", " 10<sup style='font-size: 65%;'>30</sup>"),
@@ -323,7 +323,7 @@ test_that("The `fmt_engineering()` function works correctly", {
   expect_equal(
     (tab %>%
        fmt_engineering(
-         columns = "num", pattern = "*{x}*", force_sign = TRUE) %>%
+         columns = "num", pattern = "*{x}*", force_sign_m = TRUE) %>%
        render_formats_test("html"))[["num"]],
     c(
       paste0("*+82.03 ", "\U000D7", " 10<sup style='font-size: 65%;'>30</sup>*"),

--- a/tests/testthat/test-fmt_engineering.R
+++ b/tests/testthat/test-fmt_engineering.R
@@ -356,6 +356,168 @@ test_that("The `fmt_engineering()` function works correctly", {
     )
   )
 
+  # Create a gt table with a mix of small and large numbers, both
+  # positive and negative
+  tab_2 <-
+    dplyr::tibble(
+      num = c(-3.49E13, -3453, -0.000234, 0, 0.00007534, 82794, 7.16E14)
+    ) %>%
+    gt()
+
+  # Format the `num` column and force the sign on the 'm' part of the
+  # notation; extract in the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", force_sign_m = TRUE) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-34.90 × 10^12", "-3.45 × 10^3", "-234.00 × 10^-6", "0.00",
+      "+75.34 × 10^-6", "+82.79 × 10^3", "+716.00 × 10^12"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' part of the
+  # notation; extract in the HTML context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", force_sign_m = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−34.90 \U000D7 10<sup style='font-size: 65%;'>12</sup>",
+      "−3.45 \U000D7 10<sup style='font-size: 65%;'>3</sup>",
+      "−234.00 \U000D7 10<sup style='font-size: 65%;'>−6</sup>",
+      "0.00",
+      "+75.34 \U000D7 10<sup style='font-size: 65%;'>−6</sup>",
+      "+82.79 \U000D7 10<sup style='font-size: 65%;'>3</sup>",
+      "+716.00 \U000D7 10<sup style='font-size: 65%;'>12</sup>"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'n' part of the
+  # notation; extract in the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", force_sign_n = TRUE) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-34.90 \U000D7 10^+12", "-3.45 \U000D7 10^+3", "-234.00 \U000D7 10^-6", "0.00",
+      "75.34 \U000D7 10^-6", "82.79 \U000D7 10^+3", "716.00 \U000D7 10^+12"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'n' part of the
+  # notation; extract in the HTML context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", force_sign_n = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−34.90 \U000D7 10<sup style='font-size: 65%;'>+12</sup>",
+      "−3.45 \U000D7 10<sup style='font-size: 65%;'>+3</sup>",
+      "−234.00 \U000D7 10<sup style='font-size: 65%;'>−6</sup>",
+      "0.00",
+      "75.34 \U000D7 10<sup style='font-size: 65%;'>−6</sup>",
+      "82.79 \U000D7 10<sup style='font-size: 65%;'>+3</sup>",
+      "716.00 \U000D7 10<sup style='font-size: 65%;'>+12</sup>"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' and 'n' parts of the
+  # notation; extract in the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", force_sign_m = TRUE, force_sign_n = TRUE) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-34.90 \U000D7 10^+12", "-3.45 \U000D7 10^+3", "-234.00 \U000D7 10^-6", "0.00",
+      "+75.34 \U000D7 10^-6", "+82.79 \U000D7 10^+3", "+716.00 \U000D7 10^+12"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' and 'n' parts of the
+  # notation; extract in the HTML context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", force_sign_m = TRUE, force_sign_n = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−34.90 \U000D7 10<sup style='font-size: 65%;'>+12</sup>",
+      "−3.45 \U000D7 10<sup style='font-size: 65%;'>+3</sup>",
+      "−234.00 \U000D7 10<sup style='font-size: 65%;'>−6</sup>",
+      "0.00",
+      "+75.34 \U000D7 10<sup style='font-size: 65%;'>−6</sup>",
+      "+82.79 \U000D7 10<sup style='font-size: 65%;'>+3</sup>",
+      "+716.00 \U000D7 10<sup style='font-size: 65%;'>+12</sup>"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' and 'n' parts of the
+  # notation and choose a exponent style of `"E"`; extract in the default
+  # context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", exp_style = "E", force_sign_m = TRUE, force_sign_n = TRUE) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-34.90E+12", "-3.45E+03", "-234.00E-06", "0.00E+00", "+75.34E-06",
+      "+82.79E+03", "+716.00E+12"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' and 'n' parts of the
+  # notation and choose a exponent style of `"E"`; extract in the HTML
+  # context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", exp_style = "E", force_sign_m = TRUE, force_sign_n = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−34.90E+12", "−3.45E+03", "−234.00E−06", "0.00E+00",
+      "+75.34E−06", "+82.79E+03", "+716.00E+12"
+    )
+  )
+
+  # Format the `num` column and choose a exponent style of `"E"`; extract in
+  # the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", exp_style = "E") %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-34.90E12", "-3.45E03", "-234.00E-06", "0.00E00", "75.34E-06",
+      "82.79E03", "716.00E12"
+    )
+  )
+
+  # Format the `num` column and choose a exponent style of `"low-ten"`; extract
+  # in the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", exp_style = "low-ten") %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-34.90E12", "-3.45E03", "-234.00E-06", "0.00E00", "75.34E-06",
+      "82.79E03", "716.00E12"
+    )
+  )
+
+  # Format the `num` column and choose a exponent style of `"low-ten"`; extract
+  # in the HTML context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_engineering(columns = "num", exp_style = "low-ten") %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−34.90<sub style='font−size: 65%;'>10</sub>12",
+      "−3.45<sub style='font−size: 65%;'>10</sub>03",
+      "−234.00<sub style='font−size: 65%;'>10</sub>−06",
+      "0.00<sub style='font−size: 65%;'>10</sub>00",
+      "75.34<sub style='font−size: 65%;'>10</sub>−06",
+      "82.79<sub style='font−size: 65%;'>10</sub>03",
+      "716.00<sub style='font−size: 65%;'>10</sub>12"
+    )
+  )
+
   # Format the `num` column to 2 decimal places, apply the `en_US`
   # locale and use all other defaults
   expect_equal(

--- a/tests/testthat/test-fmt_scientific.R
+++ b/tests/testthat/test-fmt_scientific.R
@@ -244,7 +244,7 @@ test_that("The `fmt_scientific()` function works correctly", {
   expect_equal(
     (tab %>%
        fmt_scientific(
-         columns = num_1, decimals = 3, force_sign = TRUE) %>%
+         columns = num_1, decimals = 3, force_sign_m = TRUE) %>%
        render_formats_test("html"))[["num_1"]],
     c(
       paste0("+1.836 ", "\U000D7", " 10<sup style='font-size: 65%;'>3</sup>"),
@@ -261,7 +261,7 @@ test_that("The `fmt_scientific()` function works correctly", {
   expect_equal(
     (tab %>%
        fmt_scientific(
-         columns = num_1, pattern = "*{x}*", force_sign = TRUE) %>%
+         columns = num_1, pattern = "*{x}*", force_sign_m = TRUE) %>%
        render_formats_test("html"))[["num_1"]],
     c(
       paste0("*+1.84 ", "\U000D7", " 10<sup style='font-size: 65%;'>3</sup>*"),

--- a/tests/testthat/test-fmt_scientific.R
+++ b/tests/testthat/test-fmt_scientific.R
@@ -139,8 +139,7 @@ test_that("The `fmt_scientific()` function works correctly", {
   # compare to expected values
   expect_equal(
     (tab %>%
-       fmt_scientific(columns = "num_1", decimals = 2,
-                      sep_mark = ".", dec_mark = ",") %>%
+       fmt_scientific(columns = "num_1", decimals = 2, sep_mark = ".", dec_mark = ",") %>%
        render_formats_test("html"))[["num_1"]],
     c(
       paste0("1,84 ", "\U000D7", " 10<sup style='font-size: 65%;'>3</sup>"),
@@ -158,8 +157,7 @@ test_that("The `fmt_scientific()` function works correctly", {
   # compare to expected values
   expect_equal(
     (tab %>%
-       fmt_scientific(columns = "num_1", decimals = 2,
-                      sep_mark = ".", dec_mark = ",") %>%
+       fmt_scientific(columns = "num_1", decimals = 2, sep_mark = ".", dec_mark = ",") %>%
        render_formats_test("default"))[["num_1"]],
     c(
       "1,84 \U000D7 10^3",
@@ -203,6 +201,168 @@ test_that("The `fmt_scientific()` function works correctly", {
       "2.2320 \U000D7 10^-3",
       "0.0000",
       "-2.3240 \U000D7 10^-2"
+    )
+  )
+
+  # Create a gt table with a mix of small and large numbers, both
+  # positive and negative
+  tab_2 <-
+    dplyr::tibble(
+      num = c(-3.49E13, -3453, -0.000234, 0, 0.00007534, 82794, 7.16E14)
+    ) %>%
+    gt()
+
+  # Format the `num` column and force the sign on the 'm' part of the
+  # notation; extract in the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", force_sign_m = TRUE) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-3.49 \U000D7 10^13", "-3.45 \U000D7 10^3", "-2.34 \U000D7 10^-4", "0.00",
+      "+7.53 \U000D7 10^-5", "+8.28 \U000D7 10^4", "+7.16 \U000D7 10^14"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' part of the
+  # notation; extract in the HTML context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", force_sign_m = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−3.49 \U000D7 10<sup style='font-size: 65%;'>13</sup>",
+      "−3.45 \U000D7 10<sup style='font-size: 65%;'>3</sup>",
+      "−2.34 \U000D7 10<sup style='font-size: 65%;'>−4</sup>",
+      "0.00",
+      "+7.53 \U000D7 10<sup style='font-size: 65%;'>−5</sup>",
+      "+8.28 \U000D7 10<sup style='font-size: 65%;'>4</sup>",
+      "+7.16 \U000D7 10<sup style='font-size: 65%;'>14</sup>"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'n' part of the
+  # notation; extract in the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", force_sign_n = TRUE) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-3.49 \U000D7 10^+13", "-3.45 \U000D7 10^+3", "-2.34 \U000D7 10^-4", "0.00",
+      "7.53 \U000D7 10^-5", "8.28 \U000D7 10^+4", "7.16 \U000D7 10^+14"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'n' part of the
+  # notation; extract in the HTML context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", force_sign_n = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−3.49 \U000D7 10<sup style='font-size: 65%;'>+13</sup>",
+      "−3.45 \U000D7 10<sup style='font-size: 65%;'>+3</sup>",
+      "−2.34 \U000D7 10<sup style='font-size: 65%;'>−4</sup>",
+      "0.00",
+      "7.53 \U000D7 10<sup style='font-size: 65%;'>−5</sup>",
+      "8.28 \U000D7 10<sup style='font-size: 65%;'>+4</sup>",
+      "7.16 \U000D7 10<sup style='font-size: 65%;'>+14</sup>"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' and 'n' parts of the
+  # notation; extract in the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", force_sign_m = TRUE, force_sign_n = TRUE) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-3.49 \U000D7 10^+13", "-3.45 \U000D7 10^+3", "-2.34 \U000D7 10^-4", "0.00",
+      "+7.53 \U000D7 10^-5", "+8.28 \U000D7 10^+4", "+7.16 \U000D7 10^+14"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' and 'n' parts of the
+  # notation; extract in the HTML context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", force_sign_m = TRUE, force_sign_n = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−3.49 \U000D7 10<sup style='font-size: 65%;'>+13</sup>",
+      "−3.45 \U000D7 10<sup style='font-size: 65%;'>+3</sup>",
+      "−2.34 \U000D7 10<sup style='font-size: 65%;'>−4</sup>",
+      "0.00",
+      "+7.53 \U000D7 10<sup style='font-size: 65%;'>−5</sup>",
+      "+8.28 \U000D7 10<sup style='font-size: 65%;'>+4</sup>",
+      "+7.16 \U000D7 10<sup style='font-size: 65%;'>+14</sup>"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' and 'n' parts of the
+  # notation and choose a exponent style of `"E"`; extract in the default
+  # context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", exp_style = "E", force_sign_m = TRUE, force_sign_n = TRUE) %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-3.49E+13", "-3.45E+03", "-2.34E-04", "0.00E+00",
+      "+7.53E-05", "+8.28E+04", "+7.16E+14"
+    )
+  )
+
+  # Format the `num` column and force the sign on the 'm' and 'n' parts of the
+  # notation and choose a exponent style of `"E"`; extract in the HTML
+  # context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", exp_style = "E", force_sign_m = TRUE, force_sign_n = TRUE) %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−3.49E+13", "−3.45E+03", "−2.34E−04", "0.00E+00",
+      "+7.53E−05", "+8.28E+04", "+7.16E+14"
+    )
+  )
+
+  # Format the `num` column and choose a exponent style of `"E"`; extract in
+  # the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", exp_style = "E") %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-3.49E13", "-3.45E03", "-2.34E-04", "0.00E00", "7.53E-05",
+      "8.28E04", "7.16E14"
+    )
+  )
+
+  # Format the `num` column and choose a exponent style of `"low-ten"`; extract
+  # in the default context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", exp_style = "low-ten") %>%
+       render_formats_test("default"))[["num"]],
+    c(
+      "-3.49E13", "-3.45E03", "-2.34E-04", "0.00E00", "7.53E-05",
+      "8.28E04", "7.16E14"
+    )
+  )
+
+  # Format the `num` column and choose a exponent style of `"low-ten"`; extract
+  # in the HTML context and compare to expected values
+  expect_equal(
+    (tab_2 %>%
+       fmt_scientific(columns = "num", exp_style = "low-ten") %>%
+       render_formats_test("html"))[["num"]],
+    c(
+      "−3.49<sub style='font−size: 65%;'>10</sub>13",
+      "−3.45<sub style='font−size: 65%;'>10</sub>03",
+      "−2.34<sub style='font−size: 65%;'>10</sub>−04",
+      "0.00<sub style='font−size: 65%;'>10</sub>00",
+      "7.53<sub style='font−size: 65%;'>10</sub>−05",
+      "8.28<sub style='font−size: 65%;'>10</sub>04",
+      "7.16<sub style='font−size: 65%;'>10</sub>14"
     )
   )
 

--- a/tests/testthat/test-l_fmt_engineering.R
+++ b/tests/testthat/test-l_fmt_engineering.R
@@ -169,7 +169,7 @@ test_that("The `fmt_engineering()` function works correctly in the LaTeX context
   expect_equal(
     (tab %>%
        fmt_engineering(
-         columns = "num", decimals = 3, force_sign = TRUE) %>%
+         columns = "num", decimals = 3, force_sign_m = TRUE) %>%
        render_formats_test("latex"))[["num"]],
     c(
       "$+82.030 \\times 10^{30}$", "$+829.300 \\times 10^{18}$",
@@ -191,7 +191,7 @@ test_that("The `fmt_engineering()` function works correctly in the LaTeX context
   expect_equal(
     (tab %>%
        fmt_engineering(
-         columns = "num", pattern = "*{x}*", force_sign = TRUE) %>%
+         columns = "num", pattern = "*{x}*", force_sign_m = TRUE) %>%
        render_formats_test("latex"))[["num"]],
     c(
       "*$+82.03 \\times 10^{30}$*", "*$+829.30 \\times 10^{18}$*",

--- a/tests/testthat/test-l_fmt_scientific.R
+++ b/tests/testthat/test-l_fmt_scientific.R
@@ -90,7 +90,7 @@ test_that("The `fmt_scientific()` function works correctly", {
   expect_equal(
     (tbl_latex %>%
        fmt_scientific(
-         columns = num_1, decimals = 3, force_sign = TRUE) %>%
+         columns = num_1, decimals = 3, force_sign_m = TRUE) %>%
        render_formats_test("latex"))[["num_1"]],
     c(
       "$+1.836 \\times 10^{3}$", "$+2.763 \\times 10^{3}$",
@@ -104,7 +104,7 @@ test_that("The `fmt_scientific()` function works correctly", {
   expect_equal(
     (tbl_latex %>%
        fmt_scientific(
-         columns = num_1, pattern = "*{x}*", force_sign = TRUE) %>%
+         columns = num_1, pattern = "*{x}*", force_sign_m = TRUE) %>%
        render_formats_test("latex"))[["num_1"]],
     c(
       "*$+1.84 \\times 10^{3}$*", "*$+2.76 \\times 10^{3}$*",

--- a/tests/testthat/test-vec_fmt.R
+++ b/tests/testthat/test-vec_fmt.R
@@ -833,7 +833,7 @@ test_that("The `vec_fmt_scientific()` function works", {
       )
     )
 
-  vec_fmt_scientific(vec_num_4_m, force_sign = TRUE, output = "plain") %>%
+  vec_fmt_scientific(vec_num_4_m, force_sign_m = TRUE, output = "plain") %>%
     expect_equal(
       c(
         "-2.50 \U000D7 10^6", "-2.00 \U000D7 10^6",
@@ -845,7 +845,7 @@ test_that("The `vec_fmt_scientific()` function works", {
       )
     )
 
-  vec_fmt_scientific(vec_num_4_m, force_sign = TRUE, output = "html") %>%
+  vec_fmt_scientific(vec_num_4_m, force_sign_m = TRUE, output = "html") %>%
     expect_equal(
       c(
         paste0("\U02212", "2.50 ", "\U000D7", " 10<sup style='font-size: 65%;'>6</sup>"),
@@ -863,7 +863,7 @@ test_that("The `vec_fmt_scientific()` function works", {
       )
     )
 
-  vec_fmt_scientific(vec_num_4_m, force_sign = TRUE, output = "latex") %>%
+  vec_fmt_scientific(vec_num_4_m, force_sign_m = TRUE, output = "latex") %>%
     expect_equal(
       c(
         "$-2.50 \\times 10^{6}$", "$-2.00 \\times 10^{6}$", "$-1.50 \\times 10^{6}$",
@@ -873,7 +873,7 @@ test_that("The `vec_fmt_scientific()` function works", {
       )
     )
 
-  vec_fmt_scientific(vec_num_4_m, force_sign = TRUE, output = "rtf") %>%
+  vec_fmt_scientific(vec_num_4_m, force_sign_m = TRUE, output = "rtf") %>%
     expect_equal(
       c(
         "-2.50 \\'d7 10{\\super 6}", "-2.00 \\'d7 10{\\super 6}", "-1.50 \\'d7 10{\\super 6}",
@@ -1192,7 +1192,7 @@ test_that("The `vec_fmt_engineering()` function works", {
       )
     )
 
-  vec_fmt_engineering(vec_num_4, force_sign = TRUE, output = "plain") %>%
+  vec_fmt_engineering(vec_num_4, force_sign_m = TRUE, output = "plain") %>%
     expect_equal(
       c(
         "-2.50 \U000D7 10^6", "-2.00 \U000D7 10^6",
@@ -1204,7 +1204,7 @@ test_that("The `vec_fmt_engineering()` function works", {
       )
     )
 
-  vec_fmt_engineering(vec_num_4, force_sign = TRUE, output = "html") %>%
+  vec_fmt_engineering(vec_num_4, force_sign_m = TRUE, output = "html") %>%
     expect_equal(
       c(
         paste0("\U02212", "2.50 ", "\U000D7", " 10<sup style='font-size: 65%;'>6</sup>"),
@@ -1222,7 +1222,7 @@ test_that("The `vec_fmt_engineering()` function works", {
       )
     )
 
-  vec_fmt_engineering(vec_num_4, force_sign = TRUE, output = "latex") %>%
+  vec_fmt_engineering(vec_num_4, force_sign_m = TRUE, output = "latex") %>%
     expect_equal(
       c(
         "$-2.50 \\times 10^{6}$", "$-2.00 \\times 10^{6}$",
@@ -1233,7 +1233,7 @@ test_that("The `vec_fmt_engineering()` function works", {
       )
     )
 
-  vec_fmt_engineering(vec_num_4, force_sign = TRUE, output = "rtf") %>%
+  vec_fmt_engineering(vec_num_4, force_sign_m = TRUE, output = "rtf") %>%
     expect_equal(
       c(
         "-2.50 \\'d7 10{\\super 6}", "-2.00 \\'d7 10{\\super 6}",


### PR DESCRIPTION
This adds new features to `fmt_scientific()` and `fmt_engineering()`. One is an `exp_style` option to both functions, allowing for some choice for type of exponent used. Forcing a positive sign can now be done to the `m` *and* `n` parts of the notation. The PR also updates the documentation for these functions.