### PR TITLE
Use `juicyjuice` as a soft dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,6 @@ Imports:
     glue (>= 1.6.1),
     htmltools (>= 0.5.2),
     htmlwidgets (>= 1.6.1),
-    juicyjuice (>= 0.1.0),
     magrittr (>= 2.0.2),
     reactable (>= 0.2.3),
     rlang (>= 1.0.2),
@@ -54,18 +53,19 @@ Imports:
     tidyselect (>= 1.1.1)
 Suggests:
     covr,
-    digest (>= 0.6.29),
+    digest (>= 0.6.31),
+    juicyjuice (>= 0.1.0),
+    lubridate,
     knitr,
     paletteer,
-    testthat (>= 3.0.0),
     RColorBrewer,
-    lubridate,
-    rmarkdown,
+    rmarkdown (>= 2.20),
     rvest,
-    shiny,
+    shiny (>= 1.7.4),
+    testthat (>= 3.1.6),
     tidyr,
-    webshot2,
-    xml2
+    webshot2 (>= 0.1.0),
+    xml2 (>= 1.3.3)
 Roxygen: list(markdown = TRUE)
 Collate: 
     'as_data_frame.R'

--- a/R/export.R
+++ b/R/export.R
@@ -451,6 +451,17 @@ as_raw_html <- function(
 
   if (inline_css) {
 
+    # Check whether juicyjuice is in the package library and stop function
+    # only if it is not present
+    if (!requireNamespace("juicyjuice", quietly = TRUE)) {
+
+      cli::cli_abort(c(
+        "Using `as_raw_html(... , inline_css = TRUE)` requires the juicyjuice
+        package.",
+        "*" = "It can be installed with `install.packages(\"juicyjuice\")`."
+      ))
+    }
+
     font_vec <- unique(dt_options_get_value(data = data, option = "table_font_names"))
     font_family_attr <- as_css_font_family_attr(font_vec = font_vec)
 


### PR DESCRIPTION
This PR puts `juicyjuice` as an optional install, since it is only used in one function (`as_raw_html()`) and some people had trouble installing the package because it uses V8.

Fixes: #1179 