### PR TITLE
Fix argument name typo

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -119,7 +119,7 @@ stop_if_not_gt_tbl_or_group <- function(data, call = caller_env()) {
   if (!is_gt_tbl(data = data) && !is_gt_group(data = data)) {
     cli::cli_abort(
       "`data` must either be a `gt_tbl` or a `gt_group`, not {.obj_type_friendly {data}}.",
-      call = error_call
+      call = call
     )
   }
 }


### PR DESCRIPTION
In #1504, I made a small typo. The variable name is `call`, not `error_call`

Currently, yields this error.

! `call` must be a call or environment, not a function.
