### PR TITLE
Ensure display of footnotes works properly for interactive tables

### DIFF
--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -45,7 +45,7 @@ render_as_ihtml <- function(data, id) {
   footnotes <- dt_footnotes_get(data = data)
 
   # Determine if the rendered table should have a footer section
-  has_footer_section <- !is.null(source_notes) || nrow(footnotes) > 1
+  has_footer_section <- !is.null(source_notes) || nrow(footnotes) >= 1
 
   # Determine if the rendered table should have a header section
   has_header_section <- dt_heading_has_title(data = data)


### PR DESCRIPTION
This fixes a bug where single footnotes (i.e., exactly one footnote) won't appear in the footer of an interactive table. Using two or greater distinct footnotes works. This simply modifies a conditional statement so that all numbers of footnotes work properly.

Fixes: https://github.com/rstudio/gt/issues/1615