### PR TITLE
Add the `autohide` argument to `cols_nanoplot()`

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2252,6 +2252,15 @@ cols_add <- function(
 #'   *x*-axis data), which is useful in those cases where the nanoplot data
 #'   should be compared across rows.
 #'
+#' @param autohide *Automatically hide the `columns`/`columns_x_vals` column(s)*
+#'
+#'   `scalar<logical>` // *default:* `TRUE`
+#'
+#'   An option to automatically hide any columns specified in `columns` and also
+#'   `columns_x_vals` (if used). Any columns with their state changed to
+#'   'hidden' will behave the same as before, they just won't be displayed in
+#'   the finalized table.
+#'
 #' @param columns_x_vals *Columns containing values for the optional x variable*
 #'
 #'   `<column-targeting expression>` // *default:* `NULL` (`optional`)

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2733,6 +2733,7 @@ cols_nanoplot <- function(
     plot_height = "2em",
     missing_vals = c("gap", "zero", "remove"),
     autoscale = FALSE,
+    autohide = TRUE,
     columns_x_vals = NULL,
     reference_line = NULL,
     reference_area = NULL,

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2987,6 +2987,24 @@ cols_nanoplot <- function(
       locations = cells_body(columns = validated_new_col_name)
     )
 
+  if (isTRUE(autohide)) {
+
+    data <-
+      cols_hide(
+        data = data,
+        columns = resolved_columns
+      )
+
+    if (length(resolved_columns_x) > 0) {
+
+      data <-
+        cols_hide(
+          data = data,
+          columns = resolved_columns_x
+        )
+    }
+  }
+
   data
 }
 

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2259,7 +2259,8 @@ cols_add <- function(
 #'   An option to automatically hide any columns specified in `columns` and also
 #'   `columns_x_vals` (if used). Any columns with their state changed to
 #'   'hidden' will behave the same as before, they just won't be displayed in
-#'   the finalized table.
+#'   the finalized table. Should you want to have these 'input' columns be
+#'   viewable, set `autohide = FALSE`.
 #'
 #' @param columns_x_vals *Columns containing values for the optional x variable*
 #'

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2437,7 +2437,7 @@ cols_add <- function(
 #'   gt(rowname_col = "test") |>
 #'   tab_header("Partial summary of daily tests performed on YF patient") |>
 #'   tab_stubhead(label = md("**Test**")) |>
-#'   cols_hide(columns = c(starts_with("norm"), starts_with("day"))) |>
+#'   cols_hide(columns = starts_with("norm")) |>
 #'   fmt_units(columns = units) |>
 #'   cols_nanoplot(
 #'     columns = starts_with("day"),
@@ -2481,6 +2481,7 @@ cols_add <- function(
 #'   cols_nanoplot(
 #'     columns = c(chicken, classic, supreme, veggie),
 #'     plot_type = "bar",
+#'     autohide = FALSE,
 #'     new_col_name = "pizzas_sold",
 #'     new_col_label = "Sales by Type",
 #'     options = nanoplot_options(
@@ -2521,12 +2522,14 @@ cols_add <- function(
 #'   cols_nanoplot(
 #'     columns = starts_with("population"),
 #'     reference_line = "median",
+#'     autohide = FALSE,
 #'     new_col_name = "population_plot",
 #'     new_col_label = md("*Change*")
 #'   ) |>
 #'   cols_nanoplot(
 #'     columns = starts_with("density"),
 #'     plot_type = "bar",
+#'     autohide = FALSE,
 #'     new_col_name = "density_plot",
 #'     new_col_label = md("*Change*")
 #'   ) |>
@@ -2594,7 +2597,6 @@ cols_add <- function(
 #'       data_bar_fill_color = "DarkOrange"
 #'     )
 #'   ) |>
-#'   cols_hide(columns = matches("0")) |>
 #'   tab_options(
 #'     table.width = px(400),
 #'     column_labels.hidden = TRUE
@@ -2646,7 +2648,6 @@ cols_add <- function(
 #'     title = md("Pizzas sold on **January 1, 2015**"),
 #'     subtitle = "Between the opening hours of 11:30 to 22:30"
 #'   ) |>
-#'   cols_hide(columns = c(date_time, sold)) |>
 #'   cols_nanoplot(
 #'     columns = sold,
 #'     columns_x_vals = date_time,
@@ -2704,7 +2705,7 @@ cols_add <- function(
 #'     plot_type = "boxplot",
 #'     options = nanoplot_options(y_val_fmt_fn = function(x) hms::as_hms(x))
 #'   ) |>
-#'   cols_hide(columns = c(time, is_weekend)) |>
+#'   cols_hide(columns = is_weekend) |>
 #'   cols_width(everything() ~ px(250)) |>
 #'   cols_align(align = "center", columns = nanoplots) |>
 #'   cols_align(align = "left", columns = date) |>

--- a/man/cols_nanoplot.Rd
+++ b/man/cols_nanoplot.Rd
@@ -106,7 +106,8 @@ should be compared across rows.}
 An option to automatically hide any columns specified in \code{columns} and also
 \code{columns_x_vals} (if used). Any columns with their state changed to
 'hidden' will behave the same as before, they just won't be displayed in
-the finalized table.}
+the finalized table. Should you want to have these 'input' columns be
+viewable, set \code{autohide = FALSE}.}
 
 \item{columns_x_vals}{\emph{Columns containing values for the optional x variable}
 

--- a/man/cols_nanoplot.Rd
+++ b/man/cols_nanoplot.Rd
@@ -12,6 +12,7 @@ cols_nanoplot(
   plot_height = "2em",
   missing_vals = c("gap", "zero", "remove"),
   autoscale = FALSE,
+  autohide = TRUE,
   columns_x_vals = NULL,
   reference_line = NULL,
   reference_area = NULL,
@@ -97,6 +98,15 @@ produced are based on the limits of data combined from all input rows. This
 will result in a shared scale across all of the nanoplots (for \emph{y}- and
 \emph{x}-axis data), which is useful in those cases where the nanoplot data
 should be compared across rows.}
+
+\item{autohide}{\emph{Automatically hide the \code{columns}/\code{columns_x_vals} column(s)}
+
+\verb{scalar<logical>} // \emph{default:} \code{TRUE}
+
+An option to automatically hide any columns specified in \code{columns} and also
+\code{columns_x_vals} (if used). Any columns with their state changed to
+'hidden' will behave the same as before, they just won't be displayed in
+the finalized table.}
 
 \item{columns_x_vals}{\emph{Columns containing values for the optional x variable}
 
@@ -332,7 +342,7 @@ possible to define a column label here using the \code{new_col_label} argument.
   gt(rowname_col = "test") |>
   tab_header("Partial summary of daily tests performed on YF patient") |>
   tab_stubhead(label = md("**Test**")) |>
-  cols_hide(columns = c(starts_with("norm"), starts_with("day"))) |>
+  cols_hide(columns = starts_with("norm")) |>
   fmt_units(columns = units) |>
   cols_nanoplot(
     columns = starts_with("day"),
@@ -375,6 +385,7 @@ in \code{\link[=nanoplot_options]{nanoplot_options()}}.
   cols_nanoplot(
     columns = c(chicken, classic, supreme, veggie),
     plot_type = "bar",
+    autohide = FALSE,
     new_col_name = "pizzas_sold",
     new_col_label = "Sales by Type",
     options = nanoplot_options(
@@ -414,12 +425,14 @@ elect to hide most of those with \code{\link[=cols_hide]{cols_hide()}}.
   cols_nanoplot(
     columns = starts_with("population"),
     reference_line = "median",
+    autohide = FALSE,
     new_col_name = "population_plot",
     new_col_label = md("*Change*")
   ) |>
   cols_nanoplot(
     columns = starts_with("density"),
     plot_type = "bar",
+    autohide = FALSE,
     new_col_name = "density_plot",
     new_col_label = md("*Change*")
   ) |>
@@ -486,7 +499,6 @@ bars.
       data_bar_fill_color = "DarkOrange"
     )
   ) |>
-  cols_hide(columns = matches("0")) |>
   tab_options(
     table.width = px(400),
     column_labels.hidden = TRUE
@@ -537,7 +549,6 @@ streams in each row (having the same number of values) we can now make a
     title = md("Pizzas sold on **January 1, 2015**"),
     subtitle = "Between the opening hours of 11:30 to 22:30"
   ) |>
-  cols_hide(columns = c(date_time, sold)) |>
   cols_nanoplot(
     columns = sold,
     columns_x_vals = date_time,
@@ -594,7 +605,7 @@ hover.
     plot_type = "boxplot",
     options = nanoplot_options(y_val_fmt_fn = function(x) hms::as_hms(x))
   ) |>
-  cols_hide(columns = c(time, is_weekend)) |>
+  cols_hide(columns = is_weekend) |>
   cols_width(everything() ~ px(250)) |>
   cols_align(align = "center", columns = nanoplots) |>
   cols_align(align = "left", columns = date) |>


### PR DESCRIPTION
This adds the `autohide` argument to the `cols_nanoplot()` function. As in several other `cols_*()` functions, there is the `autohide` argument to automatically hide columns that participate as input but become redundant after the function is invoking. 

In this case, inputs to `cols_nanoplot()` provide data for the nanoplot in a separate column. Once the plot is made, the data in the input column(s) is likely going to require a separate `cols_hide()` call to hide the columns providing the input. We can save the trouble in doing so with the `autohide = TRUE` default (same default for all functions having an `autohide` argument). For those cases where the input column *should* remain visible, the user is able to set `autohide = FALSE`.