### PR TITLE
Improve error message for gt functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `gtsave()` now returns the file path invisibly instead of `TRUE` (@olivroy, #1478).
 
+* Most functions in gt receive a better error message if they don't provide a `gt_tbl` as an input (@olivroy, #1504).
+
 # gt 0.10.0
 
 ## Nanoplots

--- a/R/utils.R
+++ b/R/utils.R
@@ -109,7 +109,7 @@ stop_if_not_gt_group <- function(data, call = caller_env()) {
   }
 }
 
-#' Stop any function if object is neither `gt_tbl` nor `gt_ group`
+#' Stop any function if object is neither `gt_tbl` nor `gt_group`
 #'
 #' @param data The input `data` object that is to be validated.
 #'
@@ -246,7 +246,7 @@ get_date_format <- function(date_style) {
       cli::cli_abort(c(
         "If using a numeric value for a `date_style`, it must be ",
         "between `1` and `{nrow(date_format_tbl)}`.",
-        "*" = "Use {.run [info_date_style](gt::info_date_style(opt_interactive = TRUE))} for a useful visual reference."
+        "*" = "Use `info_date_style()` for a useful visual reference."
       ))
     }
   }
@@ -257,7 +257,7 @@ get_date_format <- function(date_style) {
     if (!(date_style %in% date_format_tbl$format_name)) {
       cli::cli_abort(c(
         "If using a `date_style` name, it must be in the valid set.",
-        "*" = "Use {.run [info_date_style](gt::info_date_style(opt_interactive = TRUE))} for a useful visual reference."
+        "*" = "Use `info_date_style()` for a useful visual reference."
       ))
     }
 
@@ -299,7 +299,7 @@ get_time_format <- function(time_style) {
       cli::cli_abort(c(
         "If using a numeric value for a `time_style`, it must be
         between `1` and `{nrow((time_format_tbl))}`.",
-        "*" = "Use {.run [info_time_style](gt::info_time_style(interactive = TRUE))} for a useful visual reference."
+        "*" = "Use `info_time_style()` for a useful visual reference."
       ))
     }
   }
