### PR TITLE
Fix unwanted pagination controls

### DIFF
--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -469,7 +469,7 @@ render_as_ihtml <- function(data, id) {
       compact = use_compact_mode,
       wrap = use_text_wrapping,
       showSortIcon = TRUE,
-      showSortable = TRUE,
+      showSortable = FALSE,
       class = NULL,
       style = NULL,
       rowClass = NULL,

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -451,7 +451,7 @@ render_as_ihtml <- function(data, id) {
       showPageSizeOptions = use_page_size_select,
       pageSizeOptions = page_size_values,
       paginationType = pagination_type,
-      showPagination = TRUE,
+      showPagination = use_pagination,
       showPageInfo = use_pagination_info,
       minRows = 1,
       paginateSubRows = FALSE,


### PR DESCRIPTION
When *not* using pagination in interactive tables as in:

```r
library(gt)

gt(iris) |> 
    opt_interactive(use_pagination = FALSE)
```

The output would show disabled controls for pagination. This is undesired and the fix here ensure that if `use_pagination` is `FALSE` we don't get any pages or pagination controls.

Fixes: https://github.com/rstudio/gt/issues/1542