### PR TITLE
Handle special nanoplot case where all `y` values are zero

### DIFF
--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -164,10 +164,16 @@ generate_nanoplot <- function(
   y_scale_max <- get_extreme_value(y_vals, stat = "max")
   y_scale_min <- get_extreme_value(y_vals, stat = "min")
 
+  # Handle cases where collection of `y_vals` is invariant
   if (y_scale_min == y_scale_max && is.null(expand_y)) {
 
+    if (y_scale_min == 0) {
+      expand_y_dist <- 5
+    } else {
+      expand_y_dist <- (y_scale_min / 10) * 2
+    }
+
     # Expand the `y` scale, centering around the `y_scale_min` value
-    expand_y_dist <- (y_scale_min / 10) * 2
     expand_y <- c(y_scale_min - expand_y_dist, y_scale_min + expand_y_dist)
   }
 


### PR DESCRIPTION
This change addresses a situation where all `y` values in a plot are zero. Previously, we'd handled the situation where all `y` values are the same and addressed the scale issue by centering the horizontal value between y limits that were (+/-)20% about the `y` values. For the all-zero case, this calculation results in upper/lower y scale limits that are zero, making the display look poor.

Fixes: https://github.com/rstudio/gt/issues/1486
  