### PR TITLE
Add the `ihtml.use_text_wrapping` option for interactive tables

### DIFF
--- a/R/dt_options.R
+++ b/R/dt_options.R
@@ -207,6 +207,7 @@ dt_options_tbl <-
     "ihtml_use_resizers",                FALSE,  "interactive",      "logical", FALSE,
     "ihtml_use_highlight",               FALSE,  "interactive",      "logical", FALSE,
     "ihtml_use_compact_mode",            FALSE,  "interactive",      "logical", FALSE,
+    "ihtml_use_text_wrapping",           FALSE,  "interactive",      "logical", TRUE,
     "ihtml_use_page_size_select",        FALSE,  "interactive",      "logical", FALSE,
     "ihtml_page_size_default",           FALSE,  "interactive",      "values",  10,
     "ihtml_page_size_values",            FALSE,  "interactive",      "values",  default_page_size_vec,

--- a/R/gt_group.R
+++ b/R/gt_group.R
@@ -663,6 +663,7 @@ grp_options <- function(
     ihtml.use_resizers = NULL,
     ihtml.use_highlight = NULL,
     ihtml.use_compact_mode = NULL,
+    ihtml.use_text_wrapping = NULL,
     ihtml.use_page_size_select = NULL,
     ihtml.page_size_default = NULL,
     ihtml.page_size_values = NULL,

--- a/R/opts.R
+++ b/R/opts.R
@@ -207,6 +207,10 @@ get_colorized_params <- function(
 #' @param use_compact_mode To reduce vertical padding and thus make the table
 #'   consume less vertical space the `use_compact_mode` option can be used. By
 #'   default, this is `FALSE`.
+#' @param use_text_wrapping The `use_text_wrapping` option controls whether
+#'   text wrapping occurs throughout the table. This is `TRUE` by default and
+#'   with that text will be wrapped to multiple lines. If `FALSE`, text will be
+#'   truncated to a single line.
 #' @param use_page_size_select,page_size_default,page_size_values The
 #'   `use_page_size_select` option lets us display a dropdown menu for the
 #'   number of rows to show per page of data. By default, this is the vector
@@ -296,6 +300,7 @@ opt_interactive <- function(
     use_resizers = FALSE,
     use_highlight = FALSE,
     use_compact_mode = FALSE,
+    use_text_wrapping = TRUE,
     use_page_size_select = FALSE,
     page_size_default = 10,
     page_size_values = c(10, 25, 50, 100),
@@ -318,6 +323,7 @@ opt_interactive <- function(
     ihtml.use_resizers = use_resizers,
     ihtml.use_highlight = use_highlight,
     ihtml.use_compact_mode = use_compact_mode,
+    ihtml.use_text_wrapping = use_text_wrapping,
     ihtml.use_page_size_select = use_page_size_select,
     ihtml.page_size_default = page_size_default,
     ihtml.page_size_values = page_size_values,

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -96,6 +96,7 @@ render_as_ihtml <- function(data, id) {
   use_resizers <- opt_val(data = data, option = "ihtml_use_resizers")
   use_highlight <- opt_val(data = data, option = "ihtml_use_highlight")
   use_compact_mode <- opt_val(data = data, option = "ihtml_use_compact_mode")
+  use_text_wrapping <- opt_val(data = data, option = "ihtml_use_text_wrapping")
   use_page_size_select <- opt_val(data = data, option = "ihtml_use_page_size_select")
   page_size_default <- opt_val(data = data, option = "ihtml_page_size_default")
   page_size_values <- opt_val(data = data, option = "ihtml_page_size_values")
@@ -200,7 +201,10 @@ render_as_ihtml <- function(data, id) {
       collapse = ""
     )
 
-  default_col_def <- reactable::colDef(style = reactable::JS(body_style_js_str))
+  default_col_def <-
+    reactable::colDef(
+      style = reactable::JS(body_style_js_str)
+    )
 
   # Generate the table header if there are any heading components
   if (has_header_section) {
@@ -353,7 +357,7 @@ render_as_ihtml <- function(data, id) {
       borderless = FALSE,
       striped = use_row_striping,
       compact = use_compact_mode,
-      wrap = TRUE,
+      wrap = use_text_wrapping,
       showSortIcon = TRUE,
       showSortable = TRUE,
       class = NULL,

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -2280,6 +2280,9 @@ set_style.cells_source_notes <- function(loc, data, style) {
 #' @param ihtml.use_compact_mode For interactive HTML output, an option to
 #'   reduce vertical padding and thus make the table consume less vertical
 #'   space. By default, this is `FALSE`.
+#' @param ihtml.use_text_wrapping For interactive HTML output, an option to
+#'   control text wrapping. By default (`TRUE`), text will be wrapped to
+#'   multiple lines; if `FALSE`, text will be truncated to a single line.
 #' @param ihtml.use_page_size_select,ihtml.page_size_default,ihtml.page_size_values
 #'   For interactive HTML output, `ihtml.use_page_size_select` provides the
 #'   option to display a dropdown menu for the number of rows to show per page
@@ -2609,6 +2612,7 @@ tab_options <- function(
     ihtml.use_resizers = NULL,
     ihtml.use_highlight = NULL,
     ihtml.use_compact_mode = NULL,
+    ihtml.use_text_wrapping = NULL,
     ihtml.use_page_size_select = NULL,
     ihtml.page_size_default = NULL,
     ihtml.page_size_values = NULL,

--- a/man/grp_options.Rd
+++ b/man/grp_options.Rd
@@ -171,6 +171,7 @@ grp_options(
   ihtml.use_resizers = NULL,
   ihtml.use_highlight = NULL,
   ihtml.use_compact_mode = NULL,
+  ihtml.use_text_wrapping = NULL,
   ihtml.use_page_size_select = NULL,
   ihtml.page_size_default = NULL,
   ihtml.page_size_values = NULL,
@@ -446,6 +447,10 @@ individual rows upon hover. By default, this is \code{FALSE}.}
 \item{ihtml.use_compact_mode}{For interactive HTML output, an option to
 reduce vertical padding and thus make the table consume less vertical
 space. By default, this is \code{FALSE}.}
+
+\item{ihtml.use_text_wrapping}{For interactive HTML output, an option to
+control text wrapping. By default (\code{TRUE}), text will be wrapped to
+multiple lines; if \code{FALSE}, text will be truncated to a single line.}
 
 \item{ihtml.use_page_size_select, ihtml.page_size_default, ihtml.page_size_values}{For interactive HTML output, \code{ihtml.use_page_size_select} provides the
 option to display a dropdown menu for the number of rows to show per page

--- a/man/opt_interactive.Rd
+++ b/man/opt_interactive.Rd
@@ -15,6 +15,7 @@ opt_interactive(
   use_resizers = FALSE,
   use_highlight = FALSE,
   use_compact_mode = FALSE,
+  use_text_wrapping = TRUE,
   use_page_size_select = FALSE,
   page_size_default = 10,
   page_size_values = c(10, 25, 50, 100),
@@ -55,6 +56,11 @@ upon hover. By default, this is \code{FALSE}.}
 \item{use_compact_mode}{To reduce vertical padding and thus make the table
 consume less vertical space the \code{use_compact_mode} option can be used. By
 default, this is \code{FALSE}.}
+
+\item{use_text_wrapping}{The \code{use_text_wrapping} option controls whether
+text wrapping occurs throughout the table. This is \code{TRUE} by default and
+with that text will be wrapped to multiple lines. If \code{FALSE}, text will be
+truncated to a single line.}
 
 \item{use_page_size_select, page_size_default, page_size_values}{The
 \code{use_page_size_select} option lets us display a dropdown menu for the

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -171,6 +171,7 @@ tab_options(
   ihtml.use_resizers = NULL,
   ihtml.use_highlight = NULL,
   ihtml.use_compact_mode = NULL,
+  ihtml.use_text_wrapping = NULL,
   ihtml.use_page_size_select = NULL,
   ihtml.page_size_default = NULL,
   ihtml.page_size_values = NULL,
@@ -447,6 +448,10 @@ individual rows upon hover. By default, this is \code{FALSE}.}
 \item{ihtml.use_compact_mode}{For interactive HTML output, an option to
 reduce vertical padding and thus make the table consume less vertical
 space. By default, this is \code{FALSE}.}
+
+\item{ihtml.use_text_wrapping}{For interactive HTML output, an option to
+control text wrapping. By default (\code{TRUE}), text will be wrapped to
+multiple lines; if \code{FALSE}, text will be truncated to a single line.}
 
 \item{ihtml.use_page_size_select, ihtml.page_size_default, ihtml.page_size_values}{For interactive HTML output, \code{ihtml.use_page_size_select} provides the
 option to display a dropdown menu for the number of rows to show per page

--- a/tests/testthat/helper-gt_attr_expectations.R
+++ b/tests/testthat/helper-gt_attr_expectations.R
@@ -107,7 +107,7 @@ expect_tab <- function(tab, df) {
 
   dt_options_get(data = tab) %>%
     dim() %>%
-    expect_equal(c(188, 5))
+    expect_equal(c(189, 5))
 
   dt_transforms_get(data = tab) %>%
     length() %>%


### PR DESCRIPTION
This PR adds the `ihtml.use_text_wrapping` option in `tab_options()` and `use_text_wrapping` in `opt_interactive()`. This will provide the option to wrap text lines (or not) in interactive HTML tables.