### PR TITLE
Improve performance of `render_html()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Imports:
     scales (>= 1.2.1),
     tibble (>= 3.1.8),
     tidyselect (>= 1.2.0),
+    vctrs,
     xml2 (>= 1.3.3)
 Suggests:
     covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,6 @@ Imports:
     rlang (>= 1.0.2),
     sass (>= 0.4.5),
     scales (>= 1.2.1),
-    tibble (>= 3.1.8),
     tidyselect (>= 1.2.0),
     vctrs,
     xml2 (>= 1.3.3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt (development version)
 
+* The performance of rendering bigger tables as HTML has been improved and is now up to 3 times faster than before (@mgirlich, #1470).
+
 # gt 0.10.0
 
 ## Nanoplots

--- a/R/dt_styles.R
+++ b/R/dt_styles.R
@@ -99,7 +99,11 @@ dt_styles_pluck <- function(
     )
   }
 
-  idx <- rep_len(TRUE, nrow(styles_tbl))
+  n <- nrow(styles_tbl)
+  if (n == 0) {
+    return(styles_tbl)
+  }
+  idx <- rep_len(TRUE, n)
 
   if (!is_missing(locname)) {
     idx <- idx & styles_tbl$locname %in% locname
@@ -120,5 +124,6 @@ dt_styles_pluck <- function(
     idx <- idx & round((styles_tbl$rownum %% 1) * 100) %in% grprow
   }
 
-  styles_tbl[idx, ]
+  # `vec_slice()` is much faster than `[`
+  vctrs::vec_slice(styles_tbl, idx)
 }

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1428,10 +1428,13 @@ create_body_component_h <- function(data) {
 
     body_rows <- lapply(
       seq_along(body_rows_vec),
-      \(i) {
-        list(htmltools::tags$tr(
-          class = if (!is.na(row_classes[[i]])) row_classes[[i]],
-          htmltools::HTML(body_rows_vec[[i]])
+      function(i) {
+        list(htmltools::tag(
+          "tr",
+          varArgs = list(
+            class = if (!is.na(row_classes[[i]])) row_classes[[i]],
+            htmltools::HTML(body_rows_vec[[i]])
+          )
         ))
       }
     )

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1240,14 +1240,10 @@ create_body_component_h <- function(data) {
     # Is this the first row of a group?
     group_start <- !is.null(g) && group_row_start == i
 
-    # Is this the first row of a group where there is a two-column stub?
-    group_start_two_col_stub <- has_two_col_stub && group_start
-
     #
     # Create a body row
     #
 
-    has_rtl_i <- has_rtl[i, ]
     # If any characters come from a RTL script, ensure that a
     # left alignment is transformed to a right alignment
     has_rtl_i <- has_rtl[i, ]
@@ -1385,7 +1381,8 @@ create_body_component_h <- function(data) {
       summaries_present &&
       !is.null(group_has_summary_rows) &&
       group_has_summary_rows &&
-      group_start_two_col_stub &&
+      has_two_col_stub &&
+      group_start &&
       !is.null(group_summary_row_side) &&
       !is.na(group_summary_row_side) &&
       group_summary_row_side == "top"

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1490,9 +1490,11 @@ render_row_data <- function(
 
   scope <- ifelse(!is.na(row_span_vals) & row_span_vals > 1, "rowgroup", "row")
 
-  header <- gsub(
-    "(^[[:space:]]*)|([[:space:]]*$)", "",
-    paste(current_group_id, row_id_i, col_id_i)
+  has_group <- !is_empty(current_group_id) && nzchar(current_group_id)
+  header <- paste0(
+    current_group_id, if (has_group) " " else "",
+    row_id_i, if (has_group | nzchar(row_id_i[[1]])) " " else "",
+    col_id_i
   )
 
   base_attributes <- ifelse(

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -2061,20 +2061,20 @@ build_row_styles <- function(
     )
   }
 
-  # This will hold the resulting styles
+  n_cols <- n_cols + include_stub
   result <- rep_len(NA_character_, n_cols)
 
   # The subset of styles_resolved_row that applies to data
-  data_styles <- styles_resolved_row[styles_resolved_row$colnum > 0, ]
-  result[data_styles$colnum] <- data_styles$html_style
+  idx <- styles_resolved_row$colnum > 0
+  result[styles_resolved_row$colnum[idx] + include_stub] <- styles_resolved_row$html_style[idx]
 
   # If a stub exists, we need to prepend a style (or NULL) to the result.
   if (include_stub) {
-    stub_style <- styles_resolved_row[styles_resolved_row$colnum == 0, ]$html_style
-    if (is_empty(stub_style)) {
-      stub_style <- NA_character_
+    idx_0 <- styles_resolved_row$colnum == 0
+    stub_style <- styles_resolved_row$html_style[idx_0]
+    if (!is_empty(stub_style)) {
+      result[1] <- stub_style
     }
-    result <- c(stub_style, result)
   }
 
   result

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1429,15 +1429,15 @@ create_body_component_h <- function(data) {
                       } else {
                         paste0(
                           "rowspan=\"",
-                          htmltools::htmlEscape(row_span, attribute = TRUE),
+                          row_span,
                           "\" "
                         )
                       },
                       paste(
                         c(
                           "gt_row",
-                          htmltools::htmlEscape(alignment_class, attribute = TRUE),
-                          htmltools::htmlEscape(extra_class, attribute = TRUE)
+                          alignment_class,
+                          extra_class
                         ),
                         collapse = " "
                       ),
@@ -1446,7 +1446,7 @@ create_body_component_h <- function(data) {
                       } else {
                         paste0(
                           " style=\"",
-                          htmltools::htmlEscape(cell_style, attribute = FALSE),
+                          cell_style,
                           "\""
                         )
                       },

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1191,6 +1191,11 @@ create_body_component_h <- function(data) {
   )
   summary_locations <- unlist(summary_locations)
 
+  # Store when rtl is detected so that later left alignment can be transformed to
+  # right alignment
+  has_rtl <- matrix(grepl(rtl_modern_unicode_charset, cell_matrix), ncol = ncol(cell_matrix))
+  cell_matrix[has_rtl] <- paste0("<p dir=\"rtl\">", cell_matrix[has_rtl], "</p>")
+
   body_rows <-
     lapply(
       seq_len(n_rows),
@@ -1222,6 +1227,11 @@ create_body_component_h <- function(data) {
         #
         # Create a body row
         #
+
+        has_rtl_i <- has_rtl[i, ]
+        # If any characters come from a RTL script, ensure that a
+        # left alignment is transformed to a right alignment
+        alignment_classes[alignment_classes != "gt_center" & has_rtl_i] <- "gt_right"
 
         # This condition determines whether we are on an every 'second' body
         # row and, if so, we use `extra_classes_2` instead of `extra_classes_1`
@@ -1371,6 +1381,7 @@ create_body_component_h <- function(data) {
           row_id_i <- row_id_i[-1]
           row_span_vals <- row_span_vals[-1]
           alignment_classes <- alignment_classes[-1]
+          has_rtl_i <- has_rtl_i[-1]
           extra_classes <- extra_classes[-1]
           row_styles <- row_styles[-1]
         }
@@ -1391,15 +1402,6 @@ create_body_component_h <- function(data) {
                   extra_classes,
                   row_styles,
                   FUN = function(x, col_id, row_id, row_span, alignment_class, extra_class, cell_style) {
-
-                    # If any characters come from a RTL script, ensure that a
-                    # left alignment is transformed to a right alignment
-                    if (grepl(rtl_modern_unicode_charset, x)) {
-                      if (alignment_class != "gt_center") {
-                        alignment_class <- "gt_right"
-                      }
-                      x <- paste0("<p dir=\"rtl\">", x, "</p>")
-                    }
 
                     sprintf(
                       "<%s %sclass=\"%s\"%s>%s</%s>",

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1211,6 +1211,7 @@ create_body_component_h <- function(data) {
 
   # FIXME: workaround for incorrect behaviour of `rows_add()`
   # only added to make tests pass
+  # #1471
   idx <- is.na(groups_rows_df$group_id)
   groups_rows_df$group_id[idx] <- "NA"
   groups_rows_df$group_label[idx] <- "NA"

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -45,6 +45,11 @@ twip_factors <-
     `cm` = 566.9291, `mm` = 56.69291, `tw` = 1
   )
 
+twip_factors_df <- data.frame(
+  unit = names(twip_factors),
+  conv = unname(twip_factors)
+)
+
 rtf_key <- function(word, val = NULL, space = FALSE) {
   rtf_raw(paste0("\\", word, val %||% "", if (space) " "))
 }
@@ -412,7 +417,7 @@ abs_len_to_twips <- function(lengths_df) {
 
   lengths_df %>%
     dplyr::left_join(
-      tibble::enframe(twip_factors, name = "unit", value = "conv"),
+      twip_factors_df,
       by = c("unit" = "unit")
     ) %>%
     dplyr::mutate(

--- a/R/z_utils_render_footnotes.R
+++ b/R/z_utils_render_footnotes.R
@@ -353,8 +353,10 @@ resolve_footnotes_styles <- function(data, tbl_type) {
     lookup_tbl <-
       dplyr::filter(tbl, locname != "none") %>%
       dplyr::select(footnotes) %>%
-      dplyr::distinct() %>%
-      tibble::rownames_to_column(var = "fs_id")
+      dplyr::distinct()
+
+    lookup_tbl <- dplyr::mutate(lookup_tbl, fs_id = rownames(lookup_tbl), .before = 1)
+    rownames(lookup_tbl) <- NULL
 
     # Join the lookup table to `tbl`
     tbl <- dplyr::left_join(tbl, lookup_tbl, by = "footnotes")

--- a/tests/testthat/test-tab_options.R
+++ b/tests/testthat/test-tab_options.R
@@ -1540,7 +1540,7 @@ test_that("The row striping options work correctly", {
         ) %>%
         render_as_html() %>%
         xml2::read_html() %>%
-        selection_text("[class='gt_row gt_right gt_stub gt_striped']"),
+        selection_text("[class='gt_row gt_right gt_stub  gt_striped']"),
       tbl %>%
         gt() %>%
         tab_options(


### PR DESCRIPTION
# Summary

Rendering slightly bigger tables (e.g. 50k rows) as HTML is very slow. The two main culprits are `create_body_component_h()` and {htmltools} (in particular `tagWrite()` but also creating the tags themself).

Two small benchmarks

```r
diamonds_1000 <- ggplot2::diamonds |>
  head(1000) |>
  gt::gt()
diamonds <- ggplot2::diamonds |>
  gt::gt()

prepare <- function(data) {
  data <- gt:::build_data(data = data, context = "html")
  data <- gt:::add_css_styles(data = data)
  gt:::create_body_component_h(data = data)
}

bench::mark(
  diamonds_1000 = prepare(diamonds_1000),
  diamonds = prepare(diamonds),
  check = FALSE
)

# CRAN
# # A tibble: 2 × 13
#   expression        min median `itr/sec` mem_alloc `gc/sec` n_itr
#   <bch:expr>    <bch:t> <bch:>     <dbl> <bch:byt>    <dbl> <int>
# 1 diamonds_1000   1.14s  1.14s    0.878     5.37MB     2.63     1
# 2 diamonds       56.42s 56.42s    0.0177  175.21MB     2.11     1

# This PR
# # A tibble: 2 × 13
#   expression         min   median `itr/sec` mem_alloc `gc/sec` n_itr
#   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int>
# 1 diamonds_1000 146.87ms 148.81ms     6.33     7.72MB     6.33     4
# 2 diamonds         7.46s    7.46s     0.134  301.76MB     6.03     1
```

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.

# Notes

`create_body_component_h()` is quite huge. I think it would make sense to split parts of it into separate functions, e.g. a function for the group headings, the summaries, the data itself. I didn't do this as I didn't want to change the style too much.

The PR is probably quite a bit easier to understand by looking at the commits one by one. Otherwise the changes are hard to follow.

There are a couple of places in `render_row_data()` that deal with spaces and creating HTML. This feels quite tedious and error prone. It would be great to use {htmltools} for such a task but this would require to increase the performance of {htmltools} much more.

I also opened an [issue](https://github.com/rstudio/htmltools/issues/413) in {htmltools} regarding the performance