### PR TITLE
Update R-CMD-check.yaml

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,8 +25,6 @@ jobs:
           - {os: windows-latest, r: '4.2'}
           # # use 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: '4.1'}
-          # # Use 3.6 to trigger usage of RTools35
-          - {os: windows-latest, r: '3.6'}
 
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}


### PR DESCRIPTION
This removes Windows / R 3.6 from the R CMD check workflow. 