### PR TITLE
Fix error in `cols_label_with()`

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -973,13 +973,14 @@ cols_label_with <- function(
   if (length(resolved_columns) < 1) {
     return(data)
   }
-
   # Obtain `boxh_df` table and filter to the rows with resolved column names
   boxh_df <- dt_boxhead_get(data = data)
   boxh_df <- boxh_df[boxh_df[["var"]] %in% resolved_columns, ]
 
-  # Obtain a list of current labels for the resolved columns
+  # Obtain a list of current labels for the resolved columns and ensure
+  # that the var names are included as names for each of the list components
   old_label_list <- boxh_df[["column_label"]]
+  names(old_label_list) <- boxh_df[["var"]]
 
   # Apply the function call to each element of `old_label_list`
   new_label_list <- lapply(old_label_list, FUN = fn)
@@ -1008,7 +1009,7 @@ cols_label_with <- function(
     data <-
       dt_boxhead_edit_column_label(
         data = data,
-        var = resolved_columns[i],
+        var = names(new_label_list)[i],
         column_label = new_label_list[[i]]
       )
   }

--- a/tests/testthat/test-cols_label_with.R
+++ b/tests/testthat/test-cols_label_with.R
@@ -163,6 +163,92 @@ test_that("The function `cols_label_with()` works correctly", {
     tbl_html_5 %>% render_as_html()
   )
 
+  #
+  # Ensure that new labels are applied to columns correctly, no matter how
+  # the column resolution occurs
+  #
+
+  towny_gt_tbl <-
+    towny %>%
+    dplyr::arrange(desc(population_2021)) %>%
+    dplyr::slice_head(n = 5) %>%
+    dplyr::select(name, latitude, longitude, ends_with("2016"), ends_with("2021")) %>%
+    gt() %>%
+    tab_spanner(columns = starts_with("pop"), label = "Population") %>%
+    tab_spanner(columns = starts_with("den"), label = "Density")
+
+  expect_equal(
+    towny_gt_tbl %>%
+      cols_label_with(
+        fn = function(x) gsub(".*_(.*)", "\\1", x)
+      ) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']"),
+    towny_gt_tbl %>%
+      cols_label_with(
+        columns = c(population_2016, population_2021, density_2016, density_2021),
+        fn = function(x) gsub(".*_(.*)", "\\1", x)
+      ) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']")
+  )
+
+  expect_equal(
+    towny_gt_tbl %>%
+      cols_label_with(
+        fn = function(x) gsub(".*_(.*)", "\\1", x)
+      ) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']"),
+    towny_gt_tbl %>%
+      cols_label_with(
+        columns =  c(population_2016, density_2016, population_2021, density_2021),
+        fn = function(x) gsub(".*_(.*)", "\\1", x)
+      ) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']")
+  )
+
+  expect_equal(
+    towny_gt_tbl %>%
+      cols_label_with(
+        fn = function(x) gsub(".*_(.*)", "\\1", x)
+      ) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']"),
+    towny_gt_tbl %>%
+      cols_label_with(
+        columns = c(starts_with("pop"), starts_with("den")),
+        fn = function(x) gsub(".*_(.*)", "\\1", x)
+      ) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']")
+  )
+
+  expect_equal(
+    towny_gt_tbl %>%
+      cols_label_with(
+        fn = function(x) gsub(".*_(.*)", "\\1", x)
+      ) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']"),
+    towny_gt_tbl %>%
+      cols_label_with(
+        columns = c(starts_with("den"), starts_with("pop")),
+        fn = function(x) gsub(".*_(.*)", "\\1", x)
+      ) %>%
+      render_as_html() %>%
+      xml2::read_html() %>%
+      selection_text("[class='gt_col_heading gt_columns_bottom_border gt_right']")
+  )
+
   # Expect an error if `fn` is missing
   expect_error(gt(tbl) %>% cols_label_with(fn = NULL))
 


### PR DESCRIPTION
The `cols_label_with()` won't properly relabel column labels if the resolved columns is only a subset of the total columns available. This fix ensures that the column name information isn't lost during the process of altering the existing column labels.