### PR TITLE
Possible performance improvement - call `utils::packageVersion` only once

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -571,7 +571,9 @@ get_markdown_engine_fn <- function(
 #' @noRd
 process_text <- function(text, context = "html") {
 
-  md_engine <- gt_package_environment$md_engine
+  # markdown is used to process text globally outside of `fmt_markdown()`
+  # Previously, commonmark was used.
+  md_engine <- "markdown"
 
   # If text is marked `AsIs` (by using `I()`) then just
   # return the text unchanged

--- a/R/utils.R
+++ b/R/utils.R
@@ -571,14 +571,7 @@ get_markdown_engine_fn <- function(
 #' @noRd
 process_text <- function(text, context = "html") {
 
-  # When processing text globally (outside of the `fmt_markdown()`
-  # function) we will use the 'markdown' package if it is available,
-  # otherwise the 'commonmark' package
-  if (utils::packageVersion("markdown") >= "1.5") {
-    md_engine <- "markdown"
-  } else {
-    md_engine <- "commonmark"
-  }
+  md_engine <- gt_package_environment$md_engine
 
   # If text is marked `AsIs` (by using `I()`) then just
   # return the text unchanged
@@ -598,6 +591,7 @@ process_text <- function(text, context = "html") {
 
     if (inherits(text, "from_markdown")) {
 
+      # could this be cached too?
       md_engine_fn <-
         get_markdown_engine_fn(
           md_engine_pref = md_engine,

--- a/R/utils.R
+++ b/R/utils.R
@@ -593,7 +593,6 @@ process_text <- function(text, context = "html") {
 
     if (inherits(text, "from_markdown")) {
 
-      # could this be cached too?
       md_engine_fn <-
         get_markdown_engine_fn(
           md_engine_pref = md_engine,

--- a/R/utils.R
+++ b/R/utils.R
@@ -571,6 +571,10 @@ get_markdown_engine_fn <- function(
 #' @noRd
 process_text <- function(text, context = "html") {
 
+  # `markdown` is used to process text globally outside of `fmt_markdown()`
+  # Previously, `commonmark` was used.
+  md_engine <- "markdown"
+
   # If text is marked `AsIs` (by using `I()`) then just
   # return the text unchanged
   if (inherits(text, "AsIs")) {
@@ -589,11 +593,9 @@ process_text <- function(text, context = "html") {
 
     if (inherits(text, "from_markdown")) {
 
-      # `markdown` is used to process text globally outside of `fmt_markdown()`
-      # Previously, `commonmark` was used.
       md_engine_fn <-
         get_markdown_engine_fn(
-          md_engine_pref = "markdown",
+          md_engine_pref = md_engine,
           context = "html"
         )
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -571,10 +571,6 @@ get_markdown_engine_fn <- function(
 #' @noRd
 process_text <- function(text, context = "html") {
 
-  # markdown is used to process text globally outside of `fmt_markdown()`
-  # Previously, commonmark was used.
-  md_engine <- "markdown"
-
   # If text is marked `AsIs` (by using `I()`) then just
   # return the text unchanged
   if (inherits(text, "AsIs")) {
@@ -593,9 +589,11 @@ process_text <- function(text, context = "html") {
 
     if (inherits(text, "from_markdown")) {
 
+      # `markdown` is used to process text globally outside of `fmt_markdown()`
+      # Previously, `commonmark` was used.
       md_engine_fn <-
         get_markdown_engine_fn(
-          md_engine_pref = md_engine,
+          md_engine_pref = "markdown",
           context = "html"
         )
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -196,8 +196,6 @@ gt_default_options <-
 # Example: gsub("a", "\u00B1", "a", fixed = TRUE)
 utf8_aware_sub <- NULL
 
-gt_package_environment <- new.env()
-
 .onLoad <- function(libname, pkgname, ...) {
 
   register_s3_method("knitr", "knit_print", "gt_tbl")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -208,14 +208,6 @@ gt_package_environment <- new.env()
   toset <- !(names(gt_default_options) %in% names(op))
   if (any(toset)) options(gt_default_options[toset])
 
-  # When processing text globally (outside of the `fmt_markdown()`
-  # function) we will use the 'markdown' package if it is available,
-  # otherwise the 'commonmark' package
-  gt_package_environment$md_engine <- "commonmark"
-  if (utils::packageVersion("markdown") >= "1.5") {
-    md_engine <- "markdown"
-  }
-       
   utf8_aware_sub <<-
     identical(
       "UTF-8",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -208,7 +208,7 @@ gt_package_environment <- new.env()
   toset <- !(names(gt_default_options) %in% names(op))
   if (any(toset)) options(gt_default_options[toset])
 
-  When processing text globally (outside of the `fmt_markdown()`
+  # When processing text globally (outside of the `fmt_markdown()`
   # function) we will use the 'markdown' package if it is available,
   # otherwise the 'commonmark' package
   gt_package_environment$md_engine <- "commonmark"

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -196,6 +196,8 @@ gt_default_options <-
 # Example: gsub("a", "\u00B1", "a", fixed = TRUE)
 utf8_aware_sub <- NULL
 
+gt_package_environment <- new.env()
+
 .onLoad <- function(libname, pkgname, ...) {
 
   register_s3_method("knitr", "knit_print", "gt_tbl")
@@ -206,6 +208,14 @@ utf8_aware_sub <- NULL
   toset <- !(names(gt_default_options) %in% names(op))
   if (any(toset)) options(gt_default_options[toset])
 
+  When processing text globally (outside of the `fmt_markdown()`
+  # function) we will use the 'markdown' package if it is available,
+  # otherwise the 'commonmark' package
+  gt_package_environment$md_engine <- "commonmark"
+  if (utils::packageVersion("markdown") >= "1.5") {
+    md_engine <- "markdown"
+  }
+       
   utf8_aware_sub <<-
     identical(
       "UTF-8",


### PR DESCRIPTION
# Summary

Small performance improvement - no longer calls `utils::packageVersion` 

# Related GitHub Issues and PRs

Fixes: [#1524](https://github.com/rstudio/gt/issues/1524)

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] **No new tests added - none needed** I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
