### PR TITLE
Improve documentation for the `sub_small_vals()` function

### DIFF
--- a/R/substitution.R
+++ b/R/substitution.R
@@ -335,7 +335,12 @@ sub_zero <- function(
 #' Wherever there is numerical data that are very small in value, replacement
 #' text may be better for explanatory purposes. The `sub_small_vals()` function
 #' allows for this replacement through specification of a `threshold`, a
-#' `small_pattern`, and the sign of the values to be considered.
+#' `small_pattern`, and the sign of the values to be considered. The
+#' substitution will occur for those values found to be between `0` and the
+#' threshold value. This is possible for small positive and small negative
+#' values (this can be explicitly set by the `sign` option). Note that the
+#' interval does not include the `0` or the `threshold` value. Should you need
+#' to include zero values, use the [sub_zero()] function.
 #'
 #' @inheritParams fmt_number
 #' @param columns Optional columns for constraining the targeting process.

--- a/man/sub_small_vals.Rd
+++ b/man/sub_small_vals.Rd
@@ -50,7 +50,12 @@ An object of class \code{gt_tbl}.
 Wherever there is numerical data that are very small in value, replacement
 text may be better for explanatory purposes. The \code{sub_small_vals()} function
 allows for this replacement through specification of a \code{threshold}, a
-\code{small_pattern}, and the sign of the values to be considered.
+\code{small_pattern}, and the sign of the values to be considered. The
+substitution will occur for those values found to be between \code{0} and the
+threshold value. This is possible for small positive and small negative
+values (this can be explicitly set by the \code{sign} option). Note that the
+interval does not include the \code{0} or the \code{threshold} value. Should you need
+to include zero values, use the \code{\link[=sub_zero]{sub_zero()}} function.
 }
 \section{Targeting cells with \code{columns} and \code{rows}}{
 


### PR DESCRIPTION
Improve the documentation for the `sub_small_vals()` function so that it is clear that the interval does not include zero or the threshold value.

Fixes: https://github.com/rstudio/gt/issues/1228