### PR TITLE
fix for fmt-functions in combination with md/html-stubs

### DIFF
--- a/R/resolver.R
+++ b/R/resolver.R
@@ -381,7 +381,9 @@ resolve_rows_l <- function(
 ) {
 
   if (is_gt_tbl(data = data)) {
-    row_names <- dt_stub_df_get(data = data)$row_id
+    # unlist because dt_stub_df_get might return a list instead of a vector
+    # (when helper functions such as md/html were used)
+    row_names <- unlist(dt_stub_df_get(data = data)$row_id)
     data <- dt_data_get(data = data)
   } else {
     row_names <- row.names(data)

--- a/tests/testthat/test-fmt_percent.R
+++ b/tests/testthat/test-fmt_percent.R
@@ -412,3 +412,34 @@ test_that("The `fmt_percent()` fn can render in the Indian numbering system", {
     )
   )
 })
+
+test_that("The `fmt_percent()` function works correctly with stubs", {
+  tbl <- tibble::tibble(
+    raw = c("[shiny](https://shiny.posit.co/)", "<a href='https://gt.rstudio.com/'>gt</a>"),
+    markdown = purrr::map(c("[shiny](https://shiny.posit.co/)", "[gt](https://gt.rstudio.com/)"), gt::md),
+    html = purrr::map(c("<a href='https://shiny.posit.co/'>shiny</a>", "<a href='https://gt.rstudio.com/'>gt</a>"), gt::html),
+    str_col = c("shiny", "gt"),
+    pct_col = c(0.75, 0.25)
+  )
+
+  # nothing special (raw)
+  # stub as html
+  # stub as markdown
+
+  for (test_case in c("raw", "markdown", "html")) {
+    tab <- tbl |>
+      gt(rowname_col = test_case) |>
+      fmt_percent(columns = pct_col, decimals = 2, dec_mark = ".") |>
+      render_formats_test(context = "html")
+
+    expect_equal(tab[["pct_col"]], c("75.00%", "25.00%"))
+
+    # with row filter
+    tab <- tbl |>
+      gt(rowname_col = test_case) |>
+      fmt_percent(columns = pct_col, decimals = 2, dec_mark = ".", rows = contains("gt")) |>
+      render_formats_test(context = "html")
+
+    expect_equal(tab[["pct_col"]], c("0.75", "25.00%"))
+  }
+})

--- a/tests/testthat/test-gtsave.R
+++ b/tests/testthat/test-gtsave.R
@@ -133,7 +133,7 @@ test_that("HTML saving with `gtsave()` is successful with different path defs", 
   #
 
   # Form final path, check for non-existence
-  path_1 <- tempfile(fileext = ".html")
+  path_1 <- normalizePath(tempfile(fileext = ".html"), winslash = "/", mustWork = F)
   on.exit(unlink(path_1))
   expect_false(file.exists(path_1))
 
@@ -145,7 +145,7 @@ test_that("HTML saving with `gtsave()` is successful with different path defs", 
   path_n <- length(split_path)
 
   # Set working directory
-  setwd(file.path(paste0("/", paste(split_path[2:3], collapse = "/"))))
+  setwd(file.path(paste0(ifelse(.Platform$OS.type == "windows", split_path[1], ""), "/", paste(split_path[2:3], collapse = "/"))))
 
   # Write the file
   exibble %>%
@@ -167,7 +167,7 @@ test_that("HTML saving with `gtsave()` is successful with different path defs", 
   #
 
   # Form final path, check for non-existence
-  path_2 <- tempfile(fileext = ".html")
+  path_2 <- normalizePath(tempfile(fileext = ".html"), winslash = "/", mustWork = F)
   on.exit(unlink(path_2))
   expect_false(file.exists(path_2))
 
@@ -179,7 +179,7 @@ test_that("HTML saving with `gtsave()` is successful with different path defs", 
   path_n <- length(split_path)
 
   # Set working directory
-  setwd(file.path(paste0("/", paste(split_path[2:3], collapse = "/"))))
+  setwd(file.path(paste0(ifelse(.Platform$OS.type == "windows", split_path[1], ""), "/", paste(split_path[2:3], collapse = "/"))))
 
   # Write the file
   exibble %>%
@@ -220,6 +220,8 @@ test_that("HTML saving with `gtsave()` is successful with different path defs", 
     path_3 %>% readLines() %>% paste(collapse = "\n") %>%
       tidy_grepl("<!DOCTYPE html>")
   )
+
+  skip_on_os("windows")
 
   # [#4] Filename starting with ~/, absolute path (expect that path is ignored)
 
@@ -276,7 +278,7 @@ test_that("HTML saving with `gt_save_html()` with different path defs works", {
   #
 
   # Form final path, check for non-existence
-  path_1 <- tempfile(fileext = ".html")
+  path_1 <- normalizePath(tempfile(fileext = ".html"), winslash = "/", mustWork = F)
   on.exit(unlink(path_1))
   expect_false(file.exists(path_1))
 
@@ -288,7 +290,7 @@ test_that("HTML saving with `gt_save_html()` with different path defs works", {
   path_n <- length(split_path)
 
   # Set working directory
-  setwd(file.path(paste0("/", paste(split_path[2:3], collapse = "/"))))
+  setwd(file.path(paste0(ifelse(.Platform$OS.type == "windows", split_path[1], ""), "/", paste(split_path[2:3], collapse = "/"))))
 
   # Write the file
   exibble %>%
@@ -310,7 +312,7 @@ test_that("HTML saving with `gt_save_html()` with different path defs works", {
   #
 
   # Form final path, check for non-existence
-  path_2 <- tempfile(fileext = ".html")
+  path_2 <- normalizePath(tempfile(fileext = ".html"), winslash = "/", mustWork = F)
   on.exit(unlink(path_2))
   expect_false(file.exists(path_2))
 
@@ -322,7 +324,7 @@ test_that("HTML saving with `gt_save_html()` with different path defs works", {
   path_n <- length(split_path)
 
   # Set working directory
-  setwd(file.path(paste0("/", paste(split_path[2:3], collapse = "/"))))
+  setwd(file.path(paste0(ifelse(.Platform$OS.type == "windows", split_path[1], ""), "/", paste(split_path[2:3], collapse = "/"))))
 
   # Write the file
   exibble %>%
@@ -363,6 +365,8 @@ test_that("HTML saving with `gt_save_html()` with different path defs works", {
     path_3 %>% readLines() %>% paste(collapse = "\n") %>%
       tidy_grepl("<!DOCTYPE html>")
   )
+
+  skip_on_os("windows")
 
   # [#4] Filename starting with ~/, absolute path (expect that path is ignored)
 


### PR DESCRIPTION
# Summary

#1600 : all fmt-functions (such as `fmt_percent`) didn't work when helper functions such as `md` or `html` for the stub were used
#1626 : was just a problem on local testing at windows env (gtsave: absolute paths beginning with / or ~)

# Related GitHub Issues and PRs

- Ref: #1600 
- Ref: #1626 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.

Fixes: #1600
Fixes: #1626