### PR TITLE
handle correctly rtf saving with cols_label + summary_rows / grand_summary_rows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,7 +71,8 @@ Suggests:
     shiny (>= 1.7.4),
     testthat (>= 3.1.9),
     tidyr,
-    webshot2 (>= 0.1.0)
+    webshot2 (>= 0.1.0),
+    withr
 Roxygen: list(markdown = TRUE)
 Collate: 
     'as_data_frame.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gt (development version)
 
-* gt saves correctly to .rtf if using `cols_label()` (@olivroy, #1233)
+* `gtsave()` saves correctly to .rtf if using `cols_label()` and `summary_rows()` or `grand_summary_rows()` (@olivroy, #1233)
 
 # gt 0.10.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt (development version)
 
+* gt saves correctly to .rtf if using `cols_label()` (@olivroy, #1233)
+
 # gt 0.10.1
 
 ## Improvements to nanoplots

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -1445,6 +1445,10 @@ create_body_component_rtf <- function(data) {
   # column names for the table
   default_vars <- dt_boxhead_get_vars_labels_default(data = data)
 
+  # Create a named vector  https://github.com/rstudio/gt/issues/1233
+  default_vars_names <-  dt_boxhead_get_vars_default(data = data)
+  names(default_vars_names) <- default_vars
+
   # Get a matrix of all cell content for the body
   cell_matrix <- get_body_component_cell_matrix(data = data)
 
@@ -1641,7 +1645,7 @@ create_body_component_rtf <- function(data) {
           dplyr::select(
             list_of_summaries$summary_df_display_list[[group_id]],
             dplyr::all_of(rowname_col_private),
-            dplyr::all_of(default_vars)
+            dplyr::all_of(default_vars_names)
           )
 
         n_summary_rows <- seq_len(nrow(summary_df))

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -1724,7 +1724,7 @@ create_body_component_rtf <- function(data) {
       dplyr::select(
         list_of_summaries$summary_df_display_list[[grand_summary_col]],
         dplyr::all_of(rowname_col_private),
-        dplyr::all_of(default_vars)
+        dplyr::all_of(default_vars_names)
       )
 
     for (j in seq_len(nrow(grand_summary_df))) {

--- a/tests/testthat/test-utils_render_rtf.R
+++ b/tests/testthat/test-utils_render_rtf.R
@@ -14,6 +14,10 @@ test_that("No error is created with gtsave() to rtf (#1233)", {
     summary_rows(
       columns = val,
       fns = "mean"
+    ) |>
+    grand_summary_rows(
+      columns = val,
+      fns = "mean"
     )
   expect_no_error(gtsave(a_gt, rtf_file))
 })

--- a/tests/testthat/test-utils_render_rtf.R
+++ b/tests/testthat/test-utils_render_rtf.R
@@ -1,0 +1,19 @@
+test_that("No error is created with gtsave() to rtf (#1233)", {
+  rtf_file <- withr::local_tempfile(fileext = ".rtf")
+  df <- data.frame(
+    group = c("a", "a", "b", "b"),
+    val = c(1, 2, 3, 4),
+    char = c("AAA", "AAA", "BBB", "BBB")
+  )
+
+  a_gt <- df %>%
+    gt(groupname_col = "group") %>%
+    cols_label(
+      val = "Value"
+    ) %>%
+    summary_rows(
+      columns = val,
+      fns = "mean"
+    )
+  expect_no_error(gtsave(a_gt, rtf_file))
+})

--- a/tests/testthat/test-utils_render_rtf.R
+++ b/tests/testthat/test-utils_render_rtf.R
@@ -14,7 +14,7 @@ test_that("No error is created with gtsave() to rtf (#1233)", {
     summary_rows(
       columns = val,
       fns = "mean"
-    ) |>
+    ) %>%
     grand_summary_rows(
       columns = val,
       fns = "mean"


### PR DESCRIPTION
# Summary

Simple fix for gtsave() for .rtf with `cols_label()`.

Extended the fix to `grand_summary_rows()` as well!

Note: The other saving tests don't work well on Windows on my machine, maybe double check if they run as expected for you locally? I also have not tested this widely.

Tested that the fix works for both `summary_rows()` and / or `grand_summary_rows()`.

# Related GitHub Issues and PRs

- Ref: fixes #1233

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.

# Screenshot 

rtf
![image](https://github.com/rstudio/gt/assets/52606734/c1246e29-9934-4521-adae-7e4a2a4c6c89)
html
![image](https://github.com/rstudio/gt/assets/52606734/8f5c89ce-993a-4f3f-8906-f9d6b6242452)
