### PR TITLE
Remove spec() from dataset generation scripts

### DIFF
--- a/data-raw/03-gtcars.R
+++ b/data-raw/03-gtcars.R
@@ -1,3 +1,6 @@
 library(tidyverse)
 
 gtcars <- readr::read_csv(file = "data-raw/gtcars.csv")
+
+# Drop spec() attribute
+gtcars <- gtcars[]

--- a/data-raw/04-sp500.R
+++ b/data-raw/04-sp500.R
@@ -1,3 +1,6 @@
 library(tidyverse)
 
 sp500 <- readr::read_csv(file = "data-raw/sp500.csv")
+
+# Drop spec attribute
+sp500 <- sp500[]

--- a/data-raw/08-peeps.R
+++ b/data-raw/08-peeps.R
@@ -21,3 +21,6 @@ peeps <-
         weight_kg = col_double()
       )
   )
+
+# Drop spec attribute
+peeps <- peeps[]

--- a/data-raw/09-films.R
+++ b/data-raw/09-films.R
@@ -15,3 +15,6 @@ films <-
         imdb_url = col_character()
       )
   )
+
+# Drop spec() attribute
+films <- films[]

--- a/data-raw/15-photolysis.R
+++ b/data-raw/15-photolysis.R
@@ -18,3 +18,5 @@ photolysis <-
       )
   )
 
+# Drop spec attribute
+photolysis <- photolysis[]


### PR DESCRIPTION
# Summary 

Fix #1697 

The next time datasets are built, they will remove the readr::spec() attribute. Other datasets don't have this issue.

This is very minor, but it is just that object comparisons will be a little bit easier if we drop these classes.

I didn't rebuild the data as this is minor and this will naturally occur next time you need to add a dataset.

Strategy found in readr 1.3.0 changelog https://readr.tidyverse.org/news/index.html#tibble-data-frame-subclass-1-3-0


Basically, this aims to solve this.

```r
v1 <- gtcars %>% dplyr::slice_head(n = 1, by = year) %>% dplyr::arrange(year)
v2 <- gtcars %>% dplyr::group_by(year) %>%  dplyr::slice_head(n = 1) %>% dplyr::ungroup()
all.equal(v1, v2)
#> [1] "Attributes: < Length mismatch: comparison on first 2 components >"                   
#> [2] "Attributes: < Component “class”: Lengths (4, 3) differ (string compare on first 3) >"
#> [3] "Attributes: < Component “class”: 3 string mismatches >"      
```

WIth the help of this PR, eventually when the datasets are redone, 

```r
# gtcars will eventually become gtcars2 with this PR.
gtcars2 <- gtcars[]
v3 <- gtcars2 %>% dplyr::slice_head(n = 1, by = year) %>% dplyr::arrange(year)
v4 <- gtcars2 %>% dplyr::group_by(year) %>%  dplyr::slice_head(n = 1) %>% dplyr::ungroup()
all.equal(v3, v4)
#> TRUE
```

Note that gtcars2 still has tbl_df class  ("tbl_df"     "tbl"        "data.frame")
