### PR TITLE
Fix tiny typo in cols_nanoplot description

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2147,7 +2147,7 @@ cols_add <- function(
 #' associated *reference area* which, by default, tries to make itself useful by
 #' bounding the area between the lower and upper quartiles of the data. These
 #' boundaries can also be customized in a similar fashion as the reference line.
-#' The nanoplots are robust against missing values, are multiple strategies are
+#' The nanoplots are robust against missing values, and multiple strategies are
 #' available for handling missingness.
 #'
 #' While basic customization options are present in the `cols_nanoplot()`, many

--- a/man/cols_nanoplot.Rd
+++ b/man/cols_nanoplot.Rd
@@ -161,7 +161,7 @@ using a nanoplot's data values. Aside from a reference line, there is also an
 associated \emph{reference area} which, by default, tries to make itself useful by
 bounding the area between the lower and upper quartiles of the data. These
 boundaries can also be customized in a similar fashion as the reference line.
-The nanoplots are robust against missing values, are multiple strategies are
+The nanoplots are robust against missing values, and multiple strategies are
 available for handling missingness.
 
 While basic customization options are present in the \code{cols_nanoplot()}, many


### PR DESCRIPTION
Change "are" to "and" in cols_nanoplot

# Checklist

- [X] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [X] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [X] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
