### PR TITLE
Issue 1465

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -725,15 +725,19 @@ as_latex <- function(data) {
     latex_packages <- NULL
   }
 
+  table_width_bookends <- derive_table_width_bookends(data = data)
+
   # Compose the LaTeX table
   knitr::asis_output(
     paste0(
+      table_width_bookends[1L],
       table_start,
       heading_component,
       columns_component,
       body_component,
       table_end,
       footer_component,
+      table_width_bookends[2L],
       collapse = ""
     ),
     meta = latex_packages

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -1169,12 +1169,19 @@ derive_table_width_bookends <- function(data) {
 
     bookends <-
       c(
-        sprintf(
-          '\\setlength\\LTleft{%s\\linewidth}\n\\setlength\\LTright{%s\\linewidth}\n',
-          side_width,
-          side_width
+        paste0(
+          "\\newlength\\holdLTleft",
+          "\\newlength\\holdLTright",
+          "\\setlength\\holdLTleft{\\LTleft}\\relax",
+          "\\setlength\\holdLTright{\\LTright}\\relax",
+          sprintf(
+            '\\setlength\\LTleft{%s\\linewidth}\n\\setlength\\LTright{%s\\linewidth}',
+            side_width,
+            side_width
+          ),
+          collapse = "\n"
         ),
-        ""
+        "\\setlength\\LTleft{\\holdLTleft}\n\\setlength\\LTright{\\holdLTright}"
       )
 
   } else {

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -183,6 +183,45 @@ create_table_start_l <- function(data) {
             ">{\\raggedright\\arraybackslash}"
           )
 
+        # Check if column width was set using gt::pct and
+        # convert to Latex friendly terminology (i.e.,
+        # '14.7%' becomes '0.147\\linewidth')
+        if (grepl('^[[:digit:].]+%$', col_widths[i])) {
+
+          table_width <- dt_options_get_value(data = data, option = 'table_width')
+
+          col_pct <- as.numeric(gsub('%$', '', col_widths[i])) / 100
+
+          if (table_width == 'auto') {
+
+            # Table width not specified, use all available space
+            col_scalar <- col_pct
+            tab_unit <- '\\linewidth'
+
+          } else if (endsWith(table_width, suffix = '%')) {
+
+            # If table width is expressed as a percentage, adjust the scaler
+            col_scalar <- col_pct * as.numeric(gsub('%', '', table_width)) / 100
+            tab_unit <- '\\linewidth'
+
+          } else {
+
+            # When table width is expressed in units, convert to points
+            col_scalar <- col_pct * convert_to_px(table_width) * 0.75 # 0.75 converts pixels to points
+            tab_unit <- 'pt'
+
+          }
+
+          col_widths[i] <-
+            paste0(
+              "\\dimexpr ",
+              col_scalar,
+              tab_unit,
+              "-2\\tabcolsep-1.5\\arrayrulewidth"
+            )
+
+        }
+
         col_defs_i <- paste0(align, "p{", col_widths[i], "}")
 
       } else {

--- a/tests/testthat/test-as_latex.R
+++ b/tests/testthat/test-as_latex.R
@@ -1,0 +1,50 @@
+test_that("Table width correctly output in LaTeX", {
+
+  gt_latex_width_1 <-
+    gt(exibble) %>%
+    tab_options(table.width = pct(90)) %>%
+    as_latex()
+
+  start_pt <- regexpr("begin\\{longtable", gt_latex_width_1)
+
+  expect_gt(start_pt, 0)  # Verifies the long table command appears in the text
+
+  end_pt <- regexpr("end\\{longtable", gt_latex_width_1)
+
+  expect_gt(end_pt, 0)
+
+  # Verify that the holdLTleft and holdLTright variables are defined and set
+  latex_prefix <- substr(gt_latex_width_1, 1L, start_pt)
+
+  expect_match(latex_prefix, "\\\\newlength\\\\holdLTleft")
+
+  expect_match(latex_prefix, "\\\\newlength\\\\holdLTright")
+
+  expect_match(latex_prefix, "\\\\setlength\\\\holdLTleft\\{\\\\LTleft\\}\\\\relax")
+
+  expect_match(latex_prefix, "\\\\setlength\\\\holdLTright\\{\\\\LTright\\}\\\\relax")
+
+  # Verify that LTleft and LTright are correctly specified
+  expect_match(latex_prefix, "\\\\setlength\\\\LTleft\\{0.05\\\\linewidth\\}")
+
+  expect_match(latex_prefix, "\\\\setlength\\\\LTright\\{0.05\\\\linewidth\\}")
+
+  # Verify that after the longtable environment, the LTleft and LT right are
+  # changed back to their previous values
+  latex_suffix <- substr(gt_latex_width_1, end_pt, nchar(gt_latex_width_1))
+
+  expect_match(latex_suffix, "\\\\setlength\\\\LTleft\\{\\\\holdLTleft\\}")
+
+  expect_match(latex_suffix, "\\\\setlength\\\\LTright\\{\\\\holdLTright\\}")
+
+  # Test specification of a table width in pixels
+  gt_latex_width_2 <-
+    gt(exibble) %>%
+    tab_options(table.width = '600px') %>%
+    as_latex()
+
+  expect_match(gt_latex_width_2, "\\\\setlength\\\\LTleft\\{\\\\dimexpr\\(0.5\\\\linewidth - 225pt\\)\\}")
+
+  expect_match(gt_latex_width_2, "\\\\setlength\\\\LTright\\{\\\\dimexpr\\(0.5\\\\linewidth - 225pt\\)\\}")
+
+})

--- a/tests/testthat/test-cols_width.R
+++ b/tests/testthat/test-cols_width.R
@@ -897,3 +897,111 @@ test_that("The function `cols_width()` works correctly with a complex table", {
     ) %>%
     expect_true()
 })
+
+test_that("The function `cols_width()` correctly specifies LaTeX table when column widths are specified by user as percentages", {
+
+  # Check that specific suggested packages are available
+  check_suggests()
+
+  # Create a `tbl_latex` object with `gt()` and size
+  # all columns in percentages
+  tbl_latex <-
+    gt(tbl) %>%
+    cols_width(
+      col_1 ~ pct(50),
+      col_2 ~ pct(30),
+      col_3 ~ pct(20),
+      col_4 ~ pct(10)
+    )
+
+  pct_string <- function(x, unit = '\\\\linewidth') {
+
+    prefix <- '>\\{\\\\ragged[[:alpha:]]+\\\\arraybackslash\\}'
+
+    sprintf(
+      '%sp\\{\\\\dimexpr %s%s-2\\\\tabcolsep-1.5\\\\arrayrulewidth\\}',
+      prefix,
+      format(x, scientific = FALSE, trim = TRUE),
+      unit
+    )
+
+  }
+
+  build_longtable_regex <- function(...) {
+
+    paste0(
+      c(
+        "^\\\\begin\\{longtable\\}\\{",
+        c(...),
+        "\\}\\n"
+      ),
+      collapse = ''
+    )
+
+  }
+
+  latex_col_regex <-
+    paste0(
+      c(
+        '^\\\\begin\\{longtable\\}\\{',
+        # '>\\{\\\\ragged[[:alpha:]]+\\\\arraybackslash'
+       sprintf('>\\{\\\\ragged[[:alpha:]]+\\\\arraybackslash\\}p\\{\\\\dimexpr 0\\.%d\\\\linewidth-2\\\\tabcolsep-1.5\\\\arrayrulewidth}',
+               c(5L, 3L, 2L, 1L)),
+        '\\}\\n'
+      ),
+      collapse = ''
+    )
+
+  # Expect that all column widths are expressed as percentage of \linewidth
+  c(0.5, 0.3, 0.2, 0.1) %>%
+    pct_string() %>%
+    build_longtable_regex() %>%
+    grepl(as_latex(tbl_latex)) %>%
+    expect_true()
+
+
+  # Check that LaTeX is correctly generated when only some
+  # column widths are specified as percentages
+  tbl_latex_partial <-
+    gt(tbl) %>%
+    cols_width(
+      col_1 ~ pct(30),
+      col_3 ~ pct(20)
+    )
+
+  c(
+    pct_string(0.3),
+    'r',
+    pct_string(0.2),
+    'r'
+  ) %>%
+    build_longtable_regex() %>%
+    grepl(as_latex(tbl_latex_partial)) %>%
+    expect_true()
+
+  # Check that LaTeX longtable command is correctly generated
+  # when table_width is specified by the user as a percentage
+  tbl_latex_tw_pct <-
+    tbl_latex %>%
+    tab_options(table.width = pct(70))
+
+  (0.7 * c(0.5, 0.3, 0.2, 0.1)) %>%
+    pct_string() %>%
+    build_longtable_regex() %>%
+    grepl(as_latex(tbl_latex_tw_pct)) %>%
+    expect_true()
+
+  # Check that LaTeX longtable command is correctly generated
+  # when table width is specified by user in pixels
+  tbl_latex_tw_px <-
+    tbl_latex %>%
+    tab_options(table.width = '400px')
+
+  (400 * 0.75 * c(0.5, 0.3, 0.2, 0.1)) %>%
+    pct_string(unit = 'pt') %>%
+    build_longtable_regex() %>%
+    grepl(as_latex(tbl_latex_tw_px))
+
+
+})
+

--- a/tests/testthat/test-cols_width.R
+++ b/tests/testthat/test-cols_width.R
@@ -916,7 +916,7 @@ test_that("The function `cols_width()` correctly specifies LaTeX table when colu
 
   pct_string <- function(x, unit = '\\\\linewidth') {
 
-    prefix <- '>\\{\\\\ragged[[:alpha:]]+\\\\arraybackslash\\}'
+    prefix <- '>\\{\\\\(raggedright|raggedleft|centering)\\\\arraybackslash\\}'
 
     sprintf(
       '%sp\\{\\\\dimexpr %s%s-2\\\\tabcolsep-1.5\\\\arrayrulewidth\\}',
@@ -931,7 +931,8 @@ test_that("The function `cols_width()` correctly specifies LaTeX table when colu
 
     paste0(
       c(
-        "^\\\\begin\\{longtable\\}\\{",
+        "\\\\begin\\{longtable\\}\\{",
+        "(@\\{\\\\extracolsep\\{\\\\fill\\}\\})*",
         c(...),
         "\\}\\n"
       ),
@@ -943,11 +944,12 @@ test_that("The function `cols_width()` correctly specifies LaTeX table when colu
   latex_col_regex <-
     paste0(
       c(
-        '^\\\\begin\\{longtable\\}\\{',
+        "\\\\begin\\{longtable\\}\\{",
+        "(@\\{\\\\extracolsep\\{\\\\fill\\}\\})*",
         # '>\\{\\\\ragged[[:alpha:]]+\\\\arraybackslash'
-       sprintf('>\\{\\\\ragged[[:alpha:]]+\\\\arraybackslash\\}p\\{\\\\dimexpr 0\\.%d\\\\linewidth-2\\\\tabcolsep-1.5\\\\arrayrulewidth}',
+       sprintf(">\\{\\\\(raggedright|raggedleft|centering)\\\\arraybackslash\\}p\\{\\\\dimexpr 0\\.%d\\\\linewidth-2\\\\tabcolsep-1.5\\\\arrayrulewidth}",
                c(5L, 3L, 2L, 1L)),
-        '\\}\\n'
+        "\\}\\n"
       ),
       collapse = ''
     )


### PR DESCRIPTION
# Summary

This pull request addresses two previously-reported bugs associated with outputting tables to LaTeX.  

1.   Issue #1465:   Fixes an issue where table columns specified with the `pct` function cause LaTeX compilation errors.   The error is caused by the fact that specifying `cols_width(everything() ~ pct(20))` specifies the column width in LaTeX as "20%".  Since % is the comment symbol in LaTeX, this produces a compilation error.  The code has been changed so that the column width in LaTeX will be output as "0.2\linewidth" if the table width is unspecified (in which case each column will take up 20% of the available width) or 0.2 times the specified table width.
2.  Issue #119 (and duplicate issue #329):   Uses the user-supplied table widths to establish the LaTeX tables widths.  The code works with user-specified widths expressed as percentages (i.e., `tab_options(table.width = pct(100))`) or as specific units (i.e., `tab_options(table.width = '400px')`).  Table widths are established using the specified LaTeX lengths \LTleft and \LTright.  Extra space to fill out the table width, if necessary, is added in between the columns by setting `\extracolsep to \fill. (The code also creates two temporary length measures in LaTex, \holdLTleft and \holdLTright which record the existing length values of \LTleft and \LTright before setting them to the user-specified lengths for the table.  After the longtable environment is ended, the preexisting values of \LTleft and \LTright are restored.

# Related GitHub Issues and PRs

- Issue #1465 
- Issue #119 
- Issue #329 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
