### PR TITLE
Improve `from_column()` docs and add sections to relevant functions

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -1,4 +1,7 @@
 on:
+  push:
+    branches:
+      - master
   schedule:
     - cron: '0 23 * * *'
 

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - master
   schedule:
     - cron: '0 23 * * *'
 

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -273,6 +273,37 @@
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_number()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `decimals`
+#' - `n_sigfig`
+#' - `drop_trailing_zeros`
+#' - `drop_trailing_dec_mark`
+#' - `use_seps`
+#' - `accounting`
+#' - `scale_by`
+#' - `suffixing`
+#' - `pattern`
+#' - `sep_mark`
+#' - `dec_mark`
+#' - `force_sign`
+#' - `system`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
+#'
 #' @section Adapting output to a specific `locale`:
 #'
 #' This formatting function can adapt outputs according to a provided `locale`
@@ -676,6 +707,32 @@ fmt_number <- function(
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_integer()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `use_seps`
+#' - `accounting`
+#' - `scale_by`
+#' - `suffixing`
+#' - `pattern`
+#' - `sep_mark`
+#' - `force_sign`
+#' - `system`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
+#'
 #' @section Adapting output to a specific `locale`:
 #'
 #' This formatting function can adapt outputs according to a provided `locale`
@@ -933,6 +990,34 @@ fmt_integer <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_scientific()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `decimals`
+#' - `drop_trailing_zeros`
+#' - `drop_trailing_dec_mark`
+#' - `scale_by`
+#' - `exp_style`
+#' - `pattern`
+#' - `sep_mark`
+#' - `dec_mark`
+#' - `force_sign_m`
+#' - `force_sign_n`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Adapting output to a specific `locale`:
 #'
@@ -1400,6 +1485,34 @@ fmt_scientific <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_engineering()` to obtain varying parameter values from a specified
+#' column within the table. This means that each row could be formatted a little
+#' bit differently. These arguments provide support for [from_column()]:
+#'
+#' - `decimals`
+#' - `drop_trailing_zeros`
+#' - `drop_trailing_dec_mark`
+#' - `scale_by`
+#' - `exp_style`
+#' - `pattern`
+#' - `sep_mark`
+#' - `dec_mark`
+#' - `force_sign_m`
+#' - `force_sign_n`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Adapting output to a specific `locale`:
 #'
@@ -1992,6 +2105,37 @@ fmt_symbol <- function(
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_percent()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `decimals`
+#' - `drop_trailing_zeros`
+#' - `drop_trailing_dec_mark`
+#' - `scale_values`
+#' - `use_seps`
+#' - `accounting`
+#' - `pattern`
+#' - `sep_mark`
+#' - `dec_mark`
+#' - `force_sign`
+#' - `incl_space`
+#' - `placement`
+#' - `system`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
+#'
 #' @section Adapting output to a specific `locale`:
 #'
 #' This formatting function can adapt outputs according to a provided `locale`
@@ -2322,6 +2466,37 @@ fmt_percent <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_partsper()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `to_units`
+#' - `symbol`
+#' - `decimals`
+#' - `drop_trailing_zeros`
+#' - `drop_trailing_dec_mark`
+#' - `scale_values`
+#' - `use_seps`
+#' - `pattern`
+#' - `sep_mark`
+#' - `dec_mark`
+#' - `force_sign`
+#' - `incl_space`
+#' - `system`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Adapting output to a specific `locale`:
 #'
@@ -2677,6 +2852,31 @@ fmt_partsper <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_fraction()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `accuracy`
+#' - `simplify`
+#' - `layout`
+#' - `use_seps`
+#' - `pattern`
+#' - `sep_mark`
+#' - `system`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Adapting output to a specific `locale`:
 #'
@@ -3345,6 +3545,39 @@ round_gt <- function(x, digits = 0) {
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_currency()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `currency`
+#' - `use_subunits`
+#' - `decimals`
+#' - `drop_trailing_dec_mark`
+#' - `use_seps`
+#' - `accounting`
+#' - `scale_by`
+#' - `suffixing`
+#' - `pattern`
+#' - `sep_mark`
+#' - `dec_mark`
+#' - `force_sign`
+#' - `placement`
+#' - `incl_space`
+#' - `system`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
+#'
 #' @section Adapting output to a specific `locale`:
 #'
 #' This formatting function can adapt outputs according to a provided `locale`
@@ -3672,6 +3905,25 @@ fmt_currency <- function(
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_roman()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `case`
+#' - `pattern`
+#'
+#' Please note that for both of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
+#'
 #' @section Examples:
 #'
 #' Create a tibble of small numeric values and generate a **gt** table. Format
@@ -3909,6 +4161,27 @@ fmt_roman <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_index()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `case`
+#' - `index_algo`
+#' - `pattern`
+#' - `locale`
+#'
+#' Please note that for all of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Examples:
 #'
@@ -4229,6 +4502,25 @@ get_letters_from_div <- function(x, set) {
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_spelled_num()` to obtain varying parameter values from a specified
+#' column within the table. This means that each row could be formatted a little
+#' bit differently. These arguments provide support for [from_column()]:
+#'
+#' - `pattern`
+#' - `locale`
+#'
+#' Please note that for both of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Supported locales:
 #'
@@ -4588,6 +4880,35 @@ fmt_spelled_num <- function(
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_bytes()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `standard`
+#' - `decimals`
+#' - `n_sigfig`
+#' - `drop_trailing_zeros`
+#' - `drop_trailing_dec_mark`
+#' - `use_seps`
+#' - `pattern`
+#' - `sep_mark`
+#' - `dec_mark`
+#' - `force_sign`
+#' - `incl_space`
+#' - `locale`
+#'
+#' Please note that for each of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
+#'
 #' @section Adapting output to a specific `locale`:
 #'
 #' This formatting function can adapt outputs according to a provided `locale`
@@ -4915,6 +5236,26 @@ fmt_bytes <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_date()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `date_style`
+#' - `pattern`
+#' - `locale`
+#'
+#' Please note that for each of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Formatting with the `date_style` argument:
 #'
@@ -5266,6 +5607,26 @@ fmt_date <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_time()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `time_style`
+#' - `pattern`
+#' - `locale`
+#'
+#' Please note that for each of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Formatting with the `time_style` argument:
 #'
@@ -5632,6 +5993,30 @@ fmt_time <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_datetime()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `date_style`
+#' - `time_style`
+#' - `sep`
+#' - `format`
+#' - `tz`
+#' - `pattern`
+#' - `locale`
+#'
+#' Please note that for each of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Formatting with the `date_style` argument:
 #'
@@ -8068,6 +8453,30 @@ format_units_by_context <- function(x, context = "html") {
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_url()` to obtain varying parameter values from a specified column within
+#' the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `label`
+#' - `as_button`
+#' - `color`
+#' - `show_underline`
+#' - `button_fill`
+#' - `button_width`
+#' - `button_outline`
+#'
+#' Please note that for each of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
+#'
 #' @section Examples:
 #'
 #' Using a portion of the [`towny`] dataset, let's create a **gt** table. We can
@@ -8635,6 +9044,28 @@ fmt_url <- function(
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_image()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `height`
+#' - `sep`
+#' - `path`
+#' - `file_pattern`
+#' - `encode`
+#'
+#' Please note that for each of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
+#'
 #' @section Examples:
 #'
 #' Using a small portion of [`metro`] dataset, let's create a **gt** table. We
@@ -8990,6 +9421,26 @@ fmt_image <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_flag()` to obtain varying parameter values from a specified column
+#' within the table. This means that each row could be formatted a little bit
+#' differently. These arguments provide support for [from_column()]:
+#'
+#' - `height`
+#' - `sep`
+#' - `use_title`
+#'
+#' Please note that for each of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Examples:
 #'
@@ -9351,6 +9802,19 @@ fmt_flag <- function(
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with the `md_engine` argument
+#' of `fmt_markdown()` to obtain varying parameter values from a specified
+#' column within the table. This means that each row could be formatted a little
+#' bit differently.
+#'
+#' Please note that for this argument (`md_engine`), a [from_column()] call
+#' needs to reference a column that has data of the `character` type. Additional
+#' columns for parameter values can be generated with the [cols_add()] function
+#' (if not already present). Columns that contain parameter data can also be
+#' hidden from final display with [hide_columns()].
+#'
 #' @section Examples:
 #'
 #' Create a few Markdown-based text snippets.
@@ -9578,6 +10042,25 @@ fmt_markdown <- function(
 #' in the table) and returns a logical vector. This is nice if you want to base
 #' formatting on values in the column or another column, or, you'd like to use a
 #' more complex predicate expression.
+#'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with certain arguments of
+#' `fmt_passthrough()` to obtain varying parameter values from a specified
+#' column within the table. This means that each row could be formatted a little
+#' bit differently. These arguments provide support for [from_column()]:
+#'
+#' - `escape`
+#' - `pattern`
+#'
+#' Please note that for both of the aforementioned arguments, a [from_column()]
+#' call needs to reference a column that has data of the correct type (this is
+#' different for each argument). Additional columns for parameter values can be
+#' generated with the [cols_add()] function (if not already present). Columns
+#' that contain parameter data can also be hidden from final display with
+#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [from_column()] helper is applied so long as the arguments belong to this
+#' closed set.
 #'
 #' @section Examples:
 #'

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -300,7 +300,7 @@
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -729,7 +729,7 @@ fmt_number <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -1015,7 +1015,7 @@ fmt_integer <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -1510,7 +1510,7 @@ fmt_scientific <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -2132,7 +2132,7 @@ fmt_symbol <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -2494,7 +2494,7 @@ fmt_percent <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -2874,7 +2874,7 @@ fmt_partsper <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -3574,7 +3574,7 @@ round_gt <- function(x, digits = 0) {
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -3920,7 +3920,7 @@ fmt_currency <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -4179,7 +4179,7 @@ fmt_roman <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -4518,7 +4518,7 @@ get_letters_from_div <- function(x, set) {
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -4905,7 +4905,7 @@ fmt_spelled_num <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -5253,7 +5253,7 @@ fmt_bytes <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -5624,7 +5624,7 @@ fmt_date <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -6014,7 +6014,7 @@ fmt_time <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -8473,7 +8473,7 @@ format_units_by_context <- function(x, context = "html") {
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -9062,7 +9062,7 @@ fmt_url <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -9438,7 +9438,7 @@ fmt_image <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'
@@ -9813,7 +9813,7 @@ fmt_flag <- function(
 #' needs to reference a column that has data of the `character` type. Additional
 #' columns for parameter values can be generated with the [cols_add()] function
 #' (if not already present). Columns that contain parameter data can also be
-#' hidden from final display with [hide_columns()].
+#' hidden from final display with [cols_hide()].
 #'
 #' @section Examples:
 #'
@@ -10058,7 +10058,7 @@ fmt_markdown <- function(
 #' different for each argument). Additional columns for parameter values can be
 #' generated with the [cols_add()] function (if not already present). Columns
 #' that contain parameter data can also be hidden from final display with
-#' [hide_columns()]. Finally, there is no limitation to how many arguments the
+#' [cols_hide()]. Finally, there is no limitation to how many arguments the
 #' [from_column()] helper is applied so long as the arguments belong to this
 #' closed set.
 #'

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -290,7 +290,7 @@ pct <- function(x) {
 #'
 #' @return A list object of class `gt_column`.
 #'
-#' @section Functions that allow the use of the `with_column()` helper:
+#' @section Functions that allow the use of the `from_column()` helper:
 #'
 #' Only certain functions (and furthermore a subset of arguments within each)
 #' support the use of `from_column()` for accessing varying parameter values.
@@ -319,9 +319,9 @@ pct <- function(x) {
 #' - [fmt_passthrough()]
 #'
 #' Within help documents for each of these functions you'll find the
-#' *Compatibility of arguments with the `with_column()` helper function* section
+#' *Compatibility of arguments with the `from_column()` helper function* section
 #' and sections like these describe which arguments support the use of
-#' `with_column()`.
+#' `from_column()`.
 #'
 #' @family helper functions
 #' @section Function ID:

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -256,13 +256,15 @@ pct <- function(x) {
 #'
 #' @description
 #'
-#' For some functions, it is useful to get parameter values from a column in the
-#' **gt** table. For example, you might have indentation values (there are
-#' indentation levels from `1` to `5`) in an adjacent column; these values could
-#' be applied to the row labels in the stub through the [tab_stub_indent()]
-#' function. To make this work, we can use the `from_column()` helper function.
-#' Invoke this helper at the `indent` argument and specify the column that has
-#' the values.
+#' It can be useful to obtain parameter values from a column in a
+#' **gt** for functions that operate on the table body and stub cells. For
+#' example, you might want to indent row labels in the stub. You could call
+#' [tab_stub_indent()] and indent different rows to various indentation levels.
+#' However, each level of indentation applied necessitates a new call of that
+#' function. To make this better, we can use indentation values available in a
+#' table column via the `from_column()` helper function. For the
+#' [tab_stub_indent()] case, you'd invoke this helper at the `indent` argument
+#' and specify the column that has the values.
 #'
 #' @param column *Column name*
 #'
@@ -287,6 +289,39 @@ pct <- function(x) {
 #'   `column` (except `NA` values) can be mutated.
 #'
 #' @return A list object of class `gt_column`.
+#'
+#' @section Functions that allow the use of the `with_column()` helper:
+#'
+#' Only certain functions (and furthermore a subset of arguments within each)
+#' support the use of `from_column()` for accessing varying parameter values.
+#' These functions are:
+#'
+#' - [tab_stub_indent()]
+#' - [fmt_number()]
+#' - [fmt_integer()]
+#' - [fmt_scientific()]
+#' - [fmt_engineering()]
+#' - [fmt_percent()]
+#' - [fmt_partsper()]
+#' - [fmt_fraction()]
+#' - [fmt_currency()]
+#' - [fmt_roman()]
+#' - [fmt_index()]
+#' - [fmt_spelled_num()]
+#' - [fmt_bytes()]
+#' - [fmt_date()]
+#' - [fmt_time()]
+#' - [fmt_datetime()]
+#' - [fmt_url()]
+#' - [fmt_image()]
+#' - [fmt_flag()]
+#' - [fmt_markdown()]
+#' - [fmt_passthrough()]
+#'
+#' Within help documents for each of these functions you'll find the
+#' *Compatibility of arguments with the `with_column()` helper function* section
+#' and sections like these describe which arguments support the use of
+#' `with_column()`.
 #'
 #' @family helper functions
 #' @section Function ID:

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1756,6 +1756,19 @@ tab_stubhead <- function(
 #'
 #' @return An object of class `gt_tbl`.
 #'
+#' @section Compatibility of arguments with the `from_column()` helper function:
+#'
+#' The [from_column()] helper function can be used with the `indent` argument
+#' of `tab_stub_indent()` to obtain varying parameter values from a specified
+#' column within the table. This means that each row label could be indented a
+#' little bit differently.
+#'
+#' Please note that for this argument (`indent`), a [from_column()] call needs
+#' to reference a column that has data of the `numeric` or `integer` type.
+#' Additional columns for parameter values can be generated with the
+#' [cols_add()] function (if not already present). Columns that contain
+#' parameter data can also be hidden from final display with [hide_columns()].
+#'
 #' @section Examples:
 #'
 #' Let's use a summarized version of the [`pizzaplace`] dataset to create a

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1767,7 +1767,7 @@ tab_stubhead <- function(
 #' to reference a column that has data of the `numeric` or `integer` type.
 #' Additional columns for parameter values can be generated with the
 #' [cols_add()] function (if not already present). Columns that contain
-#' parameter data can also be hidden from final display with [hide_columns()].
+#' parameter data can also be hidden from final display with [cols_hide()].
 #'
 #' @section Examples:
 #'

--- a/man/fmt_bytes.Rd
+++ b/man/fmt_bytes.Rd
@@ -261,7 +261,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_bytes.Rd
+++ b/man/fmt_bytes.Rd
@@ -234,6 +234,38 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_bytes()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{standard}
+\item \code{decimals}
+\item \code{n_sigfig}
+\item \code{drop_trailing_zeros}
+\item \code{drop_trailing_dec_mark}
+\item \code{use_seps}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{dec_mark}
+\item \code{force_sign}
+\item \code{incl_space}
+\item \code{locale}
+}
+
+Please note that for each of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_currency.Rd
+++ b/man/fmt_currency.Rd
@@ -361,7 +361,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_currency.Rd
+++ b/man/fmt_currency.Rd
@@ -330,6 +330,42 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_currency()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{currency}
+\item \code{use_subunits}
+\item \code{decimals}
+\item \code{drop_trailing_dec_mark}
+\item \code{use_seps}
+\item \code{accounting}
+\item \code{scale_by}
+\item \code{suffixing}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{dec_mark}
+\item \code{force_sign}
+\item \code{placement}
+\item \code{incl_space}
+\item \code{system}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_date.Rd
+++ b/man/fmt_date.Rd
@@ -150,7 +150,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_date.Rd
+++ b/man/fmt_date.Rd
@@ -132,6 +132,29 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_date()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{date_style}
+\item \code{pattern}
+\item \code{locale}
+}
+
+Please note that for each of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Formatting with the \code{date_style} argument}{
 
 

--- a/man/fmt_datetime.Rd
+++ b/man/fmt_datetime.Rd
@@ -173,6 +173,33 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_datetime()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{date_style}
+\item \code{time_style}
+\item \code{sep}
+\item \code{format}
+\item \code{tz}
+\item \code{pattern}
+\item \code{locale}
+}
+
+Please note that for each of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Formatting with the \code{date_style} argument}{
 
 

--- a/man/fmt_datetime.Rd
+++ b/man/fmt_datetime.Rd
@@ -195,7 +195,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -220,6 +220,37 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_engineering()} to obtain varying parameter values from a specified
+column within the table. This means that each row could be formatted a little
+bit differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{decimals}
+\item \code{drop_trailing_zeros}
+\item \code{drop_trailing_dec_mark}
+\item \code{scale_by}
+\item \code{exp_style}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{dec_mark}
+\item \code{force_sign_m}
+\item \code{force_sign_n}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -246,7 +246,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_flag.Rd
+++ b/man/fmt_flag.Rd
@@ -151,7 +151,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_flag.Rd
+++ b/man/fmt_flag.Rd
@@ -133,6 +133,29 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_flag()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{height}
+\item \code{sep}
+\item \code{use_title}
+}
+
+Please note that for each of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Examples}{
 
 

--- a/man/fmt_fraction.Rd
+++ b/man/fmt_fraction.Rd
@@ -200,6 +200,34 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_fraction()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{accuracy}
+\item \code{simplify}
+\item \code{layout}
+\item \code{use_seps}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{system}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_fraction.Rd
+++ b/man/fmt_fraction.Rd
@@ -223,7 +223,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_image.Rd
+++ b/man/fmt_image.Rd
@@ -138,6 +138,31 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_image()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{height}
+\item \code{sep}
+\item \code{path}
+\item \code{file_pattern}
+\item \code{encode}
+}
+
+Please note that for each of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Examples}{
 
 

--- a/man/fmt_image.Rd
+++ b/man/fmt_image.Rd
@@ -158,7 +158,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_index.Rd
+++ b/man/fmt_index.Rd
@@ -141,6 +141,30 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_index()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{case}
+\item \code{index_algo}
+\item \code{pattern}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Examples}{
 
 

--- a/man/fmt_index.Rd
+++ b/man/fmt_index.Rd
@@ -160,7 +160,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_integer.Rd
+++ b/man/fmt_integer.Rd
@@ -224,6 +224,35 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_integer()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{use_seps}
+\item \code{accounting}
+\item \code{scale_by}
+\item \code{suffixing}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{force_sign}
+\item \code{system}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_integer.Rd
+++ b/man/fmt_integer.Rd
@@ -248,7 +248,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_markdown.Rd
+++ b/man/fmt_markdown.Rd
@@ -98,6 +98,21 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with the \code{md_engine} argument
+of \code{fmt_markdown()} to obtain varying parameter values from a specified
+column within the table. This means that each row could be formatted a little
+bit differently.
+
+Please note that for this argument (\code{md_engine}), a \code{\link[=from_column]{from_column()}} call
+needs to reference a column that has data of the \code{character} type. Additional
+columns for parameter values can be generated with the \code{\link[=cols_add]{cols_add()}} function
+(if not already present). Columns that contain parameter data can also be
+hidden from final display with \code{\link[=hide_columns]{hide_columns()}}.
+}
+
 \section{Examples}{
 
 

--- a/man/fmt_markdown.Rd
+++ b/man/fmt_markdown.Rd
@@ -110,7 +110,7 @@ Please note that for this argument (\code{md_engine}), a \code{\link[=from_colum
 needs to reference a column that has data of the \code{character} type. Additional
 columns for parameter values can be generated with the \code{\link[=cols_add]{cols_add()}} function
 (if not already present). Columns that contain parameter data can also be
-hidden from final display with \code{\link[=hide_columns]{hide_columns()}}.
+hidden from final display with \code{\link[=cols_hide]{cols_hide()}}.
 }
 
 \section{Examples}{

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -279,6 +279,40 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_number()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{decimals}
+\item \code{n_sigfig}
+\item \code{drop_trailing_zeros}
+\item \code{drop_trailing_dec_mark}
+\item \code{use_seps}
+\item \code{accounting}
+\item \code{scale_by}
+\item \code{suffixing}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{dec_mark}
+\item \code{force_sign}
+\item \code{system}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -308,7 +308,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_partsper.Rd
+++ b/man/fmt_partsper.Rd
@@ -269,6 +269,40 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_partsper()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{to_units}
+\item \code{symbol}
+\item \code{decimals}
+\item \code{drop_trailing_zeros}
+\item \code{drop_trailing_dec_mark}
+\item \code{scale_values}
+\item \code{use_seps}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{dec_mark}
+\item \code{force_sign}
+\item \code{incl_space}
+\item \code{system}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_partsper.Rd
+++ b/man/fmt_partsper.Rd
@@ -298,7 +298,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_passthrough.Rd
+++ b/man/fmt_passthrough.Rd
@@ -112,6 +112,28 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_passthrough()} to obtain varying parameter values from a specified
+column within the table. This means that each row could be formatted a little
+bit differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{escape}
+\item \code{pattern}
+}
+
+Please note that for both of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Examples}{
 
 

--- a/man/fmt_passthrough.Rd
+++ b/man/fmt_passthrough.Rd
@@ -129,7 +129,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_percent.Rd
+++ b/man/fmt_percent.Rd
@@ -284,7 +284,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_percent.Rd
+++ b/man/fmt_percent.Rd
@@ -255,6 +255,40 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_percent()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{decimals}
+\item \code{drop_trailing_zeros}
+\item \code{drop_trailing_dec_mark}
+\item \code{scale_values}
+\item \code{use_seps}
+\item \code{accounting}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{dec_mark}
+\item \code{force_sign}
+\item \code{incl_space}
+\item \code{placement}
+\item \code{system}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_roman.Rd
+++ b/man/fmt_roman.Rd
@@ -132,7 +132,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_roman.Rd
+++ b/man/fmt_roman.Rd
@@ -115,6 +115,28 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_roman()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{case}
+\item \code{pattern}
+}
+
+Please note that for both of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Examples}{
 
 

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -247,7 +247,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -221,6 +221,37 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_scientific()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{decimals}
+\item \code{drop_trailing_zeros}
+\item \code{drop_trailing_dec_mark}
+\item \code{scale_by}
+\item \code{exp_style}
+\item \code{pattern}
+\item \code{sep_mark}
+\item \code{dec_mark}
+\item \code{force_sign_m}
+\item \code{force_sign_n}
+\item \code{locale}
+}
+
+Please note that for all of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Adapting output to a specific \code{locale}}{
 
 

--- a/man/fmt_spelled_num.Rd
+++ b/man/fmt_spelled_num.Rd
@@ -127,6 +127,28 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_spelled_num()} to obtain varying parameter values from a specified
+column within the table. This means that each row could be formatted a little
+bit differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{pattern}
+\item \code{locale}
+}
+
+Please note that for both of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Supported locales}{
 
 

--- a/man/fmt_spelled_num.Rd
+++ b/man/fmt_spelled_num.Rd
@@ -144,7 +144,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_time.Rd
+++ b/man/fmt_time.Rd
@@ -151,7 +151,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_time.Rd
+++ b/man/fmt_time.Rd
@@ -133,6 +133,29 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_time()} to obtain varying parameter values from a specified column
+within the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{time_style}
+\item \code{pattern}
+\item \code{locale}
+}
+
+Please note that for each of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Formatting with the \code{time_style} argument}{
 
 

--- a/man/fmt_url.Rd
+++ b/man/fmt_url.Rd
@@ -180,7 +180,7 @@ call needs to reference a column that has data of the correct type (this is
 different for each argument). Additional columns for parameter values can be
 generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
 that contain parameter data can also be hidden from final display with
-\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=cols_hide]{cols_hide()}}. Finally, there is no limitation to how many arguments the
 \code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
 closed set.
 }

--- a/man/fmt_url.Rd
+++ b/man/fmt_url.Rd
@@ -158,6 +158,33 @@ formatting on values in the column or another column, or, you'd like to use a
 more complex predicate expression.
 }
 
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with certain arguments of
+\code{fmt_url()} to obtain varying parameter values from a specified column within
+the table. This means that each row could be formatted a little bit
+differently. These arguments provide support for \code{\link[=from_column]{from_column()}}:
+\itemize{
+\item \code{label}
+\item \code{as_button}
+\item \code{color}
+\item \code{show_underline}
+\item \code{button_fill}
+\item \code{button_width}
+\item \code{button_outline}
+}
+
+Please note that for each of the aforementioned arguments, a \code{\link[=from_column]{from_column()}}
+call needs to reference a column that has data of the correct type (this is
+different for each argument). Additional columns for parameter values can be
+generated with the \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns
+that contain parameter data can also be hidden from final display with
+\code{\link[=hide_columns]{hide_columns()}}. Finally, there is no limitation to how many arguments the
+\code{\link[=from_column]{from_column()}} helper is applied so long as the arguments belong to this
+closed set.
+}
+
 \section{Examples}{
 
 

--- a/man/from_column.Rd
+++ b/man/from_column.Rd
@@ -33,14 +33,52 @@ If a function is provided here, any values extracted from the table
 A list object of class \code{gt_column}.
 }
 \description{
-For some functions, it is useful to get parameter values from a column in the
-\strong{gt} table. For example, you might have indentation values (there are
-indentation levels from \code{1} to \code{5}) in an adjacent column; these values could
-be applied to the row labels in the stub through the \code{\link[=tab_stub_indent]{tab_stub_indent()}}
-function. To make this work, we can use the \code{from_column()} helper function.
-Invoke this helper at the \code{indent} argument and specify the column that has
-the values.
+It can be useful to obtain parameter values from a column in a
+\strong{gt} for functions that operate on the table body and stub cells. For
+example, you might want to indent row labels in the stub. You could call
+\code{\link[=tab_stub_indent]{tab_stub_indent()}} and indent different rows to various indentation levels.
+However, each level of indentation applied necessitates a new call of that
+function. To make this better, we can use indentation values available in a
+table column via the \code{from_column()} helper function. For the
+\code{\link[=tab_stub_indent]{tab_stub_indent()}} case, you'd invoke this helper at the \code{indent} argument
+and specify the column that has the values.
 }
