### PR TITLE
Add `position: initial;` CSS rule for footnotes

### DIFF
--- a/inst/css/gt_styles_default.scss
+++ b/inst/css/gt_styles_default.scss
@@ -391,6 +391,7 @@
     font-weight: normal;
     font-size: 75%;
     vertical-align: 0.4em;
+    position: initial;
   }
 
   .gt_asterisk {


### PR DESCRIPTION
This adds a single rule to the SCSS class `.gt_footnote_marks` to ensure that the footnote mark is at a consistent height from the baseline in different CSS environments.