### PR TITLE
Resolve Issue 1416

### DIFF
--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -51,17 +51,30 @@ footnote_mark_to_latex <- function(
     spec <- "^i"
   }
 
-  if (grepl("\\.", spec)) mark <- paste0(mark, ".")
-  if (grepl("b", spec)) mark <- paste0("\\textbf{", mark, "}")
-  if (grepl("i", spec)) mark <- paste0("\\textit{", mark, "}")
-  if (grepl("\\(|\\[", spec)) mark <- paste0("(", mark)
-  if (grepl("\\)|\\]", spec)) mark <- paste0(mark, ")")
+  if (grepl("\\.", spec)) mark <- sprintf_unless_na("%s.", mark)
+  if (grepl("b", spec)) mark <- sprintf_unless_na("\\textbf{%s}", mark)
+  if (grepl("i", spec)) mark <- sprintf_unless_na("\\textit{%s}", mark)
+  if (grepl("\\(|\\[", spec)) mark <- sprintf_unless_na("(%s", mark)
+  if (grepl("\\)|\\]", spec)) mark <- sprintf_unless_na("%s)", mark)
 
   if (grepl("\\^", spec)) {
-    mark <- paste0("\\textsuperscript{", mark, "}")
+    mark <- sprintf_unless_na("\\textsuperscript{%s}", mark)
   }
 
+  mark[is.na(mark)] <- ""
+
   mark
+}
+
+#' @noRd
+sprintf_unless_na <- function(fmt, x) {
+
+  ifelse(
+    is.na(x),
+    NA_character_,
+    sprintf(fmt, as.character(x))
+  )
+
 }
 
 #' @noRd

--- a/tests/testthat/_snaps/tab_footnote.md
+++ b/tests/testthat/_snaps/tab_footnote.md
@@ -204,7 +204,7 @@
     Code
       .
     Output
-      [1] "\\setlength{\\LTpost}{0mm}\n\\begin{longtable}{rlcrrrrll}\n\\toprule\nnum & char & fctr & date & time & datetime & currency & row & group \\\\ \n\\midrule\\addlinespace[2.5pt]\n\\textsuperscript{\\textit{1}} 0.1111 & apricot & one & 2015-01-15 & 13:35 & 2018-01-01 02:22 & 49.95 & row\\_1 & grp\\_a \\\\ \n\\bottomrule\n\\end{longtable}\n\\begin{minipage}{\\linewidth}\n\\textsuperscript{\\textit{NA}}A footnote.\\\\\n\\textsuperscript{\\textit{1}}A footnote.\\\\\n\\end{minipage}\n"
+      [1] "\\setlength{\\LTpost}{0mm}\n\\begin{longtable}{rlcrrrrll}\n\\toprule\nnum & char & fctr & date & time & datetime & currency & row & group \\\\ \n\\midrule\\addlinespace[2.5pt]\n\\textsuperscript{\\textit{1}} 0.1111 & apricot & one & 2015-01-15 & 13:35 & 2018-01-01 02:22 & 49.95 & row\\_1 & grp\\_a \\\\ \n\\bottomrule\n\\end{longtable}\n\\begin{minipage}{\\linewidth}\nA footnote.\\\\\n\\textsuperscript{\\textit{1}}A footnote.\\\\\n\\end{minipage}\n"
 
 ---
 
@@ -301,7 +301,7 @@
     Code
       .
     Output
-      [1] "\\setlength{\\LTpost}{0mm}\n\\begin{longtable}{rlcrrrrll}\n\\toprule\nnum & char & fctr & date & time & datetime & currency & row & group \\\\ \n\\midrule\\addlinespace[2.5pt]\n\\textsuperscript{\\textit{1}} 0.1111 & apricot & one & 2015-01-15 & 13:35 & 2018-01-01 02:22 & 49.95 & row\\_1 & grp\\_a \\\\ \n\\bottomrule\n\\end{longtable}\n\\begin{minipage}{\\linewidth}\n\\textsuperscript{\\textit{NA}}A footnote. \\textsuperscript{\\textit{NA}}A second footnote. \\textsuperscript{\\textit{1}}location note\\\\\n\\end{minipage}\n"
+      [1] "\\setlength{\\LTpost}{0mm}\n\\begin{longtable}{rlcrrrrll}\n\\toprule\nnum & char & fctr & date & time & datetime & currency & row & group \\\\ \n\\midrule\\addlinespace[2.5pt]\n\\textsuperscript{\\textit{1}} 0.1111 & apricot & one & 2015-01-15 & 13:35 & 2018-01-01 02:22 & 49.95 & row\\_1 & grp\\_a \\\\ \n\\bottomrule\n\\end{longtable}\n\\begin{minipage}{\\linewidth}\nA footnote. A second footnote. \\textsuperscript{\\textit{1}}location note\\\\\n\\end{minipage}\n"
 
 ---
 


### PR DESCRIPTION
# Summary

When creating tables in LaTeX, if there are multiple footnotes, footnotes without an explicit superscript are preceded by "\\textsuperscript{NA}" when rendered.  This pull request removes these NAs.

The change replaces a series of `paste0` calls with calls to a new function, `sprintf_unless_na`, that returns an NA_character_ when an NA is passed to the function.  (I switched from `paste0` to `sprintf` because it's slightly more streamlined -- using `paste0` would have required three arguments be passed each time.)

The existing tests are sufficient to cover this pull request, though the snapshots for three tests have to be modified to show results without NA's preceding the unnumbered footnotes.  Those modifications are included in the pull request.

I'm assuming this is a 

# Related GitHub Issues and PRs

- Ref: #1416 

# Checklist

- [ x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.


Fixes: https://github.com/rstudio/gt/issues/1416