### PR TITLE
Add hoverable data values for single-bar nanoplots

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -735,6 +735,19 @@ currency <- function(
 #'   nanoplot. This hidden layer is active by default but can be deactivated by
 #'   using `show_y_axis_guide = FALSE`.
 #'
+#' @param interactive_data_values *Should data values be interactively shown?*
+#'
+#'   `scalar<logical>` // *default:* `NULL` (`optional`)
+#'
+#'   By default, numeric data values will be shown only when the user interacts
+#'   with certain regions of a nanoplot. This is because the values may be
+#'   numerous (i.e., clutter the display when all are visible) and it can be
+#'   argued that the values themselves are secondary to the presentation.
+#'   However, for some types of plots (like horizontal bar plots), a persistent
+#'   display of values alongside the plot marks may be desirable. By setting
+#'   `interactive_data_values = FALSE` we can opt for always displaying the data
+#'   values alongside the plot components.
+#'
 #' @param y_val_fmt_fn,y_axis_fmt_fn,y_ref_line_fmt_fn *Custom formatting for y values*
 #'
 #'   `function` // *default:* `NULL` (`optional`)
@@ -791,6 +804,7 @@ nanoplot_options <- function(
     show_reference_area = NULL,
     show_vertical_guides = NULL,
     show_y_axis_guide = NULL,
+    interactive_data_values = NULL,
     y_val_fmt_fn = NULL,
     y_axis_fmt_fn = NULL,
     y_ref_line_fmt_fn = NULL,
@@ -815,19 +829,20 @@ nanoplot_options <- function(
   data_bar_negative_fill_color   <- data_bar_negative_fill_color %||% "#D75A68"
 
   reference_line_color      <- reference_line_color %||% "#75A8B0"
-  reference_area_fill_color <- reference_area_fill_color%||% "#A6E6F2"
+  reference_area_fill_color <- reference_area_fill_color %||% "#A6E6F2"
 
   vertical_guide_stroke_color <- vertical_guide_stroke_color %||% "#911EB4"
   vertical_guide_stroke_width <- vertical_guide_stroke_width %||% 12
 
   show_data_points <- show_data_points %||% TRUE
-  show_data_line   <- show_data_line %||% TRUE
-  show_data_area   <- show_data_area %||% TRUE
-
-  show_reference_line  <- show_reference_line %||% TRUE
-  show_reference_area  <- show_reference_area %||% TRUE
+  show_data_line <- show_data_line %||% TRUE
+  show_data_area <- show_data_area %||% TRUE
+  show_reference_line <- show_reference_line %||% TRUE
+  show_reference_area <- show_reference_area %||% TRUE
   show_vertical_guides <- show_vertical_guides %||% TRUE
-  show_y_axis_guide    <- show_y_axis_guide %||% TRUE
+  show_y_axis_guide <- show_y_axis_guide %||% TRUE
+
+  interactive_data_values <- interactive_data_values %||% TRUE
 
   # y_val_fmt_fn, y_axis_fmt_fn, and y_ref_line_fmt_fn
   # are not assigned to a default value
@@ -860,6 +875,7 @@ nanoplot_options <- function(
       show_reference_area = show_reference_area,
       show_vertical_guides = show_vertical_guides,
       show_y_axis_guide = show_y_axis_guide,
+      interactive_data_values = interactive_data_values,
       y_val_fmt_fn = y_val_fmt_fn,
       y_axis_fmt_fn = y_axis_fmt_fn,
       y_ref_line_fmt_fn = y_ref_line_fmt_fn,

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2842,6 +2842,7 @@ cols_nanoplot <- function(
         show_ref_area = options_plots$show_reference_area,
         show_vertical_guides = options_plots$show_vertical_guides,
         show_y_axis_guide = options_plots$show_y_axis_guide,
+        interactive_data_values = options_plots$interactive_data_values,
         svg_height = plot_height
       )
 

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -1067,6 +1067,96 @@ generate_nanoplot <- function(
       rect_width <- 5
     }
 
+    # Format number compactly
+    y_value <-
+      format_number_compactly(
+        val = y_vals,
+        currency = currency,
+        as_integer = y_vals_integerlike,
+        fn = y_val_fmt_fn
+      )
+
+    rect_strings <-
+      paste0(
+        "<rect ",
+        "x=\"", 0, "\" ",
+        "y=\"", (bottom_y / 2) - (bar_thickness / 2), "\" ",
+        "width=\"600\" ",
+        "height=\"", bar_thickness, "\" ",
+        "stroke=\"transparent\" ",
+        "stroke-width=\"", vertical_guide_stroke_width, "\" ",
+        "fill=\"transparent\"",
+        ">",
+        "</rect>"
+      )
+
+    if (y_vals[1] > 0) {
+
+      text_strings <-
+        paste0(
+          "<text ",
+          "x=\"", y0_width + 10, "\" ",
+          "y=\"", safe_y_d + 10, "\" ",
+          "fill=\"transparent\" ",
+          "stroke=\"transparent\" ",
+          "font-size=\"", "30px", "\"",
+          ">",
+          y_value,
+          "</text>"
+        )
+
+    } else if (y_vals[1] < 0) {
+
+      text_strings <-
+        paste0(
+          "<text ",
+          "x=\"", y0_width - 10, "\" ",
+          "y=\"", safe_y_d + 10, "\" ",
+          "fill=\"transparent\" ",
+          "stroke=\"transparent\" ",
+          "font-size=\"30px\" ",
+          "text-anchor=\"end\"",
+          ">",
+          y_value,
+          "</text>"
+        )
+
+    } else if (y_vals[1] == 0) {
+
+      if (all(all_single_y_vals == 0)) {
+        text_anchor <- "start"
+        x_position_text <- y0_width + 10
+      } else if (all(all_single_y_vals <= 0)) {
+        text_anchor <- "end"
+        x_position_text <- y0_width - 10
+      } else {
+        text_anchor <- "start"
+        x_position_text <- y0_width + 10
+      }
+
+      text_strings <-
+        paste0(
+          "<text ",
+          "x=\"", x_position_text, "\" ",
+          "y=\"", (bottom_y / 2) + 10, "\" ",
+          "fill=\"transparent\" ",
+          "stroke=\"transparent\" ",
+          "font-size=\"", "30px", "\" ",
+          "text-anchor=\"", text_anchor, "\"",
+          ">",
+          y_value,
+          "</text>"
+        )
+    }
+
+    g_guide_tags <-
+      paste0(
+        "<g class=\"horizontal-line\">\n",
+        rect_strings, "\n",
+        text_strings,
+        "</g>"
+      )
+
     bar_tags <-
       paste0(
         "<rect ",
@@ -1379,6 +1469,15 @@ generate_nanoplot <- function(
           "color: red; ",
           "} ",
           ".vert-line:hover text { ",
+          "stroke: white; ",
+          "fill: #212427; ",
+          "} ",
+          ".horizontal-line:hover rect { ",
+          "fill: transparent; ",
+          "stroke: transparent; ",
+          "color: blue; ",
+          "} ",
+          ".horizontal-line:hover text { ",
           "stroke: white; ",
           "fill: #212427; ",
           "} ",

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -61,6 +61,7 @@ generate_nanoplot <- function(
     show_ref_area = TRUE,
     show_vertical_guides = TRUE,
     show_y_axis_guide = TRUE,
+    interactive_data_values = TRUE,
     svg_height = "2em",
     view = FALSE
 ) {
@@ -1468,7 +1469,7 @@ generate_nanoplot <- function(
           "stroke: #FFFFFF60; ",
           "color: red; ",
           "} ",
-          ".vert-line:hover text { ",
+          ".horizontal-line:hover text { ",
           "stroke: white; ",
           "fill: #212427; ",
           "} ",
@@ -1477,7 +1478,7 @@ generate_nanoplot <- function(
           "stroke: transparent; ",
           "color: blue; ",
           "} ",
-          ".horizontal-line:hover text { ",
+          ".horizontal-line", ifelse(interactive_data_values, ":hover", ""), " text { ",
           "stroke: white; ",
           "fill: #212427; ",
           "} ",

--- a/man/nanoplot_options.Rd
+++ b/man/nanoplot_options.Rd
@@ -29,6 +29,7 @@ nanoplot_options(
   show_reference_area = NULL,
   show_vertical_guides = NULL,
   show_y_axis_guide = NULL,
+  interactive_data_values = NULL,
   y_val_fmt_fn = NULL,
   y_axis_fmt_fn = NULL,
   y_ref_line_fmt_fn = NULL,
@@ -235,6 +236,19 @@ active by default but can be deactivated by using
 The \emph{y}-axis guide will appear when hovering over the far left side of a
 nanoplot. This hidden layer is active by default but can be deactivated by
 using \code{show_y_axis_guide = FALSE}.}
+
+\item{interactive_data_values}{\emph{Should data values be interactively shown?}
+
+\verb{scalar<logical>} // \emph{default:} \code{NULL} (\code{optional})
+
+By default, numeric data values will be shown only when the user interacts
+with certain regions of a nanoplot. This is because the values may be
+numerous (i.e., clutter the display when all are visible) and it can be
+argued that the values themselves are secondary to the presentation.
+However, for some types of plots (like horizontal bar plots), a persistent
+display of values alongside the plot marks may be desirable. By setting
+\code{interactive_data_values = FALSE} we can opt for always displaying the data
+values alongside the plot components.}
 
 \item{y_val_fmt_fn, y_axis_fmt_fn, y_ref_line_fmt_fn}{\emph{Custom formatting for y values}
 


### PR DESCRIPTION
This PR makes single-bar nanoplots display their values on hover. As these types of nanoplots can have a mix of positive, negative, and zero-value bars, it was important to ensure that the compactly-formatted data values are affixed to the zero-line, with the text anchored on the appropriate side. Zero value labels were adjusted to lie in a more central position (since there is no bar). The user could hover virtually anywhere in the cell and the value will then appear (i.e., the hover area is large for convenience).

Here we also add the `interactive_data_values` argument to the `nanoplot_options()` function. This allows for having persistent data values shown on the single-bar nanoplots. This may be desirable in some cases since there is only a single value per nanoplot (i.e., clutter won't be an issue) and having a compactly formatted value present is commonly seen in bar plots.

Here is an example of this:

```r
dplyr::tibble(
  a = c(-20, -10, 0, 10, 5)
) |>
  gt() |>
  cols_nanoplot(
    columns = a,
    plot_type = "bar",
    options = nanoplot_options(
      data_bar_negative_fill_color = "lightblue",
      data_bar_fill_color = "lightgreen",
      data_bar_stroke_color = "forestgreen",
      data_bar_negative_stroke_color = "steelblue",
      interactive_data_values = FALSE
    )
  ) |>
  tab_style(
    style = cell_borders(sides = c("left", "right"), weight = "2px"),
    locations = cells_body(columns = nanoplots)
  )
```

<img width="1075" alt="nanoplot-single-bars-static-values" src="https://github.com/rstudio/gt/assets/5612024/fe62f62e-46b6-4e7d-990a-0d6c495c4bc7">

If that option is unset or `TRUE` (i.e., the default display) we get this:

<img width="886" alt="nanoplot-single-bars-values" src="https://github.com/rstudio/gt/assets/5612024/9094b776-8c2d-4362-b18e-a907812770a0">

where the screenshot was taken while hovering over the second nanoplot.

Fixes: https://github.com/rstudio/gt/issues/1517
