### PR TITLE
Render SVG cells as images in `as_gtable()` output.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,6 +65,7 @@ Suggests:
     paletteer,
     RColorBrewer,
     rmarkdown (>= 2.20),
+    rsvg,
     rvest,
     shiny (>= 1.7.4),
     testthat (>= 3.1.9),

--- a/R/export.R
+++ b/R/export.R
@@ -1324,6 +1324,9 @@ render_grobs <- function(
     text_grob = grid::textGrob,
     cell_grob = grid::segmentsGrob
 ) {
+  if (any(grepl("<svg.*>.*</svg>", layout$label))) {
+    rlang::check_installed("rsvg", "for rendering SVG cells.")
+  }
 
   style <- grid_resolve_style(layout = layout, data = data)
 

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -841,24 +841,13 @@ render_grid_cell <- function(
   height <- 0
 
   if (nzchar(label)) {
-    hjust <- style$hjust %||% 0
-    vjust <- style$vjust %||% 0
 
-    x <- (1 - hjust) * margin[4] - hjust * margin[2]
-    y <- (1 - vjust) * margin[3] - vjust * margin[1]
-    x <- grid::unit(hjust, "npc") + x
-    y <- grid::unit(vjust, "npc") + y
+      content <- render_grid_text(label, style, margin, text_grob)
 
-    text <- text_grob(
-      label, x = x, y = y,
-      hjust = hjust, vjust = vjust,
-      gp = style$text_gp
-    )
+    width  <- grid_width(content)  + sum(grid_width(margin[c(2, 4)]))
+    height <- grid_height(content) + sum(grid_height(margin[c(1, 3)]))
 
-    width  <- grid_width(text)  + sum(grid_width(margin[c(2, 4)]))
-    height <- grid_height(text) + sum(grid_height(margin[c(1, 3)]))
-
-    grobs <- c(grobs, list(text))
+    grobs <- c(grobs, list(content))
   }
 
   if (sum(lengths(style$cell_gp))) {
@@ -886,6 +875,21 @@ render_grid_cell <- function(
   )
 }
 
+render_grid_text <- function(label, style, margin, text_grob) {
+  hjust <- style$hjust %||% 0
+  vjust <- style$vjust %||% 0
+
+  x <- (1 - hjust) * margin[4] - hjust * margin[2]
+  y <- (1 - vjust) * margin[3] - vjust * margin[1]
+  x <- grid::unit(hjust, "npc") + x
+  y <- grid::unit(vjust, "npc") + y
+
+  text_grob(
+    label, x = x, y = y,
+    hjust = hjust, vjust = vjust,
+    gp = style$text_gp
+  )
+}
 # This is just a data.frame wrapper to set standard columns for the layout.
 grid_layout <- function(left, right = left, top, bottom = top, label,
                         classes, style, name) {

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -915,14 +915,14 @@ render_grid_svg <- function(label, style, margin) {
   if (any(grepl("^height:", svg_style))) {
     height <- gsub("^height:", "", svg_style[grep("^height:", svg_style)]) %>%
       parse_fontsize(style$text_gp$fontsize) %>%
-      unit(.grid_unit)
+      grid::unit(.grid_unit)
   }
 
   # Try if any width is declared in style attribute
   if (any(grepl("^width:", svg_style))) {
     width <- gsub("^width:", "", svg_style[grep("^width:", svg_style)]) %>%
       parse_fontsize(style$text_gp$fontsize) %>%
-      unit(.grid_unit)
+      grid::unit(.grid_unit)
   }
 
   # If style attribute was incomplete; try to derive width/height from viewbox
@@ -944,8 +944,8 @@ render_grid_svg <- function(label, style, margin) {
       width  <- height / asp
     } else {
       # Interpret view box as pixels
-      width  <- unit(dx * 0.75, "pt")
-      height <- unit(dy * 0.75, "pt")
+      width  <- grid::unit(dx * 0.75, "pt")
+      height <- grid::unit(dy * 0.75, "pt")
     }
   }
 
@@ -957,8 +957,7 @@ render_grid_svg <- function(label, style, margin) {
   x <- grid::unit(hjust, "npc") + x
   y <- grid::unit(vjust, "npc") + y
 
-  w <- ceiling(convertUnit(width,  "in", valueOnly = TRUE) * 300)
-  h <- ceiling(convertUnit(height, "in", valueOnly = TRUE) * 300)
+  w <- ceiling(grid::convertUnit(width,  "in", valueOnly = TRUE) * 300)
 
   raster <- try_fetch(
     {
@@ -970,9 +969,10 @@ render_grid_svg <- function(label, style, margin) {
           x = x, y = y, hjust = hjust, vjust = vjust
         )
     },
-    error = function(...) grid::rasterGrob(
-      NA, width = unit(0, .grid_unit), height = unit(0, .grid_unit)
-    )
+    error = function(...) {
+      zero <- grid::unit(0, .grid_unit)
+      grid::rasterGrob(NA, width = zero, height = zero)
+    }
   )
 
   raster

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -897,6 +897,11 @@ render_grid_text <- function(label, style, margin, text_grob) {
 
 render_grid_svg <- function(label, style, margin) {
 
+  # Delete title
+  # Titles may contain contain html that cannot be interpreted by rsvg,
+  # and they cannot be displayed interactively in {grid} anyway.
+  label <- gsub("<title(.*?)</title>", "", label)
+
   svg_string <- regexpr("<svg(.*?)>.*</svg>", label) %>%
     regmatches(x = label) %>%
     gsub(pattern = "\n", replacement = "") %>%
@@ -942,18 +947,16 @@ render_grid_svg <- function(label, style, margin) {
         # Try extract width from tag
         w <- regexpr("width=(.*?) ", svg_tag) %>%
           regmatches(x = svg_tag)
-        w <- regexpr("\\d+", w) %>%
+        viewbox[3] <- regexpr("\\d+", w) %>%
           regmatches(x = w) %>%
           as.numeric()
-        viewbox[3] <- w
 
         # Try extract height from tag
         h <- regexpr("height=(.*?) ", svg_tag) %>%
           regmatches(x = svg_tag)
-        h <- regexpr("\\d+", h) %>%
+        viewbox[4] <- regexpr("\\d+", h) %>%
           regmatches(x = h) %>%
           as.numeric()
-        viewbox[4] <- h
 
       } else {
         viewbox <- c(0, 0, 20, 20)

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -1109,6 +1109,11 @@ parse_fontsize <- function(size, base) {
     new_size[pct] <- as.numeric(gsub("\\%$", "", size[pct])) / 100 * base
   }
 
+  em <- grep("em$", size)
+  if (length(em) > 0) {
+    new_size[em] <- as.numeric(gsub("rem$|em$", "", size[em])) * base
+  }
+
   # Parse pixels
   px <- grep("px$", size)
   if (length(px) > 0) {

--- a/tests/testthat/test-utils_render_grid.R
+++ b/tests/testthat/test-utils_render_grid.R
@@ -533,3 +533,23 @@ test_that("Classes and styles are parsed correctly", {
 
 
 })
+
+# Feature tests -----------------------------------------------------------
+
+test_that("as_gtable renders svg entries", {
+
+  df <- data.frame(
+    x = 1,
+    y = I("<svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"50\" cy=\"50\" r=\"50\"/></svg> ")
+  )
+
+  test <- as_gtable(gt(df))
+  test <- test$grobs[test$layout$t == 2 & test$layout$l == 3][[1]]
+
+  raster <- test$children[[2]]
+  expect_equal(dim(raster$raster), c(312, 312))
+  expect_equal(as.numeric(raster$width),  75)
+  expect_equal(as.numeric(raster$height), 75)
+
+})
+


### PR DESCRIPTION
# Summary

This PR aims to fix #1652. 

Briefly, in the `as_gtable()` approach, it renders cells with the `<svg>` tags using {rsvg} into raster images. It uses a regex pattern to recognise the tag and switches from a 'render plain text' mode to 'render svg' mode via a new internal function `render_grid_svg()`. Most of this function's body is just trying to parse dimensions from the svg string.

# Related GitHub Issues and PRs

- Ref: #1652

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