+\section{Functions that allow the use of the \code{with_column()} helper}{
+
+
+Only certain functions (and furthermore a subset of arguments within each)
+support the use of \code{from_column()} for accessing varying parameter values.
+These functions are:
+\itemize{
+\item \code{\link[=tab_stub_indent]{tab_stub_indent()}}
+\item \code{\link[=fmt_number]{fmt_number()}}
+\item \code{\link[=fmt_integer]{fmt_integer()}}
+\item \code{\link[=fmt_scientific]{fmt_scientific()}}
+\item \code{\link[=fmt_engineering]{fmt_engineering()}}
+\item \code{\link[=fmt_percent]{fmt_percent()}}
+\item \code{\link[=fmt_partsper]{fmt_partsper()}}
+\item \code{\link[=fmt_fraction]{fmt_fraction()}}
+\item \code{\link[=fmt_currency]{fmt_currency()}}
+\item \code{\link[=fmt_roman]{fmt_roman()}}
+\item \code{\link[=fmt_index]{fmt_index()}}
+\item \code{\link[=fmt_spelled_num]{fmt_spelled_num()}}
+\item \code{\link[=fmt_bytes]{fmt_bytes()}}
+\item \code{\link[=fmt_date]{fmt_date()}}
+\item \code{\link[=fmt_time]{fmt_time()}}
+\item \code{\link[=fmt_datetime]{fmt_datetime()}}
+\item \code{\link[=fmt_url]{fmt_url()}}
+\item \code{\link[=fmt_image]{fmt_image()}}
+\item \code{\link[=fmt_flag]{fmt_flag()}}
+\item \code{\link[=fmt_markdown]{fmt_markdown()}}
+\item \code{\link[=fmt_passthrough]{fmt_passthrough()}}
+}
+
+Within help documents for each of these functions you'll find the
+\emph{Compatibility of arguments with the \code{with_column()} helper function} section
+and sections like these describe which arguments support the use of
+\code{with_column()}.
+}
+
 \section{Function ID}{
 
 8-5

--- a/man/from_column.Rd
+++ b/man/from_column.Rd
@@ -43,7 +43,7 @@ table column via the \code{from_column()} helper function. For the
 \code{\link[=tab_stub_indent]{tab_stub_indent()}} case, you'd invoke this helper at the \code{indent} argument
 and specify the column that has the values.
 }
