### PR TITLE
Add option to change fill color of nanoplot data area (bounded to data points)

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -787,6 +787,7 @@ nanoplot_options <- function(
     data_line_type = NULL,
     data_line_stroke_color = NULL,
     data_line_stroke_width = NULL,
+    data_area_fill_color = NULL,
     data_bar_stroke_color = NULL,
     data_bar_stroke_width = NULL,
     data_bar_fill_color = NULL,

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -820,24 +820,26 @@ nanoplot_options <- function(
     currency = NULL
 ) {
 
-  data_point_radius       <- data_point_radius %||% 10
+  data_point_radius <- data_point_radius %||% 10
   data_point_stroke_color <- data_point_stroke_color %||% "#FFFFFF"
   data_point_stroke_width <- data_point_stroke_width %||% 4
-  data_point_fill_color   <- data_point_fill_color %||% "#FF0000"
+  data_point_fill_color <- data_point_fill_color %||% "#FF0000"
 
-  data_line_type         <- data_line_type %||% "curved"
+  data_line_type <- data_line_type %||% "curved"
   data_line_stroke_color <- data_line_stroke_color %||% "#4682B4"
   data_line_stroke_width <- data_line_stroke_width %||% 8
 
+  data_area_fill_color <- data_area_fill_color %||% "#FF0000"
+
   data_bar_stroke_color <- data_bar_stroke_color %||% "#3290CC"
   data_bar_stroke_width <- data_bar_stroke_width %||% 4
-  data_bar_fill_color   <- data_bar_fill_color %||% "#3FB5FF"
+  data_bar_fill_color <- data_bar_fill_color %||% "#3FB5FF"
 
   data_bar_negative_stroke_color <- data_bar_negative_stroke_color %||% "#CC3243"
   data_bar_negative_stroke_width <- data_bar_negative_stroke_width %||% 4
-  data_bar_negative_fill_color   <- data_bar_negative_fill_color %||% "#D75A68"
+  data_bar_negative_fill_color <- data_bar_negative_fill_color %||% "#D75A68"
 
-  reference_line_color      <- reference_line_color %||% "#75A8B0"
+  reference_line_color <- reference_line_color %||% "#75A8B0"
   reference_area_fill_color <- reference_area_fill_color %||% "#A6E6F2"
 
   vertical_guide_stroke_color <- vertical_guide_stroke_color %||% "#911EB4"
@@ -867,6 +869,7 @@ nanoplot_options <- function(
       data_line_type = data_line_type,
       data_line_stroke_color = data_line_stroke_color,
       data_line_stroke_width = data_line_stroke_width,
+      data_area_fill_color = data_area_fill_color,
       data_bar_stroke_color = data_bar_stroke_color,
       data_bar_stroke_width = data_bar_stroke_width,
       data_bar_fill_color = data_bar_fill_color,

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -597,6 +597,14 @@ currency <- function(
 #'   `data_line_stroke_width` option. By default, a value of `4` (as in '4px')
 #'   is used.
 #'
+#' @param data_area_fill_color *Fill color for the data-point-bounded area*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   The fill color for the area that bounds the data points in line plot. The
+#'   default is `"#FF0000"` (`"red"`) but can be changed by providing a color
+#'   value to `data_area_fill_color`.
+#'
 #' @param data_bar_stroke_color *Color of a data bar's outside line*
 #'
 #'   `scalar<character>` // *default:* `NULL` (`optional`)

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -2887,6 +2887,7 @@ cols_nanoplot <- function(
         data_point_fill_color = options_plots$data_point_fill_color,
         data_line_stroke_color = options_plots$data_line_stroke_color,
         data_line_stroke_width = options_plots$data_line_stroke_width,
+        data_area_fill_color = options_plots$data_area_fill_color,
         data_bar_stroke_color = options_plots$data_bar_stroke_color,
         data_bar_stroke_width = options_plots$data_bar_stroke_width,
         data_bar_fill_color = options_plots$data_bar_fill_color,

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -44,6 +44,7 @@ generate_nanoplot <- function(
     data_point_fill_color = "#FF0000",
     data_line_stroke_color = "#4682B4",
     data_line_stroke_width = 8,
+    data_area_fill_color = "#FF0000",
     data_bar_stroke_color = "#3290CC",
     data_bar_stroke_width = 4,
     data_bar_fill_color = "#3FB5FF",
@@ -1856,7 +1857,7 @@ generate_nanoplot <- function(
         paste0(
           "<path class=\"pattern-line\" ",
           "d=\"M 0,8 l 8,-8 M -1,1 l 4,-4 M 6,10 l 4,-4\" ",
-          "stroke=\"red\" ",
+          "stroke=\"", data_area_fill_color, "\" ",
           "stroke-width=\"1.5\" ",
           "stroke-linecap=\"round\" ",
           "shape-rendering=\"geometricPrecision\"",

--- a/man/nanoplot_options.Rd
+++ b/man/nanoplot_options.Rd
@@ -12,6 +12,7 @@ nanoplot_options(
   data_line_type = NULL,
   data_line_stroke_color = NULL,
   data_line_stroke_width = NULL,
+  data_area_fill_color = NULL,
   data_bar_stroke_color = NULL,
   data_bar_stroke_width = NULL,
   data_bar_fill_color = NULL,
@@ -98,6 +99,14 @@ option.}
 The width of the connecting data line can be modified with the
 \code{data_line_stroke_width} option. By default, a value of \code{4} (as in '4px')
 is used.}
+
+\item{data_area_fill_color}{\emph{Fill color for the data-point-bounded area}
+
+\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+
+The fill color for the area that bounds the data points in line plot. The
+default is \code{"#FF0000"} (\code{"red"}) but can be changed by providing a color
+value to \code{data_area_fill_color}.}
 
 \item{data_bar_stroke_color}{\emph{Color of a data bar's outside line}
 


### PR DESCRIPTION
The fill color for the area that bounds the data points in line plot type of nanoplot can now be changed through this PR. The default value is `"#FF0000"` (`"red"`), which is unchanged from before. This can be modified via `nanoplot_options()`'s `data_area_fill_color` argument.

Here is an example of this:

```r
library(gt)
library(tidyverse)

illness |>
  dplyr::slice_head(n = 10) |>
  gt(rowname_col = "test") |>
  tab_header("Partial summary of daily tests performed on YF patient") |>
  tab_stubhead(label = md("**Test**")) |>
  cols_hide(columns = c(starts_with("norm"), starts_with("day"))) |>
  fmt_units(columns = units) |>
  cols_nanoplot(
    columns = starts_with("day"),
    new_col_name = "nanoplots",
    new_col_label = md("*Progression*"),
    options = nanoplot_options(data_area_fill_color = "lightgreen") 
  ) |>
  cols_align(align = "center", columns = nanoplots) |>
  cols_merge(columns = c(test, units), pattern = "{1} ({2})") |>
  tab_footnote(
    footnote = "Measurements from Day 3 through to Day 8.",
    locations = cells_column_labels(columns = nanoplots)
  )
```

<img width="938" alt="data_area_fill_color" src="https://github.com/rstudio/gt/assets/5612024/4faea708-5b45-4906-870e-aa479e550645">

Fixes: https://github.com/rstudio/gt/issues/1521