### PR TITLE
Ensure that supplied locale is normalized when creating an interactive table

### DIFF
--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -54,7 +54,7 @@ render_as_ihtml <- function(data, id) {
   has_tab_spanners <- dt_spanners_exists(data = data)
 
   # Obtain the language from the `locale`, if provided
-  locale <- dt_locale_get_value(data = data)
+  locale <- normalize_locale(dt_locale_get_value(data = data))
 
   # Generate a `lang_defs` object to pass to the `language` argument
   if (is.null(locale) || locale == "en") {


### PR DESCRIPTION
When using an interactive table, the locale value (supplied in the initial `gt()` call) is retrieved in order to display elements/controls in the language of the locale. However, there are a few ways to write a locale and internally `normalize_locale()` is used to standardize a provided locale to a chosen form.

This wasn't done in the codepath for making an interactive table so using `"fr_CH"` instead of `"fr-CH"` would have resulted in english text (the result of a failed lookup). This PR ensures that the locale value is normalized so the following code works as expected:

```r
library(gt)
library(tidyverse)

mtcars |> 
  mutate(mpg = mpg*1000) |> 
  gt(locale = "de_CH") |> # or "fr_CH"
  fmt_number(mpg, decimals = 2) |>
  opt_interactive()
```

Fixes: https://github.com/rstudio/gt/issues/1637