### PR TITLE
Make it possible to `gtsave()` a `"gt_group"` object to RTF

### DIFF
--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -918,16 +918,23 @@ rtf_border <- function(
   rtf_border
 }
 
-as_rtf_string <- function(x) {
+as_rtf_string <- function(
+    x,
+    incl_open = TRUE,
+    incl_header = TRUE,
+    incl_page_info = TRUE,
+    incl_body = TRUE,
+    incl_close = TRUE
+) {
 
   rtf_paste0(
-    rtf_raw("{"),
-    rtf_raw(as.character(x$header)),
+    if (incl_open) rtf_raw("{") else NULL,
+    if (incl_header) rtf_raw(as.character(x$header)) else NULL,
     "\n",
-    rtf_raw(as.character(x$page_information)),
+    if (incl_page_info) rtf_raw(as.character(x$page_information)) else NULL,
     "\n",
-    rtf_raw(as.character(x$document)),
-    rtf_raw("}")
+    if (incl_body) rtf_raw(as.character(x$document)) else NULL,
+    if (incl_close) rtf_raw("}") else NULL
   )
 }
 

--- a/man/as_rtf.Rd
+++ b/man/as_rtf.Rd
@@ -4,10 +4,30 @@
 \alias{as_rtf}
 \title{Output a \strong{gt} object as RTF}
 \usage{
-as_rtf(data)
+as_rtf(
+  data,
+  incl_open = TRUE,
+  incl_header = TRUE,
+  incl_page_info = TRUE,
+  incl_body = TRUE,
+  incl_close = TRUE
+)
 }
 \arguments{
 \item{data}{A table object that is created using the \code{gt()} function.}
+
+\item{incl_open, incl_close}{Options that govern whether the opening or
+closing \code{"{"} and \code{"}"} should be included. By default, both options are
+\code{TRUE}.}
+
+\item{incl_header}{Should the RTF header be included in the output? By
+default, this is \code{TRUE}.}
+
+\item{incl_page_info}{Should the RTF output include directives for the
+document pages? This is \code{TRUE} by default.}
+
+\item{incl_body}{An option to include the body of RTF document. By
+default, this is \code{TRUE}.}
 }
 \description{
 Get the RTF content from a \code{gt_tbl} object as as a single-element character

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -276,6 +276,14 @@ reference:
     - extract_cells
 
   - title: Multiple-table Functions
+    desc: >
+      Sometimes you want to deal with a multitude of **gt** tables, all at once.
+      There are some advantages to having a group of tables bundled together in
+      a `gt_group` object. You could apply options that petain to all tables yet
+      still access the individual tables for their own specialized
+      modifications. They all print together at once too! For HTML, each table
+      will be separated by a line break whereas in paginated formats the tables
+      are separated by page breaks.
     contents:
     - gt_group
     - grp_pull


### PR DESCRIPTION
This adds support for RTF output of `"gt_group"` objects (multi-table objects generated through the `gt_group()` function). The `as_rtf()` function was amended so that the user (and the print method for `"gt_group"` objects) can output certain RTF components (e.g., header, body, page info, etc.).