### PR TITLE
Fix Issue #1580

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -725,25 +725,25 @@ as_latex <- function(data) {
     latex_packages <- NULL
   }
 
-  table_width_bookends <- derive_table_width_bookends(data = data)
+  table_width_statement <- derive_table_width_statement_l(data = data)
 
   # Allow user to set a font-size
-  font_size_bookends <- create_font_size_bookends_l(data = data)
+  fontsize_statement <- create_fontsize_statement_l(data = data)
 
 
   # Compose the LaTeX table
   knitr::asis_output(
     paste0(
-      table_width_bookends[1L],
-      font_size_bookends[1L],
+      "\\begingroup\n",
+      table_width_statement,
+      fontsize_statement,
       table_start,
       heading_component,
       columns_component,
       body_component,
       table_end,
       footer_component,
-      font_size_bookends[2L],
-      table_width_bookends[2L],
+      "\\endgroup\n",
       collapse = ""
     ),
     meta = latex_packages

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -1282,14 +1282,14 @@ split_row_content <- function(x) {
   split(row_content, ceiling(seq_along(row_content) / ncol(x)))
 }
 
-derive_table_width_bookends <- function(data) {
+derive_table_width_statement_l <- function(data) {
 
   table_width <- dt_options_get_value(data = data, 'table_width')
 
   # Bookends are not required if a table width is not specified
   if (table_width == 'auto') {
 
-    bookends <- c('', '')
+    statement <- ''
 
   } else if (endsWith(table_width, "%")) {
 
@@ -1299,22 +1299,14 @@ derive_table_width_bookends <- function(data) {
       ((100 - tw) / 200) %>%
       format(scientific = FALSE, trim = TRUE)
 
-    bookends <-
-      c(
-        paste0(
-          "\\newlength\\holdLTleft",
-          "\\newlength\\holdLTright",
-          "\\setlength\\holdLTleft{\\LTleft}\\relax",
-          "\\setlength\\holdLTright{\\LTright}\\relax",
-          sprintf(
-            '\\setlength\\LTleft{%s\\linewidth}\n\\setlength\\LTright{%s\\linewidth}',
-            side_width,
-            side_width
-          ),
-          collapse = "\n"
-        ),
-        "\\setlength\\LTleft{\\holdLTleft}\n\\setlength\\LTright{\\holdLTright}"
-      )
+    statement <- paste0(
+      "\\setlength\\",
+      c("LTleft", "LTright"),
+      "{",
+      side_width,
+      "\\linewidth}",
+      collapse = "\n"
+    )
 
   } else {
 
@@ -1322,30 +1314,18 @@ derive_table_width_bookends <- function(data) {
 
     halfwidth_in_pt <- format(width_in_pt / 2, scientific = FALSE, trim = TRUE)
 
-    bookends <-
-      c(
-        paste0(
-          "\\newlength\\holdLTleft",
-          "\\newlength\\holdLTright",
-          "\\setlength\\holdLTleft{\\LTleft}\\relax",
-          "\\setlength\\holdLTright{\\LTright}\\relax",
-          sprintf(
-            "\\setlength\\LTleft{\\dimexpr(0.5\\linewidth - %spt)}\n\\setlength\\LTright{\\dimexpr(0.5\\linewidth - %spt)}",
-            halfwidth_in_pt,
-            halfwidth_in_pt
-          ),
-          collapse = '\n'
-        ),
-        paste0(
-          "\\setlength\\LTleft{\\holdLTleft}",
-          "\\setlength\\LTright{\\holdLTright}",
-          collapse = "\n"
-        )
-      )
+    statement <- paste0(
+      "\\setlength\\",
+      c("LTleft", "LTright"),
+      "{\\dimexpr(0.5\\linewidth - ",
+      halfwidth_in_pt,
+      "pt)}",
+      collapse = "\n"
+    )
 
   }
 
-  bookends
+  statement
 
 }
 
@@ -1580,12 +1560,12 @@ apply_spanner_styles_l <- function(spanners_rle, styles_tbl) {
   spanners_rle
 }
 
-create_font_size_bookends_l <- function(data) {
+create_fontsize_statement_l <- function(data) {
 
   size_options <- dplyr::filter(dt_options_get(data), parameter == 'table_font_size')
   size <- unlist(size_options$value)[1L]
 
-  fs_fmt <- "\\begingroup\n\\fontsize{%3.1fpt}{%3.1fpt}\\selectfont\n"
+  fs_fmt <- "\\fontsize{%3.1fpt}{%3.1fpt}\\selectfont\n"
   if (grepl(pattern = "^[[:digit:]]+(\\%|in|cm|emu|em|pt|px)$", size)) {
 
     if (endsWith("%", x = size)) {
@@ -1605,9 +1585,9 @@ create_font_size_bookends_l <- function(data) {
 
     }
 
-  } else return(c("", ""))
+  } else return("")
 
-  c(fs_statement, "\\endgroup\n")
+  fs_statement
 
 }
 

--- a/tests/testthat/test-as_latex.R
+++ b/tests/testthat/test-as_latex.R
@@ -13,29 +13,12 @@ test_that("Table width correctly output in LaTeX", {
 
   expect_gt(end_pt, 0)
 
-  # Verify that the holdLTleft and holdLTright variables are defined and set
   latex_prefix <- substr(gt_latex_width_1, 1L, start_pt)
-
-  expect_match(latex_prefix, "\\\\newlength\\\\holdLTleft")
-
-  expect_match(latex_prefix, "\\\\newlength\\\\holdLTright")
-
-  expect_match(latex_prefix, "\\\\setlength\\\\holdLTleft\\{\\\\LTleft\\}\\\\relax")
-
-  expect_match(latex_prefix, "\\\\setlength\\\\holdLTright\\{\\\\LTright\\}\\\\relax")
 
   # Verify that LTleft and LTright are correctly specified
   expect_match(latex_prefix, "\\\\setlength\\\\LTleft\\{0.05\\\\linewidth\\}")
 
   expect_match(latex_prefix, "\\\\setlength\\\\LTright\\{0.05\\\\linewidth\\}")
-
-  # Verify that after the longtable environment, the LTleft and LT right are
-  # changed back to their previous values
-  latex_suffix <- substr(gt_latex_width_1, end_pt, nchar(gt_latex_width_1))
-
-  expect_match(latex_suffix, "\\\\setlength\\\\LTleft\\{\\\\holdLTleft\\}")
-
-  expect_match(latex_suffix, "\\\\setlength\\\\LTright\\{\\\\holdLTright\\}")
 
   # Test specification of a table width in pixels
   gt_latex_width_2 <-


### PR DESCRIPTION
# Summary

This pull request makes a minor correction to avoid a Latex error when including multiple tables in a Quarto document.

I've simplified the code to avoid having to define the holdLTright and holdLTleft variables, which were causing errors when being redefined in Quarto.  These variables existed because to change the table width, we need to reset the lengths stored in variables LTright and LTleft.  This would create side effects in Latex since changing these would alter them for every table that followed.  As a result, I used holdLTright and holdLTleft to record the lengths of these variables at the very beginning of the table code and then restored those values at the end.

Among the changes made to master by my last PR, was the use of \begingroup and \endgroup at the start and end of the table code block to make changes to the font size only apply to the table code block.  This change gets rid of the need for holdLTright and holdLTleft because changes made to LTright and LTleft will now also only apply within the code between \begingroup and \endgroup. 

With the change, we no longer need "bookend" values for fontsize and table  width values.  I've changed the names of the functions that generated these values to reflect that they're now returning single fontsize and table width statements to make the code clearer.

I verified that the code works in RMarkdown and Quarto and have updated the tests.

# Related GitHub Issues and PRs

- Ref: #1580 

# Checklist

- [x ] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
