### PR TITLE
Small documentation fixes for `locale` throughout the `vec_fmt_*()` fns; text fixes in docs of `fmt_chem()`

### DIFF
--- a/R/format_data.R
+++ b/R/format_data.R
@@ -9367,7 +9367,7 @@ fmt_units <- function(
 #' It's always best to show examples on usage:
 #'
 #' - `"CH3O2"` and `"(NH4)2S"` will render with subscripted numerals
-#' - Charges can be expressed terminating `"+"` or `"-"` as in `"H+"` and
+#' - Charges can be expressed with terminating `"+"` or `"-"`, as in `"H+"` and
 #'   `"[AgCl2]-"`; if any charges involve the use of a number, the following
 #'   incantations could be used: `"CrO4^2-"`, `"Fe^n+"`, `"Y^99+"`, `"Y^{99+}"`
 #'   (the final two forms produce equivalent output)
@@ -9392,7 +9392,7 @@ fmt_units <- function(
 #'   adjacent characters (i.e., these shouldn't be at the beginning or end of
 #'   the markup); two examples: `"C6H5-CHO"`, `"CH3CH=CH2"`
 #' - as with units notation, Greek letters can be inserted by surrounding the
-#'   letter name with `":"`; here's an example that denotes the delta value
+#'   letter name with `":"`; here's an example that describes the delta value
 #'   of carbon-13: `":delta: ^13C"`
 #'
 #' @section Examples:

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -9436,8 +9436,8 @@ fmt_units <- function(
 #' Taking just a few rows from the [`photolysis`] dataset, let's and create a
 #' new **gt** table. The `cmpd_formula` and `products` columns both contain
 #' text in chemistry notation (the first has compounds, and the second column
-#' has the products of photolysis reactions). These columns will be formatting
-#' by the `fmt_chem()` function. The compound formulas will be merged with the
+#' has the products of photolysis reactions). These columns will be formatted by
+#' the `fmt_chem()` function. The compound formulas will be merged with the
 #' compound names via the [cols_merge()] function.
 #'
 #' ```r

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -9433,12 +9433,12 @@ fmt_units <- function(
 #' `r man_get_image_tag(file = "man_fmt_chem_1.png")`
 #' }}
 #'
-#' Taking just a few rows from the [`photolysis`] dataset, let's and create a
-#' new **gt** table. The `cmpd_formula` and `products` columns both contain
-#' text in chemistry notation (the first has compounds, and the second column
-#' has the products of photolysis reactions). These columns will be formatted by
-#' the `fmt_chem()` function. The compound formulas will be merged with the
-#' compound names via the [cols_merge()] function.
+#' Taking just a few rows from the [`photolysis`] dataset, let's create a new
+#' **gt** table. The `cmpd_formula` and `products` columns both contain text in
+#' chemistry notation (the first has compounds, and the second column has the
+#' products of photolysis reactions). These columns will be formatted by the
+#' `fmt_chem()` function. The compound formulas will be merged with the compound
+#' names via the [cols_merge()] function.
 #'
 #' ```r
 #' photolysis %>%

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -60,6 +60,15 @@
 #'   `"word"`. In **knitr** rendering (i.e., Quarto or R Markdown), the `"auto"`
 #'   option will choose the correct `output` value
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Examples:
@@ -218,6 +227,15 @@ vec_fmt_number <- function(
 #'
 #' @inheritParams vec_fmt_number
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Examples:
@@ -345,6 +363,15 @@ vec_fmt_integer <- function(
 #' @inheritParams fmt_scientific
 #'
 #' @inheritParams vec_fmt_number
+#'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
 #'
 #' @return A character vector.
 #'
@@ -494,6 +521,15 @@ vec_fmt_scientific <- function(
 #'
 #' @inheritParams vec_fmt_number
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Examples:
@@ -639,6 +675,15 @@ vec_fmt_engineering <- function(
 #' @inheritParams fmt_percent
 #'
 #' @inheritParams vec_fmt_number
+#'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
 #'
 #' @return A character vector.
 #'
@@ -814,6 +859,15 @@ vec_fmt_percent <- function(
 #'
 #' @inheritParams vec_fmt_number
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Examples:
@@ -975,6 +1029,15 @@ vec_fmt_partsper <- function(
 #'
 #' @inheritParams vec_fmt_number
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Examples:
@@ -1130,6 +1193,15 @@ vec_fmt_fraction <- function(
 #'   glyph for the Dutch guilder in an HTML output table, and it would simply be
 #'   the letter "f" in all other output contexts). Please note that `decimals`
 #'   will default to `2` when using the [currency()] helper function.
+#'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
 #'
 #' @return A character vector.
 #'
@@ -1373,6 +1445,15 @@ vec_fmt_roman <- function(
 #'
 #' @inheritParams vec_fmt_number
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Examples:
@@ -1488,6 +1569,15 @@ vec_fmt_index <- function(
 #' instead be `"tjugotre"`.
 #'
 #' @inheritParams vec_fmt_number
+#'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
 #'
 #' @return A character vector.
 #'
@@ -1631,6 +1721,15 @@ vec_fmt_spelled_num <- function(
 #'
 #' @inheritParams vec_fmt_number
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Examples:
@@ -1765,6 +1864,15 @@ vec_fmt_bytes <- function(
 #' @inheritParams fmt_date
 #'
 #' @inheritParams vec_fmt_number
+#'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
 #'
 #' @return A character vector.
 #'
@@ -1939,6 +2047,15 @@ vec_fmt_date <- function(
 #'
 #' @inheritParams vec_fmt_number
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Formatting with the `time_style` argument:
@@ -2101,6 +2218,15 @@ vec_fmt_time <- function(
 #' @inheritParams fmt_datetime
 #'
 #' @inheritParams vec_fmt_number
+#'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
 #'
 #' @return A character vector.
 #'
@@ -2937,6 +3063,15 @@ vec_fmt_datetime <- function(
 #'
 #' @inheritParams vec_fmt_number
 #'
+#' @param locale *Locale identifier*
+#'
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'
+#'   An optional locale identifier that can be used for formatting values
+#'   according the locale's rules. Examples include `"en"` for English (United
+#'   States) and `"fr"` for French (France). We can use the [info_locales()]
+#'   function as a useful reference for all of the locales that are supported.
+#'
 #' @return A character vector.
 #'
 #' @section Examples:
@@ -3062,8 +3197,6 @@ vec_fmt_duration <- function(
     locale = NULL,
     output = c("auto", "plain", "html", "latex", "rtf", "word")
 ) {
-
-
 
   # Stop function if class of `x` is incompatible with the formatting
   check_vector_valid(x, valid_classes = c("numeric", "integer", "difftime"))

--- a/man/fmt_chem.Rd
+++ b/man/fmt_chem.Rd
@@ -170,8 +170,8 @@ surrounding the text with \code{"{{\%"}/\code{"\%}}"}.
 Taking just a few rows from the \code{\link{photolysis}} dataset, let's and create a
 new \strong{gt} table. The \code{cmpd_formula} and \code{products} columns both contain
 text in chemistry notation (the first has compounds, and the second column
-has the products of photolysis reactions). These columns will be formatting
-by the \code{fmt_chem()} function. The compound formulas will be merged with the
+has the products of photolysis reactions). These columns will be formatted by
+the \code{fmt_chem()} function. The compound formulas will be merged with the
 compound names via the \code{\link[=cols_merge]{cols_merge()}} function.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{photolysis \%>\%

--- a/man/fmt_chem.Rd
+++ b/man/fmt_chem.Rd
@@ -167,12 +167,12 @@ surrounding the text with \code{"{{\%"}/\code{"\%}}"}.
 <img src="https://raw.githubusercontent.com/rstudio/gt/master/images/man_fmt_chem_1.png" alt="This image of a table was generated from the first code example in the `fmt_chem()` help file." style="width:100\%;">
 }}
 
-Taking just a few rows from the \code{\link{photolysis}} dataset, let's and create a
-new \strong{gt} table. The \code{cmpd_formula} and \code{products} columns both contain
-text in chemistry notation (the first has compounds, and the second column
-has the products of photolysis reactions). These columns will be formatted by
-the \code{fmt_chem()} function. The compound formulas will be merged with the
-compound names via the \code{\link[=cols_merge]{cols_merge()}} function.
+Taking just a few rows from the \code{\link{photolysis}} dataset, let's create a new
+\strong{gt} table. The \code{cmpd_formula} and \code{products} columns both contain text in
+chemistry notation (the first has compounds, and the second column has the
+products of photolysis reactions). These columns will be formatted by the
+\code{fmt_chem()} function. The compound formulas will be merged with the compound
+names via the \code{\link[=cols_merge]{cols_merge()}} function.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{photolysis \%>\%
   dplyr::filter(cmpd_name \%in\% c(

--- a/man/fmt_chem.Rd
+++ b/man/fmt_chem.Rd
@@ -99,7 +99,7 @@ the more advanced typesetting tries to limit the amount of syntax needed.
 It's always best to show examples on usage:
 \itemize{
 \item \code{"CH3O2"} and \code{"(NH4)2S"} will render with subscripted numerals
-\item Charges can be expressed terminating \code{"+"} or \code{"-"} as in \code{"H+"} and
+\item Charges can be expressed with terminating \code{"+"} or \code{"-"}, as in \code{"H+"} and
 \code{"[AgCl2]-"}; if any charges involve the use of a number, the following
 incantations could be used: \code{"CrO4^2-"}, \code{"Fe^n+"}, \code{"Y^99+"}, \code{"Y^{99+}"}
 (the final two forms produce equivalent output)
@@ -124,7 +124,7 @@ examples \code{"KCr(SO4)2 . 12 H2O"} and \code{"KCr(SO4)2 * 12 H2O"}
 adjacent characters (i.e., these shouldn't be at the beginning or end of
 the markup); two examples: \code{"C6H5-CHO"}, \code{"CH3CH=CH2"}
 \item as with units notation, Greek letters can be inserted by surrounding the
-letter name with \code{":"}; here's an example that denotes the delta value
+letter name with \code{":"}; here's an example that describes the delta value
 of carbon-13: \code{":delta: ^13C"}
 }
 }

--- a/man/vec_fmt_bytes.Rd
+++ b/man/vec_fmt_bytes.Rd
@@ -130,10 +130,7 @@ The default is to use a space character for separation.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_currency.Rd
+++ b/man/vec_fmt_currency.Rd
@@ -198,10 +198,7 @@ symbol. The default is to not introduce a space character.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_date.Rd
+++ b/man/vec_fmt_date.Rd
@@ -44,10 +44,7 @@ literals.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_datetime.Rd
+++ b/man/vec_fmt_datetime.Rd
@@ -84,10 +84,7 @@ literals.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_duration.Rd
+++ b/man/vec_fmt_duration.Rd
@@ -128,10 +128,7 @@ default only negative values will display a minus sign.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_engineering.Rd
+++ b/man/vec_fmt_engineering.Rd
@@ -115,10 +115,7 @@ will display a sign.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_fraction.Rd
+++ b/man/vec_fmt_fraction.Rd
@@ -87,10 +87,7 @@ value of \code{"1,000"}. This argument is ignored if a \code{locale} is supplied
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_index.Rd
+++ b/man/vec_fmt_index.Rd
@@ -54,10 +54,7 @@ literals.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_integer.Rd
+++ b/man/vec_fmt_integer.Rd
@@ -116,10 +116,7 @@ This option is disregarded when using accounting notation with
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_number.Rd
+++ b/man/vec_fmt_number.Rd
@@ -166,10 +166,7 @@ This option is disregarded when using accounting notation with
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_partsper.Rd
+++ b/man/vec_fmt_partsper.Rd
@@ -142,10 +142,7 @@ the mark itself. This can be directly controlled by using either \code{TRUE} or
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_percent.Rd
+++ b/man/vec_fmt_percent.Rd
@@ -137,10 +137,7 @@ be \code{"right"} (the default) or \code{"left"}.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_scientific.Rd
+++ b/man/vec_fmt_scientific.Rd
@@ -127,10 +127,7 @@ will display a sign.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_spelled_num.Rd
+++ b/man/vec_fmt_spelled_num.Rd
@@ -35,10 +35,7 @@ literals.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 

--- a/man/vec_fmt_time.Rd
+++ b/man/vec_fmt_time.Rd
@@ -45,10 +45,7 @@ literals.}
 An optional locale identifier that can be used for formatting values
 according the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can use the \code{\link[=info_locales]{info_locales()}}
-function as a useful reference for all of the locales that are supported. A
-locale ID can be also set in the initial \code{\link[=gt]{gt()}} function call (where it
-would be used automatically by any function with a \code{locale} argument) but a
-\code{locale} value provided here will override that global locale.}
+function as a useful reference for all of the locales that are supported.}
 
 \item{output}{\emph{Output format}
 


### PR DESCRIPTION
This PR makes small changes that remove irrelevant text from the `vec_fmt_*()` function docs, and, small changes to the documentation of `fmt_chem()`.