### PR TITLE
Bug fix for summary rows where only one group is involved

### DIFF
--- a/R/dt_groups_rows.R
+++ b/R/dt_groups_rows.R
@@ -17,6 +17,8 @@ dt_groups_rows_set <- function(data, groups_rows) {
 
 dt_groups_rows_build <- function(data, context) {
 
+  data <- dt_stub_df_build(data = data, context = context)
+
   stub_df <- dt_stub_df_get(data = data)
   ordering <- dt_row_groups_get(data = data)
 
@@ -27,8 +29,8 @@ dt_groups_rows_build <- function(data, context) {
   if (dt_stub_df_exists(data = data)) {
 
     stub_var <- dt_boxhead_get_var_stub(data = data)
-    table_body <- dt_body_get(data = data)
-    stub_df[["rowname"]] <- table_body[[stub_var]]
+    table_body <- dt_data_get(data = data)
+    stub_df[["rowname"]] <- as.character(table_body[[stub_var]])
   }
 
   groups_rows <-
@@ -87,7 +89,7 @@ dt_groups_rows_build <- function(data, context) {
     groups_rows <- cbind(groups_rows, group_label = character(0))
   }
 
-  if (nrow(groups_rows) > 1) {
+  if (nrow(groups_rows) > 0) {
 
     groups_rows[["has_summary_rows"]] <- rep(FALSE, nrow(groups_rows))
     groups_rows[["summary_row_side"]] <- rep(NA_character_, nrow(groups_rows))

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -277,7 +277,7 @@ create_heading_component_h <- function(data) {
 
   title_classes <- c("gt_heading", "gt_title", "gt_font_normal")
 
-  subtitle_classes <- title_classes %>% tidy_sub("title", "subtitle")
+  subtitle_classes <- tidy_sub(title_classes, "title", "subtitle")
 
   if (!subtitle_defined) {
     title_classes <- c(title_classes, "gt_bottom_border")
@@ -820,9 +820,12 @@ create_body_component_h <- function(data) {
 
   # Replace an NA group with an empty string
   if (any(is.na(groups_rows_df$group_label))) {
+
     groups_rows_df <-
-      groups_rows_df %>%
-      dplyr::mutate(group_label = ifelse(is.na(group_label), "", group_label))
+      dplyr::mutate(
+        groups_rows_df,
+        group_label = ifelse(is.na(group_label), "", group_label)
+      )
   }
 
   # Is the stub to be striped?
@@ -1417,13 +1420,11 @@ create_footnotes_component_h <- function(data) {
 
   styles_tbl <- dt_styles_get(data = data)
 
-  # Get effective number of columns
+  # Get the effective number of columns
   n_cols_total <- get_effective_number_of_columns(data = data)
 
-  footnotes_tbl <-
-    footnotes_tbl %>%
-    dplyr::select(fs_id, footnotes) %>%
-    dplyr::distinct()
+  # Get the distinct set of `fs_id` & `footnotes` values in the `footnotes_tbl`
+  footnotes_tbl <- dplyr::distinct(dplyr::select(footnotes_tbl, fs_id, footnotes))
 
   # Get the style attrs for the footnotes
   if ("footnotes" %in% styles_tbl$locname) {


### PR DESCRIPTION
This fixes a problem where summary rows generated with only a single group would not display the summary rows at all.