-\section{Functions that allow the use of the \code{with_column()} helper}{
+\section{Functions that allow the use of the \code{from_column()} helper}{
 
 
 Only certain functions (and furthermore a subset of arguments within each)
@@ -74,9 +74,9 @@ These functions are:
 }
 
 Within help documents for each of these functions you'll find the
-\emph{Compatibility of arguments with the \code{with_column()} helper function} section
+\emph{Compatibility of arguments with the \code{from_column()} helper function} section
 and sections like these describe which arguments support the use of
-\code{with_column()}.
+\code{from_column()}.
 }
 
 \section{Function ID}{

--- a/man/tab_stub_indent.Rd
+++ b/man/tab_stub_indent.Rd
@@ -46,6 +46,21 @@ table stub. The \code{tab_stub_indent()} function allows for fine control over
 row label indentation in the stub. We can use an explicit definition of an
 indentation level, or, employ an indentation directive using keywords.
 }
+\section{Compatibility of arguments with the \code{from_column()} helper function}{
+
+
+The \code{\link[=from_column]{from_column()}} helper function can be used with the \code{indent} argument
+of \code{tab_stub_indent()} to obtain varying parameter values from a specified
+column within the table. This means that each row label could be indented a
+little bit differently.
+
+Please note that for this argument (\code{indent}), a \code{\link[=from_column]{from_column()}} call needs
+to reference a column that has data of the \code{numeric} or \code{integer} type.
+Additional columns for parameter values can be generated with the
+\code{\link[=cols_add]{cols_add()}} function (if not already present). Columns that contain
+parameter data can also be hidden from final display with \code{\link[=hide_columns]{hide_columns()}}.
+}
+
 \section{Examples}{
 
 

--- a/man/tab_stub_indent.Rd
+++ b/man/tab_stub_indent.Rd
@@ -58,7 +58,7 @@ Please note that for this argument (\code{indent}), a \code{\link[=from_column]{
 to reference a column that has data of the \code{numeric} or \code{integer} type.
 Additional columns for parameter values can be generated with the
 \code{\link[=cols_add]{cols_add()}} function (if not already present). Columns that contain
-parameter data can also be hidden from final display with \code{\link[=hide_columns]{hide_columns()}}.
+parameter data can also be hidden from final display with \code{\link[=cols_hide]{cols_hide()}}.
 }
 
 \section{Examples}{


### PR DESCRIPTION
This adds more documentation around which functions the `from_column()` helper supports and which specific arguments have support (within their respective help docs, via a standardized section).