### PR TITLE
Recognize and utilize column labels inside column data attires

### DIFF
--- a/R/dt_boxhead.R
+++ b/R/dt_boxhead.R
@@ -10,7 +10,16 @@ dt_boxhead_set <- function(data, boxh) {
 
 dt_boxhead_init <- function(data) {
 
+  # Get the column names from the data table
   vars <- colnames(dt_data_get(data = data))
+
+  # If there are any 'labeled' columns in the data table, use those labels
+  # wherever possible; otherwise, use column names as the column labels
+  if (any_labeled_columns_in_data_tbl(data = data)) {
+    column_labels <- get_columns_labels_from_attrs(data = data)
+  } else {
+    column_labels <- vars
+  }
 
   empty_list <- lapply(seq_along(vars), function(x) NULL)
 
@@ -37,7 +46,7 @@ dt_boxhead_init <- function(data) {
       # row_group_label = lapply(seq_along(names(data)), function(x) NULL),
       # The presentation label, which is a list of labels by
       # render context (e.g., HTML, LaTeX, etc.)
-      column_label = as.list(vars),
+      column_label = as.list(column_labels),
       # The alignment of the column ("left", "right", "center")
       column_align = "center",
       # The width of the column in `px`

--- a/R/utils.R
+++ b/R/utils.R
@@ -1482,6 +1482,39 @@ extract_strings <- function(text, pattern, perl = TRUE) {
   sapply(regmatches(text, regexec(pattern, text, perl = perl)), "[", 1)
 }
 
+any_labeled_columns_in_data_tbl <- function(data) {
+
+  data_tbl <- dt_data_get(data = data)
+
+  any(
+    vapply(
+      seq_len(ncol(data_tbl)),
+      FUN.VALUE = logical(1),
+      USE.NAMES = FALSE,
+      FUN = function(x) {
+        "label" %in% names(attributes(data_tbl[[x]]))
+      }
+    )
+  )
+}
+
+get_columns_labels_from_attrs <- function(data) {
+
+  data_tbl <- dt_data_get(data = data)
+
+  # Initialize vector of column labels
+  var_labels <- colnames(data_tbl)
+
+  # Overwrite `var_labels` wherever a column contains a `label` attribute value
+  for (i in seq_along(var_labels)) {
+    if ("label" %in% names(attributes(data_tbl[[i]]))) {
+      var_labels[i] <- attr(data_tbl[[i]], which = "label")
+    }
+  }
+
+  var_labels
+}
+
 #' Split any strings that are values in scientific notation
 #'
 #' @param x_str The input character vector of values formatted in scientific


### PR DESCRIPTION
This allows for column labels to be obtained from any columns that have a `label` attribute. For those columns not having an attribute (in a mixed case), the fallback will be the column name. In cases where there are no such attrs for any columns, we use the original codepath (in `dt_boxhead_init()`).

Fixes: https://github.com/rstudio/gt/issues/656