### PR TITLE
Modify `fmt_url()` URLs such that line breaks don't occur

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -9295,12 +9295,14 @@ fmt_url <- function(
 
         x_str_non_missing <-
           paste0(
+            "<span style=\"white-space: pre;\">",
             "<a",
             " href=\"", x_str_non_missing, "\"",
             anchor_attr,
             ">",
             label_str,
-            "</a>"
+            "</a>",
+            "</span>"
           )
 
         x_str[!is.na(x)] <- x_str_non_missing

--- a/tests/testthat/test-fmt_url.R
+++ b/tests/testthat/test-fmt_url.R
@@ -31,9 +31,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -42,9 +42,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, label = "static label") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a></span>",
       NA
     )
   )
@@ -53,9 +53,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -64,9 +64,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, color = "forestgreen") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -75,9 +75,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, show_underline = FALSE) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -86,9 +86,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, show_underline = TRUE) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -97,9 +97,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "red") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -108,9 +108,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "red", color = "black") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -119,9 +119,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "red", color = "black", button_width = px(500)) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -130,9 +130,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "red", color = "black", button_width = pct(80)) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -141,9 +141,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "auto", color = "black") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #ADD8E6;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #ADD8E6;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #ADD8E6;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #ADD8E6;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #ADD8E6;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #ADD8E6;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -152,9 +152,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "auto", color = "#FFFADF") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: none; outline-color: #BEBEBE; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -163,9 +163,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "auto", color = "#FFFADF", button_outline = "pink") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: solid; outline-color: pink; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: solid; outline-color: pink; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: solid; outline-color: pink; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: solid; outline-color: pink; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: solid; outline-color: pink; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFADF;text-decoration:none;display: inline-block;background-color: #00008B;padding: 8px 12px;outline-style: solid; outline-color: pink; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -174,9 +174,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "#FFFFFF", button_outline = "auto") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FFFFFF;padding: 8px 12px;outline-style: solid; outline-color: #DFDFDF; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FFFFFF;padding: 8px 12px;outline-style: solid; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FFFFFF;padding: 8px 12px;outline-style: solid; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FFFFFF;padding: 8px 12px;outline-style: solid; outline-color: #DFDFDF; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FFFFFF;padding: 8px 12px;outline-style: solid; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FFFFFF;padding: 8px 12px;outline-style: solid; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -185,9 +185,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "#FAD5EF", button_outline = "auto") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FAD5EF;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">http://www.example.com</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FAD5EF;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FAD5EF;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a>",
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FAD5EF;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">http://www.example.com</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FAD5EF;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/docs/Learn/</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: #FAD5EF;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">https://developer.mozilla.org/en-US/search?q=URL</a></span>",
       NA
     )
   )
@@ -212,9 +212,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -222,9 +222,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, label = "static label") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"[Example Site](http://www.example.com)\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a>",
-      "<a href=\"[Learn at Mozilla](https://developer.mozilla.org/en-US/docs/Learn/)\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a>",
-      "<a href=\"[Search Mozilla](https://developer.mozilla.org/en-US/search?q=URL)\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a>"
+      "<span style=\"white-space: pre;\"><a href=\"[Example Site](http://www.example.com)\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"[Learn at Mozilla](https://developer.mozilla.org/en-US/docs/Learn/)\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"[Search Mozilla](https://developer.mozilla.org/en-US/search?q=URL)\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">static label</a></span>"
     )
   )
   expect_equal(
@@ -232,9 +232,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -242,9 +242,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, color = "forestgreen") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#228B22;text-decoration:underline;text-underline-position: under;display: inline-block;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -252,9 +252,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, show_underline = FALSE) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#008B8B;text-decoration:none;display: inline-block;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -262,9 +262,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, show_underline = TRUE) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:underline;text-underline-position: under;display: inline-block;background-color: #4682B4;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -272,9 +272,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "red") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#FFFFFF;text-decoration:none;display: inline-block;background-color: #FF0000;padding: 8px 12px;outline-style: none; outline-color: #DFDFDF; outline-width: 2px;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -282,9 +282,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "red", color = "black") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -292,9 +292,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "red", color = "black", button_width = px(500)) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 500px; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -302,9 +302,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, as_button = TRUE, button_fill = "red", color = "black", button_width = pct(80)) %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" style=\"color:#000000;text-decoration:none;display: inline-block;background-color: red;padding: 8px 12px;width: 80%; text-align: center;outline-style: solid; outline-color: auto; outline-width: 2px;\">Search Mozilla</a></span>"
     )
   )
   expect_equal(
@@ -312,9 +312,9 @@ test_that("The `fmt_url()` function works correctly", {
        fmt_url(columns = a, hreflang = "en-GB", target = "_blank", rel = "external", referrerpolicy = "no-referrer") %>%
        render_formats_test(context = "html"))[["a"]],
     c(
-      "<a href=\"http://www.example.com\" target=\"_blank\" rel=\"external\" referrerpolicy=\"no-referrer\" hreflang=\"en-GB\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Example Site</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" rel=\"external\" referrerpolicy=\"no-referrer\" hreflang=\"en-GB\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Learn at Mozilla</a>",
-      "<a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" rel=\"external\" referrerpolicy=\"no-referrer\" hreflang=\"en-GB\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Search Mozilla</a>"
+      "<span style=\"white-space: pre;\"><a href=\"http://www.example.com\" target=\"_blank\" rel=\"external\" referrerpolicy=\"no-referrer\" hreflang=\"en-GB\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Example Site</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/docs/Learn/\" target=\"_blank\" rel=\"external\" referrerpolicy=\"no-referrer\" hreflang=\"en-GB\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Learn at Mozilla</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://developer.mozilla.org/en-US/search?q=URL\" target=\"_blank\" rel=\"external\" referrerpolicy=\"no-referrer\" hreflang=\"en-GB\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">Search Mozilla</a></span>"
     )
   )
 

--- a/tests/testthat/test-helper_functions.R
+++ b/tests/testthat/test-helper_functions.R
@@ -541,14 +541,14 @@ test_that("The `from_column()` helper works correctly", {
        render_formats_test("html")
     )[["url"]],
     c(
-      "<a href=\"https://addingtonhighlands.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">apricot</a>",
-      "<a href=\"https://adelaidemetcalfe.on.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">banana</a>",
-      "<a href=\"https://www.adjtos.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">coconut</a>",
-      "<a href=\"https://admastonbromley.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">durian</a>",
-      "<a href=\"https://www.ajax.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">missing</a>",
-      "<a href=\"https://alberton.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">fig</a>",
-      "<a href=\"https://www.alfred-plantagenet.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">grapefruit</a>",
-      "<a href=\"https://www.algonquinhighlands.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">honeydew</a>"
+      "<span style=\"white-space: pre;\"><a href=\"https://addingtonhighlands.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">apricot</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://adelaidemetcalfe.on.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">banana</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://www.adjtos.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">coconut</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://admastonbromley.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">durian</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://www.ajax.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">missing</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://alberton.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">fig</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://www.alfred-plantagenet.com\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">grapefruit</a></span>",
+      "<span style=\"white-space: pre;\"><a href=\"https://www.algonquinhighlands.ca\" target=\"_blank\" style=\"color:#008B8B;text-decoration:underline;text-underline-position: under;display: inline-block;\">honeydew</a></span>"
     )
   )
 })


### PR DESCRIPTION
This change ensures that any URLs generated via `fmt_url()` don't inadvertently break across lines. This fixes an issue where line breaks could occur in Quarto 1.4, affecting the presentation in an adverse way.

Fixes: https://github.com/rstudio/gt/issues/1509