### PR TITLE
Allow for nanoplot output of horizontal bars 

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2760,6 +2760,18 @@ cols_nanoplot <- function(
     options_plots <- options
   }
 
+  # Get all `y` vals into a vector
+  all_y_vals <- unlist(data_vals_plot_y)
+
+  # Get all `y` vals from single-valued components of `data_vals_plot_y`
+  # into a vector
+  all_single_y_vals <- c()
+  for (i in seq_along(data_vals_plot_y)) {
+    if (length(data_vals_plot_y[[i]]) == 1 && !is.na(data_vals_plot_y[[i]])) {
+      all_single_y_vals <- c(all_single_y_vals, data_vals_plot_y[[i]])
+    }
+  }
+
   # Automatically apply `expand_x` and `expand_y` values as necessary if
   # `autoscale` has been set to TRUE
   if (autoscale) {

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2811,6 +2811,8 @@ cols_nanoplot <- function(
         expand_x = expand_x,
         expand_y = expand_y,
         missing_vals = missing_vals,
+        all_y_vals = all_y_vals,
+        all_single_y_vals = all_single_y_vals,
         plot_type = plot_type,
         line_type = options_plots$data_line_type,
         currency = options_plots$currency,

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2672,6 +2672,7 @@ cols_nanoplot <- function(
     plot_type = c("line", "bar"),
     plot_height = "2em",
     missing_vals = c("gap", "zero", "remove"),
+    autoscale = FALSE,
     columns_x_vals = NULL,
     reference_line = NULL,
     reference_area = NULL,

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2776,7 +2776,6 @@ cols_nanoplot <- function(
   # `autoscale` has been set to TRUE
   if (autoscale) {
 
-    all_y_vals <- unlist(data_vals_plot_y)
     min_y_vals <- min(all_y_vals, na.rm = TRUE)
     max_y_vals <- max(all_y_vals, na.rm = TRUE)
     expand_y <- c(min_y_vals, max_y_vals)

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2750,6 +2750,24 @@ cols_nanoplot <- function(
     options_plots <- options
   }
 
+  # Automatically apply `expand_x` and `expand_y` values as necessary if
+  # `autoscale` has been set to TRUE
+  if (autoscale) {
+
+    all_y_vals <- unlist(data_vals_plot_y)
+    min_y_vals <- min(all_y_vals, na.rm = TRUE)
+    max_y_vals <- max(all_y_vals, na.rm = TRUE)
+    expand_y <- c(min_y_vals, max_y_vals)
+
+    if (!is.null(data_vals_plot_x)) {
+
+      all_x_vals <- unlist(data_vals_plot_x)
+      min_x_vals <- min(all_x_vals, na.rm = TRUE)
+      max_x_vals <- max(all_x_vals, na.rm = TRUE)
+      expand_x <- c(min_x_vals, max_x_vals)
+    }
+  }
+
   # Initialize vector that will contain the nanoplots
   nanoplots <- c()
 

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2237,6 +2237,16 @@ cols_add <- function(
 #'   (2) `"zero"` will replace `NA` values with zero values; and (3) `"remove"`
 #'   will remove any incoming `NA` values.
 #'
+#' @param autoscale *Automatically set x- and y-axis scale limits based on data*
+#'
+#'   `scalar<logical>` // *default:* `FALSE`
+#'
+#'   Using `autoscale = TRUE` will ensure that the bounds of all nanoplots
+#'   produced are based on the limits of data combined from all input rows. This
+#'   will result in a shared scale across all of the nanoplots (for *y*- and
+#'   *x*-axis data), which is useful in those cases where the nanoplot data
+#'   should be compared across rows.
+#'
 #' @param columns_x_vals *Columns containing values for the optional x variable*
 #'
 #'   `<column-targeting expression>` // *default:* `NULL` (`optional`)

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -30,6 +30,8 @@ generate_nanoplot <- function(
     expand_x = NULL,
     expand_y = NULL,
     missing_vals = c("gap", "zero", "remove"),
+    all_y_vals = NULL,
+    all_single_y_vals = NULL,
     plot_type = c("line", "bar"),
     line_type = c("curved", "straight"),
     currency = NULL,

--- a/man/cols_nanoplot.Rd
+++ b/man/cols_nanoplot.Rd
@@ -11,6 +11,7 @@ cols_nanoplot(
   plot_type = c("line", "bar"),
   plot_height = "2em",
   missing_vals = c("gap", "zero", "remove"),
+  autoscale = FALSE,
   columns_x_vals = NULL,
   reference_line = NULL,
   reference_area = NULL,
@@ -85,6 +86,16 @@ strategies available for their handling: (1) \code{"gap"} will display data gaps
 at the sites of missing data, where data lines will have discontinuities;
 (2) \code{"zero"} will replace \code{NA} values with zero values; and (3) \code{"remove"}
 will remove any incoming \code{NA} values.}
+
+\item{autoscale}{\emph{Automatically set x- and y-axis scale limits based on data}
+
+\verb{scalar<logical>} // \emph{default:} \code{FALSE}
+
+Using \code{autoscale = TRUE} will ensure that the bounds of all nanoplots
+produced are based on the limits of data combined from all input rows. This
+will result in a shared scale across all of the nanoplots (for \emph{y}- and
+\emph{x}-axis data), which is useful in those cases where the nanoplot data
+should be compared across rows.}
 
 \item{columns_x_vals}{\emph{Columns containing values for the optional x variable}
 


### PR DESCRIPTION
This allows for single line bar plots in `cols_nanoplot()`. If the `plot_type` is set to `"bar"` and single values are found, then horizontal bars will be generated. With single bars, the width is meaningless unless compared against other single values found across other rows. If there is a combination of single values and multiple values within the collection of rows, the single-value bar plots will only be proportional to the other single values (i.e., the different plot views won't interfere with each other).

Here is a simple example:

```r
library(tidyverse)
library(gt)

dplyr::tibble(
  a = c(4.6, 0.2, 5.6, 6.3, 0, NA)
) %>%
  gt() %>%
  cols_nanoplot(columns = a, plot_type = "bar")
```
<img width="1486" alt="barplot-nanoplot" src="https://github.com/rstudio/gt/assets/5612024/0a45c750-7be6-4a5f-9def-f4684c142607">

This also adds the `autoscale` arg so that plots can have a shared `y` and even `x` scale. 