### PR TITLE
Add significant figures support to `fmt_scientific()` and `vec_fmt_scientific()`

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -586,10 +586,10 @@ fmt_number <- function(
 
   # Set the `formatC_format` option according to whether number
   # formatting with significant figures is to be performed
-  if (!is.null(n_sigfig)) {
+  if (!is.null(n_sigfig) && !is.na(n_sigfig[1])) {
 
     # Stop function if `n_sigfig` does not have a valid value
-    validate_n_sigfig(n_sigfig)
+    validate_n_sigfig(n_sigfig = n_sigfig)
 
     formatC_format <- "fg"
   } else {
@@ -1180,6 +1180,7 @@ fmt_scientific <- function(
     columns = everything(),
     rows = everything(),
     decimals = 2,
+    n_sigfig = NULL,
     drop_trailing_zeros = FALSE,
     drop_trailing_dec_mark = TRUE,
     scale_by = 1.0,
@@ -1202,6 +1203,7 @@ fmt_scientific <- function(
   # Supports parameters:
   #
   # - decimals
+  # - n_sigfig
   # - drop_trailing_zeros
   # - drop_trailing_dec_mark
   # - scale_by
@@ -1247,6 +1249,7 @@ fmt_scientific <- function(
           columns = {{ columns }},
           rows = resolved_rows_idx[i],
           decimals = p_i$decimals %||% decimals,
+          n_sigfig = p_i$n_sigfig %||% n_sigfig,
           drop_trailing_zeros = p_i$drop_trailing_zeros %||% drop_trailing_zeros,
           drop_trailing_dec_mark = p_i$drop_trailing_dec_mark %||% drop_trailing_dec_mark,
           scale_by = p_i$scale_by %||% scale_by,
@@ -1304,6 +1307,17 @@ fmt_scientific <- function(
       with numeric data."
       )
     }
+  }
+
+  # If `n_sigfig` is defined (and not `NA`) modify the number of
+  # decimal places and keep all trailing zeros
+  if (!is.null(n_sigfig) && !is.na(n_sigfig[1])) {
+
+    # Stop function if `n_sigfig` does not have a valid value
+    validate_n_sigfig(n_sigfig = n_sigfig)
+
+    decimals <- n_sigfig - 1
+    drop_trailing_zeros <- FALSE
   }
 
   # Pass `data`, `columns`, `rows`, and the formatting

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -618,6 +618,7 @@ vec_fmt_integer <- function(
 vec_fmt_scientific <- function(
     x,
     decimals = 2,
+    n_sigfig = NULL,
     drop_trailing_zeros = FALSE,
     drop_trailing_dec_mark = TRUE,
     scale_by = 1.0,
@@ -654,6 +655,7 @@ vec_fmt_scientific <- function(
       columns = "x",
       rows = everything(),
       decimals = decimals,
+      n_sigfig = n_sigfig,
       drop_trailing_zeros = drop_trailing_zeros,
       drop_trailing_dec_mark = drop_trailing_dec_mark,
       scale_by = scale_by,

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -9,6 +9,7 @@ fmt_scientific(
   columns = everything(),
   rows = everything(),
   decimals = 2,
+  n_sigfig = NULL,
   drop_trailing_zeros = FALSE,
   drop_trailing_dec_mark = TRUE,
   scale_by = 1,
@@ -61,6 +62,17 @@ it would result in \code{"2"}. With \code{4} decimal places, the formatted value
 becomes \code{"2.3400"}. The trailing zeros can be removed with
 \code{drop_trailing_zeros = TRUE}. If you always need \code{decimals = 0}, the
 \code{\link[=fmt_integer]{fmt_integer()}} function should be considered.}
+
+\item{n_sigfig}{\emph{Number of significant figures}
+
+\code{scalar<numeric|integer>(val>=1)} // \emph{default:} \code{NULL} (\code{optional})
+
+A option to format numbers to \emph{n} significant figures. By default, this is
+\code{NULL} and thus number values will be formatted according to the number of
+decimal places set via \code{decimals}. If opting to format according to the
+rules of significant figures, \code{n_sigfig} must be a number greater than or
+equal to \code{1}. Any values passed to the \code{decimals} and \code{drop_trailing_zeros}
+arguments will be ignored.}
 
 \item{drop_trailing_zeros}{\emph{Drop any trailing zeros}
 

--- a/man/vec_fmt_scientific.Rd
+++ b/man/vec_fmt_scientific.Rd
@@ -7,6 +7,7 @@
 vec_fmt_scientific(
   x,
   decimals = 2,
+  n_sigfig = NULL,
   drop_trailing_zeros = FALSE,
   drop_trailing_dec_mark = TRUE,
   scale_by = 1,
@@ -38,6 +39,17 @@ it would result in \code{"2"}. With \code{4} decimal places, the formatted value
 becomes \code{"2.3400"}. The trailing zeros can be removed with
 \code{drop_trailing_zeros = TRUE}. If you always need \code{decimals = 0}, the
 \code{\link[=fmt_integer]{fmt_integer()}} function should be considered.}
+
+\item{n_sigfig}{\emph{Number of significant figures}
+
+\code{scalar<numeric|integer>(val>=1)} // \emph{default:} \code{NULL} (\code{optional})
+
+A option to format numbers to \emph{n} significant figures. By default, this is
+\code{NULL} and thus number values will be formatted according to the number of
+decimal places set via \code{decimals}. If opting to format according to the
+rules of significant figures, \code{n_sigfig} must be a number greater than or
+equal to \code{1}. Any values passed to the \code{decimals} and \code{drop_trailing_zeros}
+arguments will be ignored.}
 
 \item{drop_trailing_zeros}{\emph{Drop any trailing zeros}
 

--- a/tests/testthat/test-fmt_number.R
+++ b/tests/testthat/test-fmt_number.R
@@ -666,11 +666,12 @@ test_that("The `fmt_number()` function format to specified significant figures",
   # Expect an error if the length of `n_sigfig` is not 1
   expect_error(fmt_number(tab, columns = num, n_sigfig = c(1, 2)))
 
-  # Expect an error if `n_sigfig` is NA
-  expect_error(tab %>% fmt_number(columns = num, n_sigfig = NA))
-  expect_error(tab %>% fmt_number(columns = num, n_sigfig = NA_integer_))
-  expect_error(tab %>% fmt_number(columns = num, n_sigfig = NA_real_))
-  expect_error(tab %>% fmt_number(columns = num, n_sigfig = NA_integer_))
+  # Don't expect an error if `n_sigfig` is NA (if `n_sigfig` has NA) then
+  # `decimals` is used
+  expect_error(regexp = NA, tab %>% fmt_number(columns = num, n_sigfig = NA))
+  expect_error(regexp = NA, tab %>% fmt_number(columns = num, n_sigfig = NA_integer_))
+  expect_error(regexp = NA, tab %>% fmt_number(columns = num, n_sigfig = NA_real_))
+  expect_error(regexp = NA, tab %>% fmt_number(columns = num, n_sigfig = NA_integer_))
 
   # Expect an error if `n_sigfig` is not numeric
   expect_error(tab %>% fmt_number(columns = num, n_sigfig = "3"))
@@ -685,7 +686,6 @@ test_that("The `fmt_number()` function format to specified significant figures",
   expect_error(tab %>% fmt_number(columns = num, n_sigfig = 0L))
   expect_error(tab %>% fmt_number(columns = num, n_sigfig = -1L))
 })
-
 
 test_that("The `drop_trailing_dec_mark` option works in select `fmt_*()` functions", {
 


### PR DESCRIPTION
Previously, `fmt_number()` and `fmt_bytes()` (and their `vec_fmt_*()` analogues) had support for significant figures. This PR includes the `n_sigfig` argument in `fmt_scientific()`. This argument is compatible with the `from_column()` helper and so the use case where measurement precision varies by row (and should be reflected in the formatting of the value in scientific notation) can now be realized. 