### PR TITLE
Improve `tab_footnote()` error message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * `cols_hide()` no longer errors if no column was supplied. Error messages are also clearer when supplying a column that doesn't exist (@olivroy, #1631).
 
+`tab_footnote()` now gives a better error message when `locations` is not correctly specified (@olivroy, #475)
+
 # gt 0.10.1
 
 ## Improvements to nanoplots

--- a/R/data_color.R
+++ b/R/data_color.R
@@ -825,7 +825,7 @@ data_color <- function(
       if (nrow(palettes_tbl) < 1) {
         cli::cli_abort(c(
           "The palette name (supplied with the `<package>::<palette>`
-          syntax) is not associated with the {palette_pkg} package as a
+          syntax) is not associated with the {.pkg {palette_pkg}} package as a
           discrete palette.",
           "*" = "Ensure that the combination of palette package and palette
           name exists as a record in the table accessed with

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -9185,8 +9185,8 @@ fmt_url <- function(
             arg,
             nm,
             values = NULL,
-            error_arg = caller_arg(arg),
-            error_call = caller_env()
+            error_arg = rlang::caller_arg(arg),
+            error_call = rlang::caller_env()
         ) {
 
           if (!is.null(values)) {
@@ -9200,7 +9200,7 @@ fmt_url <- function(
               )
           }
 
-          if (!is_string(arg)) {
+          if (!rlang::is_string(arg)) {
             cli::cli_abort(
               "{.arg {nm}} must be a string, not {.obj_type_friendly {arg}}",
               call = error_call

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -3799,7 +3799,7 @@ gt_one_col <- function(x) {
   gt(dplyr::tibble(x = x), auto_align = FALSE, process_md = FALSE)
 }
 
-stop_if_not_vector <- function(x, call = caller_env()) {
+stop_if_not_vector <- function(x, call = rlang::caller_env()) {
   if (!rlang::is_vector(x)) {
     cli::cli_abort(
       "`x` must be a vector, not {.obj_type_friendly {x}}.",

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -3799,9 +3799,12 @@ gt_one_col <- function(x) {
   gt(dplyr::tibble(x = x), auto_align = FALSE, process_md = FALSE)
 }
 
-stop_if_not_vector <- function(x) {
+stop_if_not_vector <- function(x, call = caller_env()) {
   if (!rlang::is_vector(x)) {
-    cli::cli_abort("The object provided as `x` should be a vector.")
+    cli::cli_abort(
+      "`x` must be a vector, not {.obj_type_friendly {x}}.",
+      call = call
+    )
   }
 }
 

--- a/R/resolver.R
+++ b/R/resolver.R
@@ -29,7 +29,7 @@
 #'
 #' @import rlang
 #' @noRd
-resolve_cells_body <- function(data, object, call = caller_env()) {
+resolve_cells_body <- function(data, object, call = rlang::caller_env()) {
 
   #
   # Resolution of columns and rows as integer vectors
@@ -109,9 +109,11 @@ resolve_cells_stub <- function(data,
 #' @param object The list object created by the `cells_column_labels()`
 #'   function.
 #' @noRd
-resolve_cells_column_labels <- function(data,
-                                        object,
-                                        call = caller_env()) {
+resolve_cells_column_labels <- function(
+    data,
+    object,
+    call = rlang::caller_env()
+) {
 
   #
   # Resolution of columns as integer vectors
@@ -140,7 +142,11 @@ resolve_cells_column_labels <- function(data,
 #' @param object The list object created by the `cells_column_labels()`
 #'   function.
 #' @noRd
-resolve_cells_column_spanners <- function(data, object, call = caller_env()) {
+resolve_cells_column_spanners <- function(
+    data,
+    object,
+    call = rlang::caller_env()
+) {
 
   spanners <- dt_spanners_get(data = data)
 
@@ -386,7 +392,7 @@ resolve_rows_l <- function(
     expr,
     data,
     null_means,
-    call = caller_env()
+    call = rlang::caller_env()
 ) {
 
   if (is_gt_tbl(data = data)) {
@@ -463,7 +469,7 @@ resolve_vector_l <- function(
     expr,
     vector,
     item_label = "item",
-    call = caller_env()
+    call = rlang::caller_env()
   ) {
 
   quo <- rlang::enquo(expr)
@@ -485,8 +491,21 @@ resolve_vector_l <- function(
   resolved
 }
 
-resolve_vector_i <- function(expr, vector, item_label = "item", call = caller_env()) {
-  which(resolve_vector_l(expr = {{ expr }}, vector = vector, item_label = item_label, call = call))
+resolve_vector_i <- function(
+    expr,
+    vector,
+    item_label = "item",
+    call = rlang::caller_env()
+) {
+
+  which(
+    resolve_vector_l(
+      expr = {{ expr }},
+      vector = vector,
+      item_label = item_label,
+      call = call
+    )
+  )
 }
 
 resolve_groups <- function(expr, vector) {
@@ -541,7 +560,7 @@ normalize_resolved <- function(
     resolved,
     item_names,
     item_label,
-    call = caller_env()
+    call = rlang::caller_env()
 ) {
 
   item_count <- length(item_names)
@@ -593,7 +612,10 @@ normalize_resolved <- function(
   resolved
 }
 
-resolver_stop_on_logical <- function(item_label, call = caller_env()) {
+resolver_stop_on_logical <- function(
+    item_label,
+    call = rlang::caller_env()
+) {
 
   cli::cli_abort(
     "The number of logical values must either be `1` or the number
@@ -602,7 +624,11 @@ resolver_stop_on_logical <- function(item_label, call = caller_env()) {
   )
 }
 
-resolver_stop_on_numeric <- function(item_label, unknown_resolved, call = caller_env()) {
+resolver_stop_on_numeric <- function(
+    item_label,
+    unknown_resolved,
+    call = rlang::caller_env()
+) {
 
   cli::cli_abort(
     "The following {item_label} indices do not exist in the data:
@@ -611,7 +637,12 @@ resolver_stop_on_numeric <- function(item_label, unknown_resolved, call = caller
   )
 }
 
-resolver_stop_on_character <- function(item_label, unknown_resolved, call = caller_env()) {
+resolver_stop_on_character <- function(
+    item_label,
+    unknown_resolved,
+    call = rlang::caller_env()
+) {
+
   l <- length(unknown_resolved)
   cli::cli_abort(
     "Can't find {item_label}{cli::qty(l)}{?s}
@@ -620,7 +651,11 @@ resolver_stop_on_character <- function(item_label, unknown_resolved, call = call
   )
 }
 
-resolver_stop_unknown <- function(item_label, resolved, call = caller_env()) {
+resolver_stop_unknown <- function(
+    item_label,
+    resolved,
+    call = rlang::caller_env()
+) {
 
   cli::cli_abort(
     "Don't know how to select {item_label}s using {.obj_type_friendly {resolved}}.",

--- a/R/resolver.R
+++ b/R/resolver.R
@@ -29,7 +29,7 @@
 #'
 #' @import rlang
 #' @noRd
-resolve_cells_body <- function(data, object) {
+resolve_cells_body <- function(data, object, call = caller_env()) {
 
   #
   # Resolution of columns and rows as integer vectors
@@ -40,7 +40,8 @@ resolve_cells_body <- function(data, object) {
   resolved_columns_idx <-
     resolve_cols_i(
       expr = !!object$columns,
-      data = data
+      data = data,
+      call = call
     )
 
   # Resolve rows as index values
@@ -109,7 +110,8 @@ resolve_cells_stub <- function(data,
 #'   function.
 #' @noRd
 resolve_cells_column_labels <- function(data,
-                                        object) {
+                                        object,
+                                        call = caller_env()) {
 
   #
   # Resolution of columns as integer vectors
@@ -118,7 +120,8 @@ resolve_cells_column_labels <- function(data,
   resolved_columns <-
     resolve_cols_i(
       expr = !!object$columns,
-      data = data
+      data = data,
+      call = call
     )
 
   # Create a list object
@@ -137,7 +140,7 @@ resolve_cells_column_labels <- function(data,
 #' @param object The list object created by the `cells_column_labels()`
 #'   function.
 #' @noRd
-resolve_cells_column_spanners <- function(data, object) {
+resolve_cells_column_spanners <- function(data, object, call = caller_env()) {
 
   spanners <- dt_spanners_get(data = data)
 
@@ -154,7 +157,8 @@ resolve_cells_column_spanners <- function(data, object) {
     resolve_vector_i(
       expr = !!object$spanners,
       vector = spanner_ids,
-      item_label = "spanner"
+      item_label = "spanner",
+      call = call
     )
 
   resolved_spanners <- spanner_ids[resolved_spanners_idx]
@@ -215,7 +219,7 @@ resolve_cols_c <- function(
 
   names(
     resolve_cols_i(
-      expr = {{expr}},
+      expr = {{ expr }},
       data = data,
       strict = strict,
       excl_stub = excl_stub,
@@ -381,7 +385,8 @@ translate_legacy_resolver_expr <- function(quo, null_means) {
 resolve_rows_l <- function(
     expr,
     data,
-    null_means
+    null_means,
+    call = caller_env()
 ) {
 
   if (is_gt_tbl(data = data)) {
@@ -425,7 +430,8 @@ resolve_rows_l <- function(
     normalize_resolved(
       resolved = resolved,
       item_names = row_names,
-      item_label = "row"
+      item_label = "row",
+      call = call
     )
 
   resolved
@@ -456,7 +462,8 @@ resolve_rows_i <- function(
 resolve_vector_l <- function(
     expr,
     vector,
-    item_label = "item"
+    item_label = "item",
+    call = caller_env()
   ) {
 
   quo <- rlang::enquo(expr)
@@ -471,14 +478,15 @@ resolve_vector_l <- function(
     normalize_resolved(
       resolved = resolved,
       item_names = vector,
-      item_label = item_label
+      item_label = item_label,
+      call = call
     )
 
   resolved
 }
 
-resolve_vector_i <- function(expr, vector, item_label = "item") {
-  which(resolve_vector_l(expr = {{ expr }}, vector = vector, item_label = item_label))
+resolve_vector_i <- function(expr, vector, item_label = "item", call = caller_env()) {
+  which(resolve_vector_l(expr = {{ expr }}, vector = vector, item_label = item_label, call = call))
 }
 
 resolve_groups <- function(expr, vector) {
@@ -532,7 +540,8 @@ resolve_groups <- function(expr, vector) {
 normalize_resolved <- function(
     resolved,
     item_names,
-    item_label
+    item_label,
+    call = caller_env()
 ) {
 
   item_count <- length(item_names)
@@ -558,14 +567,14 @@ normalize_resolved <- function(
     } else if (length(resolved) == item_count) {
       # Do nothing
     } else {
-      resolver_stop_on_logical(item_label = item_label)
+      resolver_stop_on_logical(item_label = item_label, call = call)
     }
 
   } else if (is.numeric(resolved)) {
 
     unknown_resolved <- setdiff(resolved, item_sequence)
     if (length(unknown_resolved) != 0) {
-      resolver_stop_on_numeric(item_label = item_label, unknown_resolved = unknown_resolved)
+      resolver_stop_on_numeric(item_label = item_label, unknown_resolved = unknown_resolved, call = call)
     }
     resolved <- item_sequence %in% resolved
 
@@ -573,45 +582,48 @@ normalize_resolved <- function(
 
     unknown_resolved <- setdiff(resolved, item_names)
     if (length(unknown_resolved) != 0) {
-      resolver_stop_on_character(item_label = item_label, unknown_resolved = unknown_resolved)
+      resolver_stop_on_character(item_label = item_label, unknown_resolved = unknown_resolved, call = call)
     }
     resolved <- item_names %in% resolved
 
   } else {
-    resolver_stop_unknown(item_label = item_label, resolved = resolved)
+    resolver_stop_unknown(item_label = item_label, resolved = resolved, call = call)
   }
 
   resolved
 }
 
-resolver_stop_on_logical <- function(item_label) {
+resolver_stop_on_logical <- function(item_label, call = caller_env()) {
 
   cli::cli_abort(
     "The number of logical values must either be `1` or the number
-    of {item_label}s."
+    of {item_label}s.",
+    call = call
   )
 }
 
-resolver_stop_on_numeric <- function(item_label, unknown_resolved) {
+resolver_stop_on_numeric <- function(item_label, unknown_resolved, call = caller_env()) {
 
   cli::cli_abort(
     "The following {item_label} indices do not exist in the data:
-    {paste0(unknown_resolved, collapse = ', ')}."
+    {paste0(unknown_resolved, collapse = ', ')}.",
+    call = call
   )
 }
 
-resolver_stop_on_character <- function(item_label, unknown_resolved) {
-
+resolver_stop_on_character <- function(item_label, unknown_resolved, call = caller_env()) {
+  l <- length(unknown_resolved)
   cli::cli_abort(
-    "The following {item_label}(s) do not exist in the data:
-    {paste0(unknown_resolved, collapse = ', ')}."
+    "Can't find {item_label}{cli::qty(l)}{?s}
+    {.code {unknown_resolved}} in the data.",
+    call = call
   )
 }
 
-resolver_stop_unknown <- function(item_label, resolved) {
+resolver_stop_unknown <- function(item_label, resolved, call = caller_env()) {
 
   cli::cli_abort(
-    "Don't know how to select {item_label}s using an object of class
-    {class(resolved)[1]}."
+    "Don't know how to select {item_label}s using {.obj_type_friendly {resolved}}.",
+    call = call
   )
 }

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -2605,7 +2605,7 @@ set_footnote.cells_body <- function(
     placement
 ) {
 
-  resolved <- resolve_cells_body(data = data, object = loc, call = call("cell_body"))
+  resolved <- resolve_cells_body(data = data, object = loc, call = call("cells_body"))
 
   rows <- resolved$rows
 

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -2418,12 +2418,19 @@ tab_footnote <- function(
   for (loc in locations) {
 
     data <-
-      set_footnote(
-        loc = loc,
-        data = data,
-        footnote = footnote,
-        placement = placement
-      )
+      withCallingHandlers(
+        set_footnote(
+          loc = loc,
+          data = data,
+          footnote = footnote,
+          placement = placement
+      ),
+      error = function(e) {
+        cli::cli_abort(
+          "Can't add footnote {.val {footnote}}",
+          parent = e
+        )
+      })
   }
 
   data
@@ -2507,7 +2514,7 @@ set_footnote.cells_column_labels <- function(
     placement
 ) {
 
-  resolved <- resolve_cells_column_labels(data = data, object = loc)
+  resolved <- resolve_cells_column_labels(data = data, object = loc, call = call("cells_column_labels"))
 
   cols <- resolved$columns
 
@@ -2536,7 +2543,7 @@ set_footnote.cells_column_spanners <- function(
     placement
 ) {
 
-  resolved <- resolve_cells_column_spanners(data = data, object = loc)
+  resolved <- resolve_cells_column_spanners(data = data, object = loc, call = call("cells_column_spanners"))
 
   groups <- resolved$spanners
 
@@ -2598,7 +2605,7 @@ set_footnote.cells_body <- function(
     placement
 ) {
 
-  resolved <- resolve_cells_body(data = data, object = loc)
+  resolved <- resolve_cells_body(data = data, object = loc, call = call("cell_body"))
 
   rows <- resolved$rows
 

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -2427,7 +2427,7 @@ tab_footnote <- function(
       ),
       error = function(e) {
         cli::cli_abort(
-          "Can't add footnote {.val {footnote}}",
+          "Can't add footnote {.val {footnote}}.",
           parent = e
         )
       })

--- a/R/utils.R
+++ b/R/utils.R
@@ -352,7 +352,7 @@ is_string_time <- function(x) {
 
 check_format_code <- function(format) {
 
-  if (!is.character(format) || length(format) != 1) {
+  if (!is_string(format)) {
     cli::cli_abort(
       "The `format` code must be a character string of length 1."
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,7 +87,7 @@ is_nonempty_string <- function(x) {
 #'
 #' @noRd
 # Use rlang::caller_env() to inform user of the precise location of failure.
-stop_if_not_gt_tbl <- function(data, call = caller_env()) {
+stop_if_not_gt_tbl <- function(data, call = rlang::caller_env()) {
   if (!is_gt_tbl(data = data)) {
     cli::cli_abort(
       "`data` must be a `gt_tbl` object, not {.obj_type_friendly {data}}.",
@@ -101,7 +101,7 @@ stop_if_not_gt_tbl <- function(data, call = caller_env()) {
 #' @param data The input `data` object that is to be validated.
 #'
 #' @noRd
-stop_if_not_gt_group <- function(data, call = caller_env()) {
+stop_if_not_gt_group <- function(data, call = rlang::caller_env()) {
   if (!is_gt_group(data = data)) {
     cli::cli_abort(
       "`data` must be a `gt_group` object, not {.obj_type_friendly {data}}.",
@@ -115,7 +115,7 @@ stop_if_not_gt_group <- function(data, call = caller_env()) {
 #' @param data The input `data` object that is to be validated.
 #'
 #' @noRd
-stop_if_not_gt_tbl_or_group <- function(data, call = caller_env()) {
+stop_if_not_gt_tbl_or_group <- function(data, call = rlang::caller_env()) {
   if (!is_gt_tbl(data = data) && !is_gt_group(data = data)) {
     cli::cli_abort(
       "`data` must either be a `gt_tbl` or a `gt_group`, not {.obj_type_friendly {data}}.",
@@ -352,7 +352,7 @@ is_string_time <- function(x) {
 
 check_format_code <- function(format) {
 
-  if (!is_string(format)) {
+  if (!rlang::is_string(format)) {
     cli::cli_abort(
       "The `format` code must be a character string of length 1."
     )

--- a/tests/testthat/_snaps/tab_create_modify.md
+++ b/tests/testthat/_snaps/tab_create_modify.md
@@ -6,7 +6,7 @@
     Condition
       Error in `tab_footnote()`:
       ! Can't add footnote "First data cell.".
-      Caused by error in `cell_body()`:
+      Caused by error in `cells_body()`:
       ! Can't select columns that don't exist.
       x Column `valuer` doesn't exist.
     Code

--- a/tests/testthat/_snaps/tab_create_modify.md
+++ b/tests/testthat/_snaps/tab_create_modify.md
@@ -1,37 +1,37 @@
 # tab_footnote produces helpful error messages (#475).
 
     Code
-      tab_footnote(start_gt, footnote = "First data cell.", locations = cells_body(
+      start_gt %>% tab_footnote(footnote = "First data cell.", locations = cells_body(
         columns = "valuer", rows = 1))
     Condition
       Error in `tab_footnote()`:
-      ! Can't add footnote "First data cell."
+      ! Can't add footnote "First data cell.".
       Caused by error in `cell_body()`:
       ! Can't select columns that don't exist.
       x Column `valuer` doesn't exist.
     Code
-      tab_footnote(start_gt, footnote = "First data cell.", locations = cells_column_labels(
+      start_gt %>% tab_footnote(footnote = "First data cell.", locations = cells_column_labels(
         columns = "valuer"))
     Condition
       Error in `tab_footnote()`:
-      ! Can't add footnote "First data cell."
+      ! Can't add footnote "First data cell.".
       Caused by error in `cells_column_labels()`:
       ! Can't select columns that don't exist.
       x Column `valuer` doesn't exist.
     Code
-      tab_footnote(start_gt, footnote = "First data cell.", locations = cells_column_spanners(
+      start_gt %>% tab_footnote(footnote = "First data cell.", locations = cells_column_spanners(
         "valuer"))
     Condition
       Error in `tab_footnote()`:
-      ! Can't add footnote "First data cell."
+      ! Can't add footnote "First data cell.".
       Caused by error in `cells_column_spanners()`:
       ! Can't find spanner `valuer` in the data.
     Code
-      tab_footnote(start_gt, footnote = "First data cell.", locations = cells_column_spanners(
+      start_gt %>% tab_footnote(footnote = "First data cell.", locations = cells_column_spanners(
         3))
     Condition
       Error in `tab_footnote()`:
-      ! Can't add footnote "First data cell."
+      ! Can't add footnote "First data cell.".
       Caused by error in `cells_column_spanners()`:
       ! The following spanner indices do not exist in the data: 3.
 

--- a/tests/testthat/_snaps/tab_create_modify.md
+++ b/tests/testthat/_snaps/tab_create_modify.md
@@ -1,0 +1,37 @@
+# tab_footnote produces helpful error messages (#475).
+
+    Code
+      tab_footnote(start_gt, footnote = "First data cell.", locations = cells_body(
+        columns = "valuer", rows = 1))
+    Condition
+      Error in `tab_footnote()`:
+      ! Can't add footnote "First data cell."
+      Caused by error in `cell_body()`:
+      ! Can't select columns that don't exist.
+      x Column `valuer` doesn't exist.
+    Code
+      tab_footnote(start_gt, footnote = "First data cell.", locations = cells_column_labels(
+        columns = "valuer"))
+    Condition
+      Error in `tab_footnote()`:
+      ! Can't add footnote "First data cell."
+      Caused by error in `cells_column_labels()`:
+      ! Can't select columns that don't exist.
+      x Column `valuer` doesn't exist.
+    Code
+      tab_footnote(start_gt, footnote = "First data cell.", locations = cells_column_spanners(
+        "valuer"))
+    Condition
+      Error in `tab_footnote()`:
+      ! Can't add footnote "First data cell."
+      Caused by error in `cells_column_spanners()`:
+      ! Can't find spanner `valuer` in the data.
+    Code
+      tab_footnote(start_gt, footnote = "First data cell.", locations = cells_column_spanners(
+        3))
+    Condition
+      Error in `tab_footnote()`:
+      ! Can't add footnote "First data cell."
+      Caused by error in `cells_column_spanners()`:
+      ! The following spanner indices do not exist in the data: 3.
+

--- a/tests/testthat/test-resolver.R
+++ b/tests/testthat/test-resolver.R
@@ -4,12 +4,12 @@ test_that("The `resolve_cols_i()` and `resolve_cols_c()` fns both work", {
   no_cols <- setNames(integer(0), character(0))
 
   expect_resolve_cols <- function(expr, expected, data = exibble, wrap = identity, ...) {
-    wrap(expect_identical(resolve_cols_i({{expr}}, data, ...), expected))
-    wrap(expect_identical(resolve_cols_c({{expr}}, data, ...), names(expected)))
+    wrap(expect_identical(resolve_cols_i({{ expr }}, data, ...), expected))
+    wrap(expect_identical(resolve_cols_c({{ expr }}, data, ...), names(expected)))
   }
   expect_resolve_errors <- function(expr, regexp = NULL, data = exibble, ...) {
-    expect_error(resolve_cols_i({{expr}}, data, ...), regexp = regexp)
-    expect_error(resolve_cols_c({{expr}}, data, ...), regexp = regexp)
+    expect_error(resolve_cols_i({{ expr }}, data, ...), regexp = regexp)
+    expect_error(resolve_cols_c({{ expr }}, data, ...), regexp = regexp)
   }
 
   expect_resolve_cols(1, c(num = 1L))

--- a/tests/testthat/test-tab_create_modify.R
+++ b/tests/testthat/test-tab_create_modify.R
@@ -1,0 +1,48 @@
+test_that("tab_footnote produces helpful error messages (#475).", {
+  # Create a table with footnotes in various cell types
+  tbl <-
+    dplyr::tribble(
+      ~date,        ~rowname,  ~value_1,  ~value_2,
+      "2018-02-10", "1",       20.4,      361.1,
+      "2018-02-10", "2",       10.9,      743.3,
+      "2018-02-10", "3",       34.6,      344.7,
+      "2018-02-10", "4",        8.3,      342.3,
+      "2018-02-11", "5",       28.3,      234.9,
+      "2018-02-11", "6",       75.5,      190.9,
+      "2018-02-11", "7",       63.1,        2.3,
+      "2018-02-11", "8",       25.8,      184.3,
+      "2018-02-11", "9",        5.2,      197.2,
+      "2018-02-11", "10",      55.3,      284.6
+    )
+
+  start_gt <- gt(data = tbl, groupname_col = "date") |>
+    tab_spanner(
+      label = "values",
+      columns = starts_with("value")
+    )
+
+  expect_snapshot(
+    error = TRUE, {
+     start_gt |>
+        tab_footnote(
+          footnote = "First data cell.",
+          locations = cells_body(columns = "valuer", rows = 1)
+        )
+      start_gt |>
+        tab_footnote(
+          footnote = "First data cell.",
+          locations = cells_column_labels(columns = "valuer")
+        )
+      start_gt |>
+        tab_footnote(
+          footnote = "First data cell.",
+          locations = cells_column_spanners("valuer")
+        )
+      start_gt |>
+        tab_footnote(
+          footnote = "First data cell.",
+          locations = cells_column_spanners(3)
+        )
+    }
+  )
+})

--- a/tests/testthat/test-tab_create_modify.R
+++ b/tests/testthat/test-tab_create_modify.R
@@ -15,7 +15,7 @@ test_that("tab_footnote produces helpful error messages (#475).", {
       "2018-02-11", "10",      55.3,      284.6
     )
 
-  start_gt <- gt(data = tbl, groupname_col = "date") |>
+  start_gt <- gt(data = tbl, groupname_col = "date") %>%
     tab_spanner(
       label = "values",
       columns = starts_with("value")
@@ -23,22 +23,22 @@ test_that("tab_footnote produces helpful error messages (#475).", {
 
   expect_snapshot(
     error = TRUE, {
-     start_gt |>
+     start_gt %>%
         tab_footnote(
           footnote = "First data cell.",
           locations = cells_body(columns = "valuer", rows = 1)
         )
-      start_gt |>
+      start_gt %>%
         tab_footnote(
           footnote = "First data cell.",
           locations = cells_column_labels(columns = "valuer")
         )
-      start_gt |>
+      start_gt %>%
         tab_footnote(
           footnote = "First data cell.",
           locations = cells_column_spanners("valuer")
         )
-      start_gt |>
+      start_gt %>%
         tab_footnote(
           footnote = "First data cell.",
           locations = cells_column_spanners(3)


### PR DESCRIPTION
# Summary

Basically uses `withCallingHandlers()` to give more precise location.

These are probably already tested by I used snapshots to display the user-facing messages. Tried to use tidyverse style guide + cli pluralization when possible.

The reprex in #475 now prints.


![image](https://github.com/rstudio/gt/assets/52606734/c7308181-8e1e-4060-998e-44f0be85f1cd)

It mentions which footnote it was to be able to find it more easily + the offending function where column selection couldn't be resolved.

## approach adding a bunch of call for error chaining.

For mentioning the function, you can see that I added manually the name of the function for better display (there were just a couple of instances.

TIL  this in case it can be helpful!

``` r
f <- function(x) {
  g(x)
}

f2 <- function(x) {
  g(x, call = call("my_fn"))
}
f3 <- function(x) {
  f_user_face <- "my_fn"
  g(x, call = call(f_user_face))
  
}

g <- function(x, call = rlang::caller_env()) {
  
  cli::cli_abort("{x}", call = call)
}

f(23)
#> Error in `f()`:
#> ! 23

f2(23)
#> Error in `my_fn()`:
#> ! 23

f3(23)
#> Error in `my_fn()`:
#> ! 23
```

<sup>Created on 2024-04-25 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

# Related GitHub Issues and PRs

Fixes #475 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
