### PR TITLE
Positive and negative horizontal-barplot nanoplots

### DIFF
--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -1125,10 +1125,6 @@ generate_nanoplot <- function(
       )
   }
 
-  if (plot_type == "bar" && single_horizontal_bar) {
-    zero_line_tags <- ""
-  }
-
   #
   # Generate reference line
   #

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -1080,6 +1080,22 @@ generate_nanoplot <- function(
         ">",
         "</rect>"
       )
+
+    stroke <- "#BFBFBF"
+    stroke_width <- 5
+
+    zero_line_tags <-
+      paste0(
+        "<line ",
+        "x1=\"", y0_width, "\" ",
+        "y1=\"", (bottom_y / 2) - (bar_thickness * 1.5), "\" ",
+        "x2=\"", y0_width, "\" ",
+        "y2=\"", (bottom_y / 2) + (bar_thickness * 1.5), "\" ",
+        "stroke=\"", stroke, "\" ",
+        "stroke-width=\"", stroke_width, "\" ",
+        ">",
+        "</line>"
+      )
   }
 
   #

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -223,7 +223,7 @@ generate_nanoplot <- function(
   # number of data points)
   if (!is.null(x_vals) || single_horizontal_bar) {
 
-    data_x_width <- 500
+    data_x_width <- 600
 
   } else {
 

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -1009,7 +1009,9 @@ generate_nanoplot <- function(
 
   if (plot_type == "bar" && single_horizontal_bar) {
 
-    # TODO: This type of display assumes there is only a single `y` value
+    # This type of display assumes there is only a single `y` value and there
+    # are possibly several such horizontal bars across different rows that
+    # need to be on a common scale
 
     bar_thickness <- data_point_radius[1] * 2
 

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -1013,7 +1013,7 @@ generate_nanoplot <- function(
     # are possibly several such horizontal bars across different rows that
     # need to be on a common scale
 
-    bar_thickness <- data_point_radius[1] * 2
+    bar_thickness <- data_point_radius[1] * 4
 
     # Scale to proportional values
     y_proportions_list <-

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -965,15 +965,20 @@ generate_nanoplot <- function(
       } else {
 
         if (y_vals[i] < 0) {
+
           y_value_i <- data_y0_point
           y_height <- data_y_points[i] - data_y0_point
           data_bar_stroke_color_i <- data_bar_negative_stroke_color[1]
           data_bar_stroke_width_i <- data_bar_negative_stroke_width[1]
           data_bar_fill_color_i <- data_bar_negative_fill_color[1]
+
         } else if (y_vals[i] > 0) {
+
           y_value_i <- data_y_points[i]
           y_height <- data_y0_point - data_y_points[i]
+
         } else if (y_vals[i] == 0) {
+
           y_value_i <- data_y0_point - 1
           y_height <- 2
           data_bar_stroke_color_i <- "#808080"

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -1096,6 +1096,10 @@ generate_nanoplot <- function(
         ">",
         "</line>"
       )
+
+    # Redefine the `viewbox` in terms of the `data_x_width` value; this ensures
+    # that the horizontal bars are centered about their extreme values
+    viewbox <- paste(left_x, top_y, data_x_width, bottom_y, collapse = " ")
   }
 
   #

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -1040,26 +1040,39 @@ generate_nanoplot <- function(
     y_width <- y_proportion * data_x_width
 
     if (y_vals[1] < 0) {
+
       data_bar_stroke_color <- data_bar_negative_stroke_color[1]
       data_bar_stroke_width <- data_bar_negative_stroke_width[1]
       data_bar_fill_color <- data_bar_negative_fill_color[1]
+
+      rect_x <- y_width
+      rect_width <- y0_width - y_width
+
     } else if (y_vals[1] > 0) {
+
       data_bar_stroke_color <- data_bar_stroke_color[1]
       data_bar_stroke_width <- data_bar_stroke_width[1]
       data_bar_fill_color <- data_bar_fill_color[1]
+
+      rect_x <- y0_width
+      rect_width <- y_width - y0_width
+
     } else if (y_vals[1] == 0) {
-      y_width <- 5
+
       data_bar_stroke_color <- "#808080"
       data_bar_stroke_width <- 4
       data_bar_fill_color <- "#808080"
+
+      rect_x <- y0_width - 2.5
+      rect_width <- 5
     }
 
     bar_tags <-
       paste0(
         "<rect ",
-        "x=\"", 5, "\" ",
+        "x=\"", rect_x, "\" ",
         "y=\"", (bottom_y / 2) - (bar_thickness / 2), "\" ",
-        "width=\"", y_width, "\" ",
+        "width=\"", rect_width, "\" ",
         "height=\"", bar_thickness, "\" ",
         "stroke=\"", data_bar_stroke_color, "\" ",
         "stroke-width=\"", data_bar_stroke_width, "\" ",

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -1015,19 +1015,28 @@ generate_nanoplot <- function(
 
     bar_thickness <- data_point_radius[1] * 4
 
-    # Scale to proportional values
-    y_proportions_list <-
-      normalize_to_list(
-        val = y_vals,
-        all_vals = all_single_y_vals,
-        zero = 0
-      )
+    if (all(all_single_y_vals == 0)) {
 
-    y_proportion <- y_proportions_list[["val"]]
-    y_proportion_zero <- y_proportions_list[["zero"]]
+      # Handle case where all values across rows are `0`
+
+      y_proportion <- 0.5
+      y_proportion_zero <- 0.5
+
+    } else {
+
+      # Scale to proportional values
+      y_proportions_list <-
+        normalize_to_list(
+          val = y_vals,
+          all_vals = all_single_y_vals,
+          zero = 0
+        )
+
+      y_proportion <- y_proportions_list[["val"]]
+      y_proportion_zero <- y_proportions_list[["zero"]]
+    }
 
     y0_width <- y_proportion_zero * data_x_width
-
     y_width <- y_proportion * data_x_width
 
     if (y_vals[1] < 0) {


### PR DESCRIPTION
The changes here allow for nanoplots that are essentially single-valued bars (when `plot_type = "bar"` and there is just a single value to plot) to display in positive and negative directions. A zero-value line marker is now displayed. Negative values have a different color (obtained from the `data_bar_negative_stroke_color` arg in `nanoplot_options()`) and other settable display attributes.

Here are some examples:

```r
library(tidyverse)
library(gt)

# Positive, zero-value, NA
dplyr::tibble(
  a = c(4.6, 0.2, 5.6, 6.3, 0, NA)
) |>
  gt() |>
  cols_nanoplot(columns = a, plot_type = "bar") |>
  tab_style(
    style = cell_borders(sides = c("left", "right"), weight = "2px"),
    locations = cells_body(columns = nanoplots)
  )
```
<img width="911" alt="example-1" src="https://github.com/rstudio/gt/assets/5612024/b0166448-e3a1-468b-813e-a2aeccfde777">


```r
# Negative, zero-value, NA
dplyr::tibble(
  a = c(-4.6, -0.2, -5.6, -6.3, 0, NA)
) |>
  gt() |>
  cols_nanoplot(columns = a, plot_type = "bar") |>
  tab_style(
    style = cell_borders(sides = c("left", "right"), weight = "2px"),
    locations = cells_body(columns = nanoplots)
  )
```
<img width="910" alt="example-2" src="https://github.com/rstudio/gt/assets/5612024/1ed63c4b-9ebb-4270-a504-ca7f917733db">


```r
# Positive, zero-value, negative 
dplyr::tibble(
  a = c(-20, -10, 0, 10, 5)
) |>
  gt() |>
  cols_nanoplot(columns = a, plot_type = "bar") |>
  tab_style(
    style = cell_borders(sides = c("left", "right"), weight = "2px"),
    locations = cells_body(columns = nanoplots)
  )
```
<img width="911" alt="example-3" src="https://github.com/rstudio/gt/assets/5612024/e56be8d2-5667-403e-831e-1802c7f8a1e0">

```r
# All zero nanoplots
dplyr::tibble(
  a = c(0, 0, 0, 0, 0)
) |>
  gt() |>
  cols_nanoplot(columns = a, plot_type = "bar") |>
  tab_style(
    style = cell_borders(sides = c("left", "right"), weight = "2px"),
    locations = cells_body(columns = nanoplots)
  )
```
<img width="911" alt="example-4" src="https://github.com/rstudio/gt/assets/5612024/85c67309-a66d-4c5d-a7ed-c54273de0b2b">

```r
# Constant non-zero value (positive)
dplyr::tibble(
  a = c(5, 5, 5, 5, 5)
) |>
  gt() |>
  cols_nanoplot(columns = a, plot_type = "bar") |>
  tab_style(
    style = cell_borders(sides = c("left", "right"), weight = "2px"),
    locations = cells_body(columns = nanoplots)
  )
```
<img width="910" alt="example-5" src="https://github.com/rstudio/gt/assets/5612024/f3f1346f-9cd9-4405-8b8d-7253f96c5244">

```r
# Constant non-zero value (negative)
dplyr::tibble(
  a = c(-5, -5, -5, -5, -5)
) |>
  gt() |>
  cols_nanoplot(columns = a, plot_type = "bar") |>
  tab_style(
    style = cell_borders(sides = c("left", "right"), weight = "2px"),
    locations = cells_body(columns = nanoplots)
  )
```
<img width="911" alt="example-6" src="https://github.com/rstudio/gt/assets/5612024/8aca9fd1-b5bd-4538-b341-c6f265986bd9">

```r
# Single value bars combined with multiple bars
dplyr::tibble(
  a = c(4.6, 0.2, 5.6, "3.4,-2.4,7.8,1.2,-6.8,0,2.4,-7.4,5.2", 6.3, 0, NA)
) |>
  gt() |>
  cols_nanoplot(columns = a, plot_type = "bar") |>
  tab_style(
    style = cell_borders(sides = c("left", "right"), weight = "2px"),
    locations = cells_body(columns = nanoplots)
  )
```
<img width="914" alt="example-7" src="https://github.com/rstudio/gt/assets/5612024/8e8cabd0-a5a4-4ca4-880e-37a74b2753b5">