@@ -310,7 +310,7 @@ get_time_format <- function(time_style) {
     if (!(time_style %in% time_format_tbl$format_name)) {
       cli::cli_abort(c(
         "If using a `time_style` name, it must be in the valid set.",
-        "*" = "Use {.run [info_time_style](gt::info_time_style(interactive = TRUE))} for a useful visual reference."
+        "*" = "Use `info_time_style()` for a useful visual reference."
       ))
     }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,7 +86,8 @@ is_nonempty_string <- function(x) {
 #' @param data The input `data` object that is to be validated.
 #'
 #' @noRd
-stop_if_not_gt_tbl <- function(data, call = rlang::caller_env()) {
+# Use rlang::caller_env() to inform user of the precise location of failure.
+stop_if_not_gt_tbl <- function(data, call = caller_env()) {
   if (!is_gt_tbl(data = data)) {
     cli::cli_abort(
       "`data` must be a `gt_tbl` object, not {.obj_type_friendly {data}}.",
@@ -114,10 +115,10 @@ stop_if_not_gt_group <- function(data, call = caller_env()) {
 #' @param data The input `data` object that is to be validated.
 #'
 #' @noRd
-stop_if_not_gt_tbl_or_group <- function(data, call = rlang::caller_env()) {
+stop_if_not_gt_tbl_or_group <- function(data, call = caller_env()) {
   if (!is_gt_tbl(data = data) && !is_gt_group(data = data)) {
     cli::cli_abort(
-      "`data` must either be a `gt_tbl` or a `gt_group`, not object{.obj_type_friendly {data}}.",
+      "`data` must either be a `gt_tbl` or a `gt_group`, not {.obj_type_friendly {data}}.",
       call = error_call
     )
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,10 +86,11 @@ is_nonempty_string <- function(x) {
 #' @param data The input `data` object that is to be validated.
 #'
 #' @noRd
-stop_if_not_gt_tbl <- function(data) {
+stop_if_not_gt_tbl <- function(data, call = rlang::caller_env()) {
   if (!is_gt_tbl(data = data)) {
     cli::cli_abort(
-      "The `data` provided is not a `gt_tbl` object."
+      "`data` must be a `gt_tbl` object, not {.obj_type_friendly {data}}.",
+      call = call
     )
   }
 }
@@ -99,23 +100,25 @@ stop_if_not_gt_tbl <- function(data) {
 #' @param data The input `data` object that is to be validated.
 #'
 #' @noRd
-stop_if_not_gt_group <- function(data) {
+stop_if_not_gt_group <- function(data, call = caller_env()) {
   if (!is_gt_group(data = data)) {
     cli::cli_abort(
-      "The `data` provided is not a `gt_group` object."
+      "`data` must be a `gt_group` object, not {.obj_type_friendly {data}}.",
+      call = call
     )
   }
 }
 
-#' Stop any function if object is neither `gt_tbl` nor `gt_group`
+#' Stop any function if object is neither `gt_tbl` nor `gt_ group`
 #'
 #' @param data The input `data` object that is to be validated.
 #'
 #' @noRd
-stop_if_not_gt_tbl_or_group <- function(data) {
+stop_if_not_gt_tbl_or_group <- function(data, call = rlang::caller_env()) {
   if (!is_gt_tbl(data = data) && !is_gt_group(data = data)) {
     cli::cli_abort(
-      "The `data` provided is neither a `gt_tbl` nor a `gt_group` object."
+      "`data` must either be a `gt_tbl` or a `gt_group`, not object{.obj_type_friendly {data}}.",
+      call = error_call
     )
   }
 }
@@ -243,7 +246,7 @@ get_date_format <- function(date_style) {
       cli::cli_abort(c(
         "If using a numeric value for a `date_style`, it must be ",
         "between `1` and `{nrow(date_format_tbl)}`.",
-        "*" = "Use `info_date_style()` for a useful visual reference."
+        "*" = "Use {.run [info_date_style](gt::info_date_style(opt_interactive = TRUE))} for a useful visual reference."
       ))
     }
   }
@@ -254,7 +257,7 @@ get_date_format <- function(date_style) {
     if (!(date_style %in% date_format_tbl$format_name)) {
       cli::cli_abort(c(
         "If using a `date_style` name, it must be in the valid set.",
-        "*" = "Use `info_date_style()` for a useful visual reference."
+        "*" = "Use {.run [info_date_style](gt::info_date_style(opt_interactive = TRUE))} for a useful visual reference."
       ))
     }
 
@@ -296,7 +299,7 @@ get_time_format <- function(time_style) {
       cli::cli_abort(c(
         "If using a numeric value for a `time_style`, it must be
         between `1` and `{nrow((time_format_tbl))}`.",
-        "*" = "Use `info_time_style()` for a useful visual reference."
+        "*" = "Use {.run [info_time_style](gt::info_time_style(interactive = TRUE))} for a useful visual reference."
       ))
     }
   }
@@ -307,7 +310,7 @@ get_time_format <- function(time_style) {
     if (!(time_style %in% time_format_tbl$format_name)) {
       cli::cli_abort(c(
         "If using a `time_style` name, it must be in the valid set.",
-        "*" = "Use `info_time_style()` for a useful visual reference."
+        "*" = "Use {.run [info_time_style](gt::info_time_style(interactive = TRUE))} for a useful visual reference."
       ))
     }
 

--- a/tests/testthat/helper-render_formats.R
+++ b/tests/testthat/helper-render_formats.R
@@ -1,8 +1,5 @@
 # Testable version of the `render_formats()` function
 render_formats_test <- function(data,
                                 context) {
-
-  data %>%
-    build_data(context = context) %>%
-    .$`_body`
+  build_data(data, context = context)$`_body`
 }

--- a/tests/testthat/test-input_data_validation.R
+++ b/tests/testthat/test-input_data_validation.R
@@ -1,6 +1,6 @@
 test_that("All exported functions validate the incoming `data` object", {
 
-  regexp_stop <- "The `data` provided is not a `gt_tbl` object"
+  regexp_stop <- "`data` must be a `gt_tbl` object"
 
   # Test the `exibble` tibble with all exported functions;
   # don't provide values for any arguments and ensure that


### PR DESCRIPTION
# Summary

Use `rlang::caller_env()` to help user find the source of the error more easily.

```r
# before 
mtcars |> fmt_number()
Error in `stop_if_not_gt_tbl()`:
! The `data` provided is not a `gt_tbl` object.

# With this PR
mtcars |> fmt_number()
Error in `fmt_number()`:
! `data` must be a `gt_tbl` object, not a data frame.

```

# Checklist

- [ ] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
