### PR TITLE
Fix lack of HTML formatting for body cells in interactive tables

### DIFF
--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -170,7 +170,8 @@ render_as_ihtml <- function(data, id) {
         formatted_cells <-
           extract_cells(
             data = data,
-            columns = column_names[x]
+            columns = column_names[x],
+            output = "html"
           )
 
         reactable::colDef(

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -917,42 +917,45 @@ format_symbol_str <- function(
     return(x_abs_str)
   }
 
-  vapply(
-    seq_along(x),
-    FUN.VALUE = character(1),
-    USE.NAMES = FALSE,
-    FUN = function(i) {
+  x_out <-
+    vapply(
+      seq_along(x),
+      FUN.VALUE = character(1),
+      USE.NAMES = FALSE,
+      FUN = function(i) {
 
-      # Using absolute value format, the minus mark will
-      # be added later
-      x_i <- x[i]
-      x_str_i <- x_abs_str[i]
+        # Using absolute value format, the minus mark will
+        # be added later
+        x_i <- x[i]
+        x_str_i <- x_abs_str[i]
 
-      # Place possible space and symbol on correct side of value
-      x_str_i <-
-        paste_on_side(
-          x_str_i,
-          x_side = ifelse(incl_space, " ", ""),
-          direction = placement
-        )
-      x_str_i <-
-        paste_on_side(
-          x_str_i,
-          x_side = as.character(symbol_str),
-          direction = placement
-        )
+        # Place possible space and symbol on correct side of value
+        x_str_i <-
+          paste_on_side(
+            x_str_i,
+            x_side = ifelse(incl_space, " ", ""),
+            direction = placement
+          )
+        x_str_i <-
+          paste_on_side(
+            x_str_i,
+            x_side = as.character(symbol_str),
+            direction = placement
+          )
 
-      # Create the minus mark for the context
-      minus_mark <- context_minus_mark(context)
+        # Create the minus mark for the context
+        minus_mark <- context_minus_mark(context)
 
-      # Place the `minus_mark` onto the formatted strings
-      if (x_i < 0) {
-        x_str_i <- paste_left(x_str_i, minus_mark)
+        # Place the `minus_mark` onto the formatted strings
+        if (x_i < 0) {
+          x_str_i <- paste_left(x_str_i, minus_mark)
+        }
+
+        x_str_i
       }
+    )
 
-      x_str_i
-    }
-  )
+  x_out
 }
 
 #' Transform currency values to accounting style

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -887,6 +887,8 @@ context_symbol_str <- function(context, symbol) {
       },
       get_currency_str(currency = symbol, fallback_to_code = TRUE)
     )
+
+  symbol
 }
 
 #' Paste a symbol string to a formatted number


### PR DESCRIPTION
This fixes the problem where certain types of formatting weren't correctly applied to body cells in interactive HTML tables.

Fixes: https://github.com/rstudio/gt/issues/1384
Fixes: https://github.com/rstudio/gt/issues/1370
Fixes: https://github.com/rstudio/gt/issues/1299