### PR TITLE
Add ability to render background fills and text colors for LaTeX body cells

### DIFF
--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -365,16 +365,6 @@ create_body_component_l <- function(data) {
   # character vectors by row, and create a vector of LaTeX body rows
   cell_matrix <- get_body_component_cell_matrix(data = data)
 
-  # Replace an NA group with an empty string
-  if (any(is.na(groups_rows_df$group_label))) {
-
-    groups_rows_df <-
-      dplyr::mutate(
-        groups_rows_df,
-        group_label = ifelse(is.na(group_label), "", group_label)
-      )
-  }
-
   row_splits_body <- split_row_content(cell_matrix)
 
   # Get the number of rows in the body

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -896,6 +896,13 @@ create_body_rows_l <- function(
                 styles_i_col_text_color <- styles_i_col[[1]][["cell_text"]][["color"]]
                 styles_i_col_cell_color <- styles_i_col[[1]][["cell_fill"]][["color"]]
 
+                if (
+                  !is.null(styles_i_col[[1]][["cell_text"]][["weight"]]) &&
+                  styles_i_col[[1]][["cell_text"]][["weight"]] == "bold"
+                ) {
+                  content[i] <- paste0("\\textbf{", content[i], "}")
+                }
+
                 if (!is.null(styles_i_col_text_color)) {
                   content[i] <-
                     paste0(

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -364,6 +364,17 @@ create_body_component_l <- function(data) {
   # Get a matrix of body cells to render, split into a list of
   # character vectors by row, and create a vector of LaTeX body rows
   cell_matrix <- get_body_component_cell_matrix(data = data)
+
+  # Replace an NA group with an empty string
+  if (any(is.na(groups_rows_df$group_label))) {
+
+    groups_rows_df <-
+      dplyr::mutate(
+        groups_rows_df,
+        group_label = ifelse(is.na(group_label), "", group_label)
+      )
+  }
+
   row_splits_body <- split_row_content(cell_matrix)
 
   # Get the number of rows in the body
@@ -407,7 +418,11 @@ create_body_component_l <- function(data) {
     )
   }
 
-  body_rows <- create_body_rows_l(row_splits_body = row_splits_body)
+  body_rows <-
+    create_body_rows_l(
+      data = data,
+      row_splits_body = row_splits_body
+    )
 
   # Replace an NA group with an empty string
   if (any(is.na(groups_rows_df$group_label))) {
@@ -804,18 +819,120 @@ create_group_rows_l <- function(
 
 
 # Function to build a vector of `body` rows
-create_body_rows_l <- function(row_splits_body) {
+create_body_rows_l <- function(
+    data,
+    row_splits_body
+) {
 
-  unname(
-    unlist(
-      lapply(
-        seq_len(length(row_splits_body)),
-        FUN = function(x) {
-          latex_body_row(content = row_splits_body[[x]], type = "row")
-        }
+  styles_tbl <- dt_styles_get(data = data)
+  styles_tbl <- dplyr::filter(styles_tbl, locname %in% c("stub", "data", "row_groups"))
+
+  # Obtain all of the visible (`"default"`), non-stub column names
+  # for the table from the `boxh` object
+  default_vars <- dt_boxhead_get_vars_default(data = data)
+
+  stub_layout <- get_stub_layout(data = data)
+
+  stub_is_2 <- length(stub_layout) > 1
+
+  if (is.null(stub_layout)) {
+    vars <- default_vars
+  } else if (!is.null(stub_layout) && !stub_is_2 && stub_layout == "rowname") {
+    vars <- c("::stub::", default_vars)
+  } else if (!is.null(stub_layout) && !stub_is_2 && stub_layout == "group_label") {
+    vars <- c("::group::", default_vars)
+  } else if (!is.null(stub_layout) && stub_is_2) {
+    vars <- c("::group::", "::stub::", default_vars)
+  }
+
+  if ("::group::" %in% vars) {
+    styles_tbl <- dplyr::mutate(styles_tbl, rownum = round(rownum))
+  }
+
+  body_rows <-
+    unname(
+      unlist(
+        lapply(
+          seq_len(length(row_splits_body)),
+          FUN = function(x) {
+
+            content <- row_splits_body[[x]]
+            content_length <- length(content)
+
+            styles_tbl_i <- dplyr::filter(styles_tbl, rownum == x)
+
+            if (nrow(styles_tbl_i) < 1) {
+              return(paste(paste(content, collapse = " & "), "\\\\ \n"))
+            }
+
+            for (i in seq_len(content_length)) {
+
+              colname_i <- vars[i]
+
+              if (
+                colname_i == "::group::" &&
+                "row_groups" %in% styles_tbl_i[["locname"]]
+              ) {
+
+                styles_tbl_i_col <- dplyr::filter(styles_tbl_i, locname == "row_groups")
+                styles_i_col <- styles_tbl_i_col[["styles"]]
+
+              } else if (
+                colname_i == "::stub::" &&
+                "stub" %in% styles_tbl_i[["locname"]]
+              ) {
+
+                styles_tbl_i_col <- dplyr::filter(styles_tbl_i, locname == "stub")
+                styles_i_col <- styles_tbl_i_col[["styles"]]
+
+              } else if (
+                "data" %in% styles_tbl_i[["locname"]] &&
+                colname_i %in% styles_tbl_i[["colname"]]
+              ) {
+
+                styles_tbl_i_col <- dplyr::filter(styles_tbl_i, colname == colname_i)
+                styles_i_col <- styles_tbl_i_col[["styles"]]
+
+              } else {
+                styles_i_col <- NULL
+              }
+
+              if (!is.null(styles_i_col)) {
+
+                # TODO: this only considers the first entry; we need to iterate
+                # through them since there may be multiple styles set for each
+                # body cell and that might result in several rows in `styles_tbl_i_col`
+                # (i.e., length greater than 1 in `styles_i_col`)
+                styles_i_col_text_color <- styles_i_col[[1]][["cell_text"]][["color"]]
+                styles_i_col_cell_color <- styles_i_col[[1]][["cell_fill"]][["color"]]
+
+                if (!is.null(styles_i_col_text_color)) {
+                  content[i] <-
+                    paste0(
+                      "\\textcolor[HTML]{",
+                      gsub("#", "", styles_i_col_text_color, fixed = TRUE),
+                      "}{", content[i], "}"
+                    )
+                }
+
+                if (!is.null(styles_i_col_cell_color)) {
+                  content[i] <-
+                    paste0(
+                      "\\cellcolor[HTML]{",
+                      gsub("#", "", styles_i_col_cell_color, fixed = TRUE),
+                      "}{", content[i], "}"
+                    )
+                }
+              }
+            }
+
+            paste(paste(content, collapse = " & "), "\\\\ \n")
+          }
+        )
       )
     )
-  )
+
+  body_rows
 }
 
 # Function to build a vector of `summary` rows in the table body

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -414,7 +414,7 @@ create_body_component_l <- function(data) {
       row_splits_body = row_splits_body
     )
 
-  # Replace an NA group with an empty string
+  # Replace an NA group with a small amount of vertical space
   if (any(is.na(groups_rows_df$group_label))) {
 
     groups_rows_df <-

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -177,7 +177,7 @@ gt_default_options <- list(
   gt.row_group.sep = " - ",
   gt.html_tag_check = TRUE,
   gt.strict_column_fmt = FALSE,
-  gt.latex_packages = c("booktabs", "caption", "longtable")
+  gt.latex_packages = c("booktabs", "caption", "longtable", "colortbl")
 )
 
 # R 3.5 and earlier have a bug on Windows where if x is latin1 or unknown and


### PR DESCRIPTION
This adds some facility for background fill colors and text coloring/bolding to be rendered in LaTeX tables. Other types of styling (including in other locations such as the column labels) will be handled in a later PR.