### PR TITLE
Add support for `rowname_to_stub` + `opt_interactive()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt (development version)
 
+* `opt_interactive()` now shows row names if `rownames_to_stub = TRUE` (@olivroy, #1702). 
+
 * `data_color()` throws a more informative error message if `rows` didn't resolve to anything (@olivroy, #1659).
 
 * PDF output now allows the font size of a table to be set using the table.font.size parameter in the tab_options function (#1472).  The font sizes of individual table cells (including those in the body, stubs, column headings, etc.) can be set using tab_style function. Several other options specified in tab_style are now reflected in PDF output.

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -183,6 +183,8 @@ render_as_ihtml <- function(data, id) {
   column_labels_border_bottom_width <- opt_val(data = data, option = "column_labels_border_bottom_width")
   column_labels_border_bottom_color <- opt_val(data = data, option = "column_labels_border_bottom_color")
 
+  rownames_to_stub <- stub_rownames_has_column(data)
+
   emoji_symbol_fonts <-
     c(
       "Apple Color Emoji", "Segoe UI Emoji",
@@ -452,7 +454,7 @@ render_as_ihtml <- function(data, id) {
       data = data_tbl,
       columns = col_defs,
       columnGroups = colgroups_def,
-      rownames = NULL,
+      rownames = rownames_to_stub,
       groupBy = NULL,
       sortable = use_sorting,
       resizable = use_resizers,


### PR DESCRIPTION
fixes #1702

~Do you think it is worth adding a new test?~

```r
gt(iris, rownames_to_stub = T) %>% 
    opt_interactive()
```

~Maybe the width is too wide? I don't know how to tweak it.~

This PR

![image](https://github.com/rstudio/gt/assets/52606734/f74ca6b3-9725-4d31-87a2-7622c453d1f9)

Before 

![image](https://github.com/rstudio/gt/assets/52606734/cca9eac5-13b3-4482-8463-4d96c2724b58)
