### PR TITLE
Add option to disable table processing by Quarto

### DIFF
--- a/R/dt_options.R
+++ b/R/dt_options.R
@@ -222,4 +222,5 @@ dt_options_tbl <-
     "page_margin_bottom",                FALSE,  "page",             "value",   "1.0in",
     "page_header_height",                FALSE,  "page",             "value",   "0.5in",
     "page_footer_height",                FALSE,  "page",             "value",   "0.5in",
+    "quarto_disable_processing",         FALSE,  "quarto",           "logical", FALSE,
   )[-1, ]

--- a/R/render_as_html.R
+++ b/R/render_as_html.R
@@ -36,10 +36,15 @@ render_as_html <- function(data) {
   # Get attributes for the gt table
   table_defs <- get_table_defs(data = data)
 
+  # Determine whether Quarto processing of the table is enabled
+  quarto_disable_processing <-
+    dt_options_get_value(data = data, option = "quarto_disable_processing")
+
   # Compose the HTML table
   finalize_html_table(
     class = "gt_table",
     style = table_defs$table_style,
+    quarto_disable_processing = quarto_disable_processing,
     caption_component,
     table_defs$table_colgroups,
     heading_component,
@@ -53,6 +58,7 @@ render_as_html <- function(data) {
 finalize_html_table <- function(
     class,
     style,
+    quarto_disable_processing,
     ...) {
 
   html_tbl <-
@@ -60,6 +66,7 @@ finalize_html_table <- function(
       htmltools::tags$table(
         class = "gt_table",
         style = style,
+        `data-quarto-disable-processing` = if (quarto_disable_processing) "true" else NULL,
         ...
       )
     )

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -2248,6 +2248,10 @@ set_style.cells_source_notes <- function(loc, data, style) {
 #'   bottom page margins. The default values for each of these is `1.0in`.
 #' @param page.header.height,page.footer.height The heights of the page header
 #'   and footer for RTF table outputs. Default values for both are `0.5in`.
+#' @param quarto.disable_processing When publishing a **gt** table with Quarto,
+#'   the table can undergo transformation to support advanced Quarto features.
+#'   Setting this to `TRUE` disables any transformation of the table. This is
+#'   `FALSE` by default.
 #'
 #' @return An object of class `gt_tbl`.
 #'
@@ -2547,7 +2551,8 @@ tab_options <- function(
     page.margin.top = NULL,
     page.margin.bottom = NULL,
     page.header.height = NULL,
-    page.footer.height = NULL
+    page.footer.height = NULL,
+    quarto.disable_processing = NULL
 ) {
 
   # Perform input object validation

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -184,7 +184,8 @@ tab_options(
   page.margin.top = NULL,
   page.margin.bottom = NULL,
   page.header.height = NULL,
-  page.footer.height = NULL
+  page.footer.height = NULL,
+  quarto.disable_processing = NULL
 )
 }
 \arguments{
@@ -477,6 +478,11 @@ bottom page margins. The default values for each of these is \verb{1.0in}.}
 
 \item{page.header.height, page.footer.height}{The heights of the page header
 and footer for RTF table outputs. Default values for both are \verb{0.5in}.}
+
+\item{quarto.disable_processing}{When publishing a \strong{gt} table with Quarto,
+the table can undergo transformation to support advanced Quarto features.
+Setting this to \code{TRUE} disables any transformation of the table. This is
+\code{FALSE} by default.}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/tests/testthat/helper-gt_attr_expectations.R
+++ b/tests/testthat/helper-gt_attr_expectations.R
@@ -107,7 +107,7 @@ expect_tab <- function(tab, df) {
 
   dt_options_get(data = tab) %>%
     dim() %>%
-    expect_equal(c(184, 5))
+    expect_equal(c(185, 5))
 
   dt_transforms_get(data = tab) %>%
     length() %>%


### PR DESCRIPTION
This adds an option in `tab_options()` (`quarto.disable_processing`) that disallows Quarto from modifying a gt table. This is useful in cases where you'd like the table to appear close to what you'd see in the Viewer (render of table in an otherwise empty HTML page).