### PR TITLE
Standardize `vec_*()` error messages.

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -7580,8 +7580,8 @@ fmt_duration <- function(
     is.null(input_units)
   ) {
     cli::cli_abort(c(
-      "When there are numeric columns to format, `input_units` must not be `NULL`.",
-      "*" = "Use one of \"seconds\", \"minutes\", \"hours\", \"days\", or \"weeks\"."
+      "{.arg input_units} must be supplied when there are numeric columns to format.",
+      "i" = "Use one of \"seconds\", \"minutes\", \"hours\", \"days\", or \"weeks\"."
     ))
   }
 

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -3686,7 +3686,7 @@ check_vector_valid <- function(x, valid_classes = NULL, call = rlang::caller_env
   cls <- valid_classes
   if (!rlang::is_vector(x) || !(is.null(cls) || inherits(x, cls))) {
     cli::cli_abort(
-      "{.arg x} must be {.or {cls}} vectors, not {.object_type_friendly {x}}.",
+      "{.arg x} must be {.or {cls}} vectors, not {.obj_type_friendly {x}}.",
       call = call
     )
   }

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -299,15 +299,8 @@ vec_fmt_number <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
-  # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_number()` function can only be used with numeric vectors."
-    )
-  }
+  # Stop function if `x` is not a vector or is incompatible with the formatting
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -462,11 +455,7 @@ vec_fmt_integer <- function(
 ) {
 
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_integer()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   vec_fmt_number(
     x,
@@ -632,15 +621,8 @@ vec_fmt_scientific <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_scientific()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -813,15 +795,8 @@ vec_fmt_engineering <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_engineering()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -1002,15 +977,8 @@ vec_fmt_percent <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_percent()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -1212,18 +1180,11 @@ vec_fmt_partsper <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
+  # Stop function if class of `x` is incompatible with the formatting
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `to_units` is matched correctly to one option
   to_units <- rlang::arg_match(to_units)
-
-  # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_partsper()` function can only be used with numeric vectors."
-    )
-  }
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -1376,18 +1337,11 @@ vec_fmt_fraction <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
+  # Stop function if class of `x` is incompatible with the formatting
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `layout` is matched correctly to one option
   layout <- rlang::arg_match(layout)
