### PR TITLE
Make gtsave return file path invisibly.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * The performance of rendering bigger tables as HTML has been improved and is now up to 3 times faster than before (@mgirlich, #1470).
 
+* `gtsave()` now returns the file path invisibly instead of `TRUE` (@olivroy, #1478).
+
 # gt 0.10.0
 
 ## Nanoplots

--- a/R/export.R
+++ b/R/export.R
@@ -97,7 +97,7 @@
 #'
 #'   All other options passed to the appropriate internal saving function.
 #'
-#' @return Invisibly returns `TRUE` if the export process is successful.
+#' @return The file name (invisibly) if the export process is successful.
 #'
 #' @section Examples:
 #'
@@ -217,8 +217,11 @@ gtsave <- function(
       ))
     }
   )
+  if (!is.null(path)) {
+    filename <- file.path(path, filename)
+  }
 
-  invisible(TRUE)
+  invisible(filename)
 }
 
 #' Saving function for an HTML file

--- a/man/gtsave.Rd
+++ b/man/gtsave.Rd
@@ -36,7 +36,7 @@ An optional path to which the file should be saved (combined with
 All other options passed to the appropriate internal saving function.}
 }
 \value{
-Invisibly returns \code{TRUE} if the export process is successful.
+The file name (invisibly) if the export process is successful.
 }
 \description{
 The \code{gtsave()} function makes it easy to save a \strong{gt} table to a file. The


### PR DESCRIPTION
# Summary

Have gtsave follow more closely `ggsave()` by returning the file path instead of `TRUE`.

This is a naive solution. I guess the code could be cleaned up a little bit for `gtsave()` since the related htmltools issue seems to have been solved. May no longer require this fs code? 

Some tests seem to be a little redundant too? I could take another (more thorough) shot at the `gtsave()` code and tests if you think this is worth pursuing.

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
