### PR TITLE
Add the `quarto_api_send()` util function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Imports:
     glue (>= 1.6.1),
     htmltools (>= 0.5.2),
     juicyjuice (>= 0.1.0),
+    jsonlite (>= 1.8.4),
     magrittr (>= 2.0.2),
     rlang (>= 1.0.2),
     sass (>= 0.4.1),
@@ -53,7 +54,7 @@ Imports:
 Suggests:
     covr,
     digest (>= 0.6.29),
-    knitr,
+    knitr (>= 1.41.5),
     paletteer,
     testthat (>= 3.0.0),
     RColorBrewer,

--- a/R/utils_quarto.R
+++ b/R/utils_quarto.R
@@ -1,0 +1,31 @@
+quarto_api_send <- function(message, ...) {
+
+  # Ensure that the knitr package is available
+  check_knitr()
+
+  # Generate a JSON-formatted line
+  line <-
+    jsonlite::toJSON(
+      list(
+        message = message,
+        cell_name = knitr::opts_current$get("label"),
+        payload = list(...)
+      ),
+      auto_unbox = TRUE
+    )
+
+  file <- Sys.getenv("QUARTO_MESSAGES_FILE")
+
+  write(line, file, append = TRUE)
+}
+
+check_knitr <- function() {
+
+  if (!requireNamespace("knitr", quietly = TRUE)) {
+
+    cli::cli_abort(c(
+      "Please install the knitr package.",
+      "*" = "Use `install.packages(\"knitr\")`."
+    ))
+  }
+}


### PR DESCRIPTION
This PR adds the `quarto_api_send()` util function to allow messages to be passed into Quarto.