### PR TITLE
Add fix for `cols_label()` that supports input from `.list` arg

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -688,6 +688,12 @@ cols_label <- function(
 
     label_i <- labels_list[i]
 
+    # When input is provided as a list in `.list`, we obtain named vectors;
+    # upgrade this to a list to match the input collected from `...`
+    if (rlang::is_named(label_i) && rlang::is_scalar_vector(label_i)) {
+      label_i <- as.list(label_i)
+    }
+
     if (
       is.list(label_i) &&
       rlang::is_named(label_i) &&


### PR DESCRIPTION
This small fix ensures that any input provided to `cols_label()` as a list (for the `.list` arg) does not fail.