### PR TITLE
Use 'data-qmd-base64' attr with base64 text when passing Markdown text to Quarto for processing

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -720,7 +720,12 @@ process_text <- function(text, context = "html") {
             }
           )
 
-        non_na_text <- tidy_gsub(non_na_text, "^", "<div data-qmd=\"")
+        # Use base64 encoding to avoid issues with escaping internal double
+        # quotes; used in conjunction with the  'data-qmd-base64' attribute
+        # that is recognized by Quarto
+        non_na_text <- base64enc::base64encode(charToRaw(non_na_text))
+
+        non_na_text <- tidy_gsub(non_na_text, "^", "<div data-qmd-base64=\"")
         non_na_text <- tidy_gsub(non_na_text, "$", "\">")
 
         non_na_text <-


### PR DESCRIPTION
This PR makes text for Markdown processing more resilient by transforming it to a base64-encoded string. In this way we can avoid having to escape double quotes (common within HTML tags); we only need to ensure the attribute used is `"data-qmd-base64"` (previously, we used `"data-qmd"`).

Fixes: https://github.com/rstudio/gt/issues/1487
Fixes: https://github.com/rstudio/gt/issues/1488