### PR TITLE
Modify vector of LaTeX packages and place these defaults in global options

### DIFF
--- a/R/data_color.R
+++ b/R/data_color.R
@@ -660,7 +660,7 @@ data_color <- function(
       if (!requireNamespace("paletteer", quietly = TRUE)) {
 
         cli::cli_abort(c(
-          "The paletteer package is required for accessing palettes with
+          "The `paletteer` package is required for accessing palettes with
           the `<package>::<palette>` syntax.",
           "*" = "It can be installed with `install.packages(\"paletteer\")`."
         ))

--- a/R/export.R
+++ b/R/export.R
@@ -236,9 +236,10 @@ gt_save_webshot <- function(
   # not present, stop with a message
   if (!requireNamespace("webshot2", quietly = TRUE)) {
 
-    cli::cli_abort(
-      "The `webshot2` package is required for saving images of gt tables."
-    )
+    cli::cli_abort(c(
+      "The `webshot2` package is required for saving images of gt tables.",
+      "*" = "It can be installed with `install.packages(\"webshot2\")`."
+    ))
 
   } else {
 
@@ -501,8 +502,7 @@ as_raw_html <- function(
     if (!requireNamespace("juicyjuice", quietly = TRUE)) {
 
       cli::cli_abort(c(
-        "Using `as_raw_html(... , inline_css = TRUE)` requires the juicyjuice
-        package.",
+        "Using `as_raw_html(... , inline_css = TRUE)` requires the `juicyjuice` package.",
         "*" = "It can be installed with `install.packages(\"juicyjuice\")`."
       ))
     }

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -3467,7 +3467,7 @@ determine_output_format <- function() {
 
     cli::cli_abort(c(
       "Automatically detecting the output context with `output = \"auto\"`
-      requires the knitr package.",
+      requires the `knitr` package.",
       "*" = "It can be installed with `install.packages(\"knitr\")`."
     ))
   }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -2753,9 +2753,10 @@ gt_latex_dependencies <- function() {
     )
 
   } else {
-    cli::cli_abort(
-      "The `knitr` package is required for getting the LaTeX dependency headers."
-    )
+    cli::cli_abort(c(
+      "The `knitr` package is required for getting the LaTeX dependency headers.",
+      "*" = "It can be installed with `install.packages(\"knitr\")`."
+    ))
   }
 }
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -218,8 +218,8 @@ check_shiny <- function() {
   if (!requireNamespace("shiny", quietly = TRUE)) {
 
     cli::cli_abort(c(
-      "Please install the shiny package before using this function.",
-      "*" = "Use `install.packages(\"shiny\")`."
+      "Please install the `shiny` package before using this function.",
+      "*" = "It can be installed with `install.packages(\"shiny\")`."
     ))
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -432,7 +432,7 @@ get_markdown_engine_fn <- function(
     if (!requireNamespace("markdown", quietly = TRUE)) {
 
       cli::cli_abort(c(
-        "Using the \"markdown\"` engine preference requires the markdown package.",
+        "Using the \"markdown\"` engine preference requires the `markdown` package.",
         "*" = "It can be installed with `install.packages(\"markdown\")`."
       ))
     }

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -3,9 +3,9 @@ latex_group <- function(...) {
   paste0("{", ..., "}")
 }
 
-# Create a vector of LaTeX packages to use as table dependencies
+# Get a vector of LaTeX packages to use as table dependencies
 latex_packages <- function() {
-  c("amsmath", "booktabs", "caption", "longtable")
+  getOption("gt.latex_packages")
 }
 
 # Transform a footnote mark to a LaTeX representation as a superscript

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -131,10 +131,17 @@ utils::globalVariables(
 #'
 #' **gt** uses the following [options()] to configure behavior:
 #'
+#' - `gt.row_group.sep`: A separator between groups for the row group label. By
+#' default this is `" - "`.
 #' - `gt.html_tag_check`: A logical scalar indicating whether or not to print a
-#'   warning when HTML tags are found in a table that is being rendered to LaTeX.
-#' - `gt.row_group.sep`: A separator between groups for the row group
-#'   label.
+#' warning when HTML tags are found in a table that is being rendered to LaTeX.
+#' The default for this is `TRUE`.
+#' - `gt.strict_column_fmt`: A logical scalar that controls whether formatting
+#' via the `fmt_*()` functions should fail if attempting to format data that is
+#' incompatible with the function. This is `FALSE` by default.
+#' - `gt.latex_packages`: A vector of LaTeX package names to use when generating
+#' tables in the LaTeX output context. The set of packages loaded is controlled
+#' by this default vector: `c("booktabs", "caption", "longtable")`.
 #'
 #' @keywords internal
 #' @name gt-options
@@ -143,7 +150,8 @@ NULL
 gt_default_options <- list(
   gt.row_group.sep = " - ",
   gt.html_tag_check = TRUE,
-  gt.strict_column_fmt = FALSE
+  gt.strict_column_fmt = FALSE,
+  gt.latex_packages = c("booktabs", "caption", "longtable")
 )
 
 # R 3.5 and earlier have a bug on Windows where if x is latin1 or unknown and

--- a/man/as_latex.Rd
+++ b/man/as_latex.Rd
@@ -18,7 +18,7 @@ containing the LaTeX code.
 }
 \details{
 LaTeX packages required to generate tables are:
-amsmath, booktabs, caption, longtable.
+booktabs, caption, longtable.
 
 In the event packages are not automatically added during the render phase
 of the document, please create and include a style file to load them.

--- a/man/gt-options.Rd
+++ b/man/gt-options.Rd
@@ -11,10 +11,17 @@
 
 \strong{gt} uses the following \code{\link[=options]{options()}} to configure behavior:
 \itemize{
+\item \code{gt.row_group.sep}: A separator between groups for the row group label. By
+default this is \code{" - "}.
 \item \code{gt.html_tag_check}: A logical scalar indicating whether or not to print a
 warning when HTML tags are found in a table that is being rendered to LaTeX.
-\item \code{gt.row_group.sep}: A separator between groups for the row group
-label.
+The default for this is \code{TRUE}.
+\item \code{gt.strict_column_fmt}: A logical scalar that controls whether formatting
+via the \verb{fmt_*()} functions should fail if attempting to format data that is
+incompatible with the function. This is \code{FALSE} by default.
+\item \code{gt.latex_packages}: A vector of LaTeX package names to use when generating
+tables in the LaTeX output context. The set of packages loaded is controlled
+by this default vector: \code{c("booktabs", "caption", "longtable")}.
 }
 }
 


### PR DESCRIPTION
This fixes a bug where LaTeX tables generated through the `xelatex` LaTeX engine wouldn't work (because of the `amsmath` package). That package has been removed from the default set. It is modifiable now through global options (the `gt.latex_packages` option).

Fixes: https://github.com/rstudio/gt/issues/751