### PR TITLE
fix usage of `rowname_col` for `opt_interactive()`

### DIFF
--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -119,8 +119,10 @@ render_as_ihtml <- function(data, id) {
       "*" = "Failing that, look at whether all columns have been inadvertently hidden."
     ))
   }
+
   #nocov end
 
+  rownames_to_stub <- stub_rownames_has_column(data)
   # use of special .rownames doesn't work.
   # Workaround https://github.com/glin/reactable/issues/378
   # rstudio/gt#1702
@@ -192,8 +194,6 @@ render_as_ihtml <- function(data, id) {
   column_labels_border_bottom_style <- opt_val(data = data, option = "column_labels_border_bottom_style")
   column_labels_border_bottom_width <- opt_val(data = data, option = "column_labels_border_bottom_width")
   column_labels_border_bottom_color <- opt_val(data = data, option = "column_labels_border_bottom_color")
-
-  rownames_to_stub <- stub_rownames_has_column(data)
 
   emoji_symbol_fonts <-
     c(

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -119,8 +119,18 @@ render_as_ihtml <- function(data, id) {
       "*" = "Failing that, look at whether all columns have been inadvertently hidden."
     ))
   }
-
   #nocov end
+
+  # use of special .rownames doesn't work.
+  # Workaround https://github.com/glin/reactable/issues/378
+  # rstudio/gt#1702
+  if (rownames_to_stub) {
+    rowname_col <- dt_boxhead_get_var_stub(data)
+    if (length(rowname_col) == 1) {
+      # avoid base R error when setting duplicate row names.
+      attr(data_tbl, "row.names") <-  as.character(data$`_data`[[rowname_col]])
+    }
+  }
 
   # Obtain column label attributes
   column_names  <- dt_boxhead_get_vars_default(data = data)
@@ -447,17 +457,6 @@ render_as_ihtml <- function(data, id) {
       pageButtonActiveStyle = NULL,
       pageButtonCurrentStyle = NULL
     )
-
-  # use of special .rownames doesn't work.
-  # Workaround https://github.com/glin/reactable/issues/378
-  # rstudio/gt#1702
-  if (rownames_to_stub) {
-    rowname_col <- dt_boxhead_get_var_stub(data)
-    if (length(rowname_col) == 1) {
-      # avoid base R error when setting duplicate row names.
-      attr(data_tbl, "row.names") <-  as.character(data$`_data`[[rowname_col]])
-    }
-  }
 
   # Create the htmlwidget
   x <-

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -448,6 +448,17 @@ render_as_ihtml <- function(data, id) {
       pageButtonCurrentStyle = NULL
     )
 
+  # use of special .rownames doesn't work.
+  # Workaround https://github.com/glin/reactable/issues/378
+  # rstudio/gt#1702
+  if (rownames_to_stub) {
+    rowname_col <- dt_boxhead_get_var_stub(data)
+    if (length(rowname_col) == 1) {
+      # avoid base R error when setting duplicate row names.
+      attr(data_tbl, "row.names") <-  as.character(data$`_data`[[rowname_col]])
+    }
+  }
+
   # Create the htmlwidget
   x <-
     reactable::reactable(

--- a/tests/testthat/test-i_html.R
+++ b/tests/testthat/test-i_html.R
@@ -75,6 +75,7 @@ test_that("Interactive tables won't fail when using different options", {
   tbl_gt_i_24 <-
     gt(mtcars_short, rowname_col = "vs") %>%
     opt_interactive()
+
   capture_output(expect_no_error(tbl_gt_i_01))
   capture_output(expect_no_error(tbl_gt_i_02))
   capture_output(expect_no_error(tbl_gt_i_03))

--- a/tests/testthat/test-i_html.R
+++ b/tests/testthat/test-i_html.R
@@ -68,7 +68,13 @@ test_that("Interactive tables won't fail when using different options", {
     tab_source_note(source_note = "Source Note.") %>%
     tab_footnote(footnote = "Footnote.") %>%
     opt_interactive()
-
+  # #1702
+  tbl_gt_i_23 <-
+    gt(exibble, rownames_to_stub = TRUE) %>%
+    opt_interactive()
+  tbl_gt_i_24 <-
+    gt(mtcars_short, rowname_col = "vs") %>%
+    opt_interactive()
   capture_output(expect_no_error(tbl_gt_i_01))
   capture_output(expect_no_error(tbl_gt_i_02))
   capture_output(expect_no_error(tbl_gt_i_03))
@@ -91,4 +97,6 @@ test_that("Interactive tables won't fail when using different options", {
   capture_output(expect_no_error(tbl_gt_i_20))
   capture_output(expect_no_error(tbl_gt_i_21))
   capture_output(expect_no_error(tbl_gt_i_22))
+  capture_output(expect_no_error(tbl_gt_i_23))
+  capture_output(expect_no_error(tbl_gt_i_24))
 })


### PR DESCRIPTION
Addresses https://github.com/rstudio/gt/issues/1702#issuecomment-2173258752

After a bit of investigation, I also realized that setting `.rownames` doesn't work. https://github.com/glin/reactable/issues/378

Let me know if you can think of a better way to achieve this. 

This is a bit sketchy, because 

```r
row.names(mtcars) <- mtcars$vs
#> Error 
#> Duplicates in row.names are not allowed.
```

before #1706, it would be silently ignored.