-
-  # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_fraction()` function can only be used with numeric vectors."
-    )
-  }
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -1596,15 +1550,8 @@ vec_fmt_currency <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_currency()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -1720,20 +1667,11 @@ vec_fmt_roman <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
-  # Ensure that `case` is matched correctly to one option
-  case <- rlang::arg_match(case)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_roman()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
-  # Ensure that `output` is matched correctly to one option
+  # Ensure that `case` and `output` are matched correctly to one option
+  case <- rlang::arg_match(case)
   output <- rlang::arg_match(output)
 
   if (output == "auto") {
@@ -1857,21 +1795,12 @@ vec_fmt_index <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_index()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
-  # Ensure that `case` and `index_algo` are matched correctly to one option
+  # Ensure that `case`, `index_algo` and `output` are matched correctly to one option
   case <- rlang::arg_match(case)
   index_algo <- rlang::arg_match(index_algo)
-
-  # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
 
   if (output == "auto") {
@@ -1996,15 +1925,8 @@ vec_fmt_spelled_num <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_spelled_num()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -2174,20 +2096,11 @@ vec_fmt_bytes <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
-    cli::cli_abort(
-      "The `vec_fmt_bytes()` function can only be used with numeric vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
-  # Ensure that `standard` is matched correctly to one option
+  # Ensure that `standard` and `output` are matched correctly to one option
   standard <- rlang::arg_match(standard)
-
-  # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
 
   if (output == "auto") {
@@ -2372,15 +2285,8 @@ vec_fmt_date <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("Date", "POSIXt", "character"))) {
-    cli::cli_abort(
-      "The `vec_fmt_date()` function can only be used with Date, POSIXt, or character vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("Date", "POSIXt", "character"))
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -2548,15 +2454,8 @@ vec_fmt_time <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("Date", "POSIXt", "character"))) {
-    cli::cli_abort(
-      "The `vec_fmt_time()` function can only be used with Date, POSIXt, or character vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("Date", "POSIXt", "character"))
 
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
@@ -3395,15 +3294,9 @@ vec_fmt_datetime <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("Date", "POSIXct", "character"))) {
-    cli::cli_abort(
-      "The `vec_fmt_datetime()` function can only be used with Date, POSIXct, or character vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("Date", "POSIXct", "character"))
+
   # Ensure that `output` is matched correctly to one option
   output <- rlang::arg_match(output)
 
@@ -3654,20 +3547,13 @@ vec_fmt_duration <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
 
-  # Ensure that `duration_style` is matched correctly to one option
-  duration_style <- rlang::arg_match(duration_style)
 
   # Stop function if class of `x` is incompatible with the formatting
-  if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer", "difftime"))) {
-    cli::cli_abort(
-      "The `vec_fmt_duration()` function can only be used with numeric, integer, or difftime vectors."
-    )
-  }
+  check_vector_valid(x, valid_classes = c("numeric", "integer", "difftime"))
 
-  # Ensure that `output` is matched correctly to one option
+  # Ensure that `duration_style` and `ouput` are matched correctly to one option
+  duration_style <- rlang::arg_match(duration_style)
   output <- rlang::arg_match(output)
 
   if (output == "auto") {
@@ -3766,11 +3652,8 @@ vec_fmt_markdown <- function(
 
   # Ensure that arguments are matched
   md_engine <- rlang::arg_match(md_engine)
-
-  # Ensure that `x` is strictly a vector with `rlang::is_vector()`
-  stop_if_not_vector(x)
-
   output <- rlang::arg_match(output)
+
   if (output == "auto") {
     output <- determine_output_format()
   }
@@ -3798,17 +3681,16 @@ gt_one_col <- function(x) {
   gt(dplyr::tibble(x = x), auto_align = FALSE, process_md = FALSE)
 }
 
-stop_if_not_vector <- function(x, call = rlang::caller_env()) {
-  if (!rlang::is_vector(x)) {
+# Similar as `stop_if_not_vector()` if `valid_classes` is not supplied.
+check_vector_valid <- function(x, valid_classes = NULL, call = rlang::caller_env()) {
+  cls <- valid_classes
+  if (!rlang::is_vector(x) || !(is.null(cls) || inherits(x, cls))) {
     cli::cli_abort(
-      "`x` must be a vector, not {.obj_type_friendly {x}}.",
+      "{.arg x} must be {.or {cls}} vectors, not {.object_type_friendly {x}}.",
       call = call
     )
   }
-}
-
-vector_class_is_valid <- function(x, valid_classes) {
-  inherits(x, valid_classes)
+  invisible()
 }
 
 render_as_vector <- function(data, output) {

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -299,13 +299,6 @@ vec_fmt_number <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -314,6 +307,13 @@ vec_fmt_number <- function(
     cli::cli_abort(
       "The `vec_fmt_number()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -632,13 +632,6 @@ vec_fmt_scientific <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -647,6 +640,13 @@ vec_fmt_scientific <- function(
     cli::cli_abort(
       "The `vec_fmt_scientific()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -813,13 +813,6 @@ vec_fmt_engineering <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -828,6 +821,13 @@ vec_fmt_engineering <- function(
     cli::cli_abort(
       "The `vec_fmt_engineering()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -1002,13 +1002,6 @@ vec_fmt_percent <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -1017,6 +1010,13 @@ vec_fmt_percent <- function(
     cli::cli_abort(
       "The `vec_fmt_percent()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -1212,13 +1212,6 @@ vec_fmt_partsper <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -1230,6 +1223,13 @@ vec_fmt_partsper <- function(
     cli::cli_abort(
       "The `vec_fmt_partsper()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -1376,13 +1376,6 @@ vec_fmt_fraction <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -1394,6 +1387,13 @@ vec_fmt_fraction <- function(
     cli::cli_abort(
       "The `vec_fmt_fraction()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -1596,13 +1596,6 @@ vec_fmt_currency <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -1611,6 +1604,13 @@ vec_fmt_currency <- function(
     cli::cli_abort(
       "The `vec_fmt_currency()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -1720,13 +1720,6 @@ vec_fmt_roman <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -1738,6 +1731,13 @@ vec_fmt_roman <- function(
     cli::cli_abort(
       "The `vec_fmt_roman()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -1857,25 +1857,25 @@ vec_fmt_index <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
-
-  # Ensure that `case` and `index_algo` are matched correctly to one option
-  case <- rlang::arg_match(case)
-  index_algo <- rlang::arg_match(index_algo)
 
   # Stop function if class of `x` is incompatible with the formatting
   if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
     cli::cli_abort(
       "The `vec_fmt_index()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `case` and `index_algo` are matched correctly to one option
+  case <- rlang::arg_match(case)
+  index_algo <- rlang::arg_match(index_algo)
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -1996,13 +1996,6 @@ vec_fmt_spelled_num <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -2011,6 +2004,13 @@ vec_fmt_spelled_num <- function(
     cli::cli_abort(
       "The `vec_fmt_spelled_num()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -2174,24 +2174,24 @@ vec_fmt_bytes <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
-
-  # Ensure that `standard` is matched correctly to one option
-  standard <- rlang::arg_match(standard)
 
   # Stop function if class of `x` is incompatible with the formatting
   if (!vector_class_is_valid(x, valid_classes = c("numeric", "integer"))) {
     cli::cli_abort(
       "The `vec_fmt_bytes()` function can only be used with numeric vectors."
     )
+  }
+
+  # Ensure that `standard` is matched correctly to one option
+  standard <- rlang::arg_match(standard)
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -2372,13 +2372,6 @@ vec_fmt_date <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -2387,6 +2380,13 @@ vec_fmt_date <- function(
     cli::cli_abort(
       "The `vec_fmt_date()` function can only be used with Date, POSIXt, or character vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -2548,13 +2548,6 @@ vec_fmt_time <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -2563,6 +2556,13 @@ vec_fmt_time <- function(
     cli::cli_abort(
       "The `vec_fmt_time()` function can only be used with Date, POSIXt, or character vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -3395,13 +3395,6 @@ vec_fmt_datetime <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -3410,6 +3403,12 @@ vec_fmt_datetime <- function(
     cli::cli_abort(
       "The `vec_fmt_datetime()` function can only be used with Date, POSIXct, or character vectors."
     )
+  }
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -3655,13 +3654,6 @@ vec_fmt_duration <- function(
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
 
-  # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
-
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
 
@@ -3673,6 +3665,13 @@ vec_fmt_duration <- function(
     cli::cli_abort(
       "The `vec_fmt_duration()` function can only be used with numeric, integer, or difftime vectors."
     )
+  }
+
+  # Ensure that `output` is matched correctly to one option
+  output <- rlang::arg_match(output)
+
+  if (output == "auto") {
+    output <- determine_output_format()
   }
 
   render_as_vector(
@@ -3766,15 +3765,15 @@ vec_fmt_markdown <- function(
 ) {
 
   # Ensure that arguments are matched
-  output <- rlang::arg_match(output)
   md_engine <- rlang::arg_match(md_engine)
-
-  if (output == "auto") {
-    output <- determine_output_format()
-  }
 
   # Ensure that `x` is strictly a vector with `rlang::is_vector()`
   stop_if_not_vector(x)
+
+  output <- rlang::arg_match(output)
+  if (output == "auto") {
+    output <- determine_output_format()
+  }
 
   vec_fmt_out <-
     render_as_vector(

--- a/tests/testthat/_snaps/vec_fmt.md
+++ b/tests/testthat/_snaps/vec_fmt.md
@@ -4,15 +4,15 @@
       check_vector_valid(1, "integer")
     Condition
       Error:
-      ! `x` must be integer vectors, not 1.
+      ! `x` must be integer vectors, not a number.
     Code
       check_vector_valid(TRUE, c("numeric", "integer"))
     Condition
       Error:
-      ! `x` must be numeric or integer vectors, not TRUE.
+      ! `x` must be numeric or integer vectors, not `TRUE`.
     Code
       check_vector_valid(data.frame(x = 1), c("numeric", "integer"))
     Condition
       Error:
-      ! `x` must be numeric or integer vectors, not 1.
+      ! `x` must be numeric or integer vectors, not a data frame.
 

--- a/tests/testthat/_snaps/vec_fmt.md
+++ b/tests/testthat/_snaps/vec_fmt.md
@@ -1,0 +1,18 @@
+# check_vector_valid() works correctly
+
+    Code
+      check_vector_valid(1, "integer")
+    Condition
+      Error:
+      ! `x` must be integer vectors, not 1.
+    Code
+      check_vector_valid(TRUE, c("numeric", "integer"))
+    Condition
+      Error:
+      ! `x` must be numeric or integer vectors, not TRUE.
+    Code
+      check_vector_valid(data.frame(x = 1), c("numeric", "integer"))
+    Condition
+      Error:
+      ! `x` must be numeric or integer vectors, not 1.
+

--- a/tests/testthat/test-vec_fmt.R
+++ b/tests/testthat/test-vec_fmt.R
@@ -6147,3 +6147,12 @@ test_that("The `vec_fmt_datetime()` function works", {
       )
     )
 })
+
+test_that("The `vec_fmt_duration()` function works", {
+  tm <- as.difftime(c("0:3:20"))
+  # tests are mostly duplicates of `fmt_duration()`
+  expect_equal(
+    vec_fmt_duration(tm),
+    "3m 20s"
+  )
+})

--- a/tests/testthat/test-vec_fmt.R
+++ b/tests/testthat/test-vec_fmt.R
@@ -6168,3 +6168,14 @@ test_that("vec_fmt_*() error when bad input are supplied.", {
   expect_error(vec_fmt_duration(list(1, 2, 3)))
   expect_error(vec_fmt_duration(dplyr::tibble(a = c(1, 2, 3))))
 })
+
+test_that("check_vector_valid() works correctly", {
+  expect_null(check_vector_valid(1))
+  expect_null(check_vector_valid(list()))
+
+  expect_snapshot(error = TRUE, {
+    check_vector_valid(1, "integer")
+    check_vector_valid(TRUE, c("numeric", "integer"))
+    check_vector_valid(data.frame(x = 1), c("numeric", "integer"))
+  })
+})

--- a/tests/testthat/test-vec_fmt.R
+++ b/tests/testthat/test-vec_fmt.R
@@ -427,11 +427,6 @@ test_that("The `vec_fmt_number()` function works", {
         "+1.00", "+1.50", "+2.00", "+2.50", "NA", "+Inf"
       )
     )
-
-  expect_error(vec_fmt_number(letters))
-  expect_error(vec_fmt_number(TRUE))
-  expect_error(vec_fmt_number(list(1, 2, 3)))
-  expect_error(vec_fmt_number(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_integer()` function works", {
@@ -605,11 +600,6 @@ test_that("The `vec_fmt_integer()` function works", {
         "NA", "+Inf"
       )
     )
-
-  expect_error(vec_fmt_integer(letters))
-  expect_error(vec_fmt_integer(TRUE))
-  expect_error(vec_fmt_integer(list(1, 2, 3)))
-  expect_error(vec_fmt_integer(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_scientific()` function works", {
@@ -911,11 +901,6 @@ test_that("The `vec_fmt_scientific()` function works", {
         "+2.00 \\'d7 10{\\super 6}", "+2.50 \\'d7 10{\\super 6}", "NA"
       )
     )
-
-  expect_error(vec_fmt_scientific(letters))
-  expect_error(vec_fmt_scientific(TRUE))
-  expect_error(vec_fmt_scientific(list(1, 2, 3)))
-  expect_error(vec_fmt_scientific(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_engineering()` function works", {
@@ -1342,11 +1327,6 @@ test_that("The `vec_fmt_engineering()` function works", {
         "+2.50 \\'d7 10{\\super 6}", "NA", "+Inf"
       )
     )
-
-  expect_error(vec_fmt_engineering(letters))
-  expect_error(vec_fmt_engineering(TRUE))
-  expect_error(vec_fmt_engineering(list(1, 2, 3)))
-  expect_error(vec_fmt_engineering(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_percent()` function works", {
@@ -1821,11 +1801,6 @@ test_that("The `vec_fmt_percent()` function works", {
         "NA", "% Inf"
       )
     )
-
-  expect_error(vec_fmt_percent(letters))
-  expect_error(vec_fmt_percent(TRUE))
-  expect_error(vec_fmt_percent(list(1, 2, 3)))
-  expect_error(vec_fmt_percent(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_partsper()` function works", {
@@ -2029,11 +2004,6 @@ test_that("The `vec_fmt_partsper()` function works", {
         "NA", "Infppm"
       )
     )
-
-  expect_error(vec_fmt_partsper(letters))
-  expect_error(vec_fmt_partsper(TRUE))
-  expect_error(vec_fmt_partsper(list(1, 2, 3)))
-  expect_error(vec_fmt_partsper(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_fraction()` function works", {
@@ -2739,12 +2709,8 @@ test_that("The `vec_fmt_fraction()` function works", {
   vec_fmt_fraction(not_numbers, layout = "inline", output = "rtf") %>%
     expect_equal(c("NA", "NaN", "Inf", "-Inf"))
 
-  expect_error(vec_fmt_fraction(letters))
   expect_error(vec_fmt_fraction(c(1, 2, 3), accuracy = 0))
   expect_error(vec_fmt_fraction(c(1, 2, 3), accuracy = -1))
-  expect_error(vec_fmt_fraction(TRUE))
-  expect_error(vec_fmt_fraction(list(1, 2, 3)))
-  expect_error(vec_fmt_fraction(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_currency()` function works", {
@@ -3383,10 +3349,6 @@ test_that("The `vec_fmt_currency()` function works", {
     )
 
   expect_error(vec_fmt_currency(c(1, 2), currency = "NOTREAL"))
-  expect_error(vec_fmt_currency(letters))
-  expect_error(vec_fmt_currency(TRUE))
-  expect_error(vec_fmt_currency(list(1, 2, 3)))
-  expect_error(vec_fmt_currency(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_roman()` function works", {
@@ -3444,10 +3406,6 @@ test_that("The `vec_fmt_roman()` function works", {
   )
 
   expect_error(vec_fmt_roman(c(1, 2), case = "middle"))
-  expect_error(vec_fmt_roman(letters))
-  expect_error(vec_fmt_roman(TRUE))
-  expect_error(vec_fmt_roman(list(1, 2, 3)))
-  expect_error(vec_fmt_roman(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_index()` function works", {
@@ -3509,10 +3467,6 @@ test_that("The `vec_fmt_index()` function works", {
     )
 
   expect_error(vec_fmt_index(c(1, 2), case = "middle"))
-  expect_error(vec_fmt_index(letters))
-  expect_error(vec_fmt_index(TRUE))
-  expect_error(vec_fmt_index(list(1, 2, 3)))
-  expect_error(vec_fmt_index(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_spelled_num()` function works", {
@@ -3551,11 +3505,6 @@ test_that("The `vec_fmt_spelled_num()` function works", {
         "een", "NA", "twintig", "tagtig", "honderd", "200"
       )
     )
-
-  expect_error(vec_fmt_spelled_num(letters))
-  expect_error(vec_fmt_spelled_num(TRUE))
-  expect_error(vec_fmt_spelled_num(list(1, 2, 3)))
-  expect_error(vec_fmt_spelled_num(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_bytes()` function works", {
@@ -4356,10 +4305,6 @@ test_that("The `vec_fmt_bytes()` function works", {
     )
 
   expect_error(vec_fmt_bytes(c(1, 2), standard = "NONE"))
-  expect_error(vec_fmt_bytes(letters))
-  expect_error(vec_fmt_bytes(TRUE))
-  expect_error(vec_fmt_bytes(list(1, 2, 3)))
-  expect_error(vec_fmt_bytes(dplyr::tibble(a = c(1, 2, 3))))
 })
 
 test_that("The `vec_fmt_date()` function works", {
@@ -6155,4 +6100,71 @@ test_that("The `vec_fmt_duration()` function works", {
     vec_fmt_duration(tm),
     "3m 20s"
   )
+})
+
+test_that("vec_fmt_*() error when bad input are supplied.", {
+  expect_error(vec_fmt_number(letters))
+  expect_error(vec_fmt_number(TRUE))
+  expect_error(vec_fmt_number(list(1, 2, 3)))
+  expect_error(vec_fmt_number(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_integer(letters))
+  expect_error(vec_fmt_integer(TRUE))
+  expect_error(vec_fmt_integer(list(1, 2, 3)))
+  expect_error(vec_fmt_integer(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_scientific(letters))
+  expect_error(vec_fmt_scientific(TRUE))
+  expect_error(vec_fmt_scientific(list(1, 2, 3)))
+  expect_error(vec_fmt_scientific(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_engineering(letters))
+  expect_error(vec_fmt_engineering(TRUE))
+  expect_error(vec_fmt_engineering(list(1, 2, 3)))
+  expect_error(vec_fmt_engineering(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_percent(letters))
+  expect_error(vec_fmt_percent(TRUE))
+  expect_error(vec_fmt_percent(list(1, 2, 3)))
+  expect_error(vec_fmt_percent(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_partsper(letters))
+  expect_error(vec_fmt_partsper(TRUE))
+  expect_error(vec_fmt_partsper(list(1, 2, 3)))
+  expect_error(vec_fmt_partsper(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_fraction(letters))
+  expect_error(vec_fmt_fraction(TRUE))
+  expect_error(vec_fmt_fraction(list(1, 2, 3)))
+  expect_error(vec_fmt_fraction(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_currency(letters))
+  expect_error(vec_fmt_currency(TRUE))
+  expect_error(vec_fmt_currency(list(1, 2, 3)))
+  expect_error(vec_fmt_currency(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_roman(letters))
+  expect_error(vec_fmt_roman(TRUE))
+  expect_error(vec_fmt_roman(list(1, 2, 3)))
+  expect_error(vec_fmt_roman(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_index(letters))
+  expect_error(vec_fmt_index(TRUE))
+  expect_error(vec_fmt_index(list(1, 2, 3)))
+  expect_error(vec_fmt_index(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_spelled_num(letters))
+  expect_error(vec_fmt_spelled_num(TRUE))
+  expect_error(vec_fmt_spelled_num(list(1, 2, 3)))
+  expect_error(vec_fmt_spelled_num(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_bytes(letters))
+  expect_error(vec_fmt_bytes(TRUE))
+  expect_error(vec_fmt_bytes(list(1, 2, 3)))
+  expect_error(vec_fmt_bytes(dplyr::tibble(a = c(1, 2, 3))))
+
+  expect_error(vec_fmt_duration(letters))
+  expect_error(vec_fmt_duration(TRUE))
+  expect_error(vec_fmt_duration(list(1, 2, 3)))
+  expect_error(vec_fmt_duration(dplyr::tibble(a = c(1, 2, 3))))
 })


### PR DESCRIPTION
# Summary

This standardizes error messages for `vec_*()`.

It gets rid of two internal functions and consolidates them into one:

`check_vector_valid()`.

## Overview of `check_vector_valid()`

``` r
pkgload::load_all()
#> ℹ Loading gt
# like stop_if_not_vector()
check_vector_valid(1)
# works
check_vector_valid(1, c("numeric", "integer"))
check_vector_valid(Sys.Date(), c("Date"))
check_vector_valid(Sys.Date(), "integer")
#> Error:
#> ! `x` must be integer vectors, not a <Date> object.
check_vector_valid(rep(Sys.Date(), length.out = 100), c("integer", "character"))
#> Error:
#> ! `x` must be integer or character vectors, not a <Date> object.
```

<sup>Created on 2024-05-13 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
