### PR TITLE
Add `ihtml.height` for interactive custom widget height

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt (development version)
 
+* `opt_interactive()` gains `height` to help specify your widget's height (@olivroy, #1544).
+
 * `opt_interactive()` now shows row names if `rownames_to_stub = TRUE` (@olivroy, #1702). 
 
 * `data_color()` throws a more informative error message if `rows` didn't resolve to anything (@olivroy, #1659).

--- a/R/dt_options.R
+++ b/R/dt_options.R
@@ -224,6 +224,7 @@ dt_options_tbl <-
     "container_overflow_x",              FALSE,  "container",        "overflow","auto",
     "container_overflow_y",              FALSE,  "container",        "overflow","auto",
     "ihtml_active",                      FALSE,  "interactive",      "logical", FALSE,
+    "ihtml_height",                      FALSE,  "interactive",      "px",      "auto",
     "ihtml_use_pagination",              FALSE,  "interactive",      "logical", TRUE,
     "ihtml_use_pagination_info",         FALSE,  "interactive",      "logical", TRUE,
     "ihtml_use_sorting",                 FALSE,  "interactive",      "logical", TRUE,

--- a/R/opts.R
+++ b/R/opts.R
@@ -334,7 +334,7 @@ get_colorized_params <- function(
 #'   with a stepper for the page number. With `"simple"`, only the 'previous'
 #'   and 'next' buttons are displayed.
 #'
-#' @param ihtml.height *Height of interactive HTML table*
+#' @param height *Height of interactive HTML table*
 #'
 #'   Height of the table in pixels. Defaults to `"auto"` for automatic sizing.
 #'

--- a/R/opts.R
+++ b/R/opts.R
@@ -220,6 +220,7 @@ get_colorized_params <- function(
 #' - `ihtml.page_size_default`
 #' - `ihtml.page_size_values`
 #' - `ihtml.pagination_type`
+#' - `ihtml.height`
 #'
 #' @inheritParams fmt_number
 #'
@@ -333,6 +334,10 @@ get_colorized_params <- function(
 #'   with a stepper for the page number. With `"simple"`, only the 'previous'
 #'   and 'next' buttons are displayed.
 #'
+#' @param ihtml.height *Height of interactive HTML table*
+#'
+#'   Height of the table in pixels. Defaults to `"auto"` for automatic sizing.
+#'
 #' @return An object of class `gt_tbl`.
 #'
 #' @section Examples:
@@ -413,7 +418,8 @@ opt_interactive <- function(
     use_page_size_select = FALSE,
     page_size_default = 10,
     page_size_values = c(10, 25, 50, 100),
-    pagination_type = c("numbers", "jump", "simple")
+    pagination_type = c("numbers", "jump", "simple"),
+    height = "auto"
 ) {
 
   # Perform input object validation
@@ -436,7 +442,8 @@ opt_interactive <- function(
     ihtml.use_page_size_select = use_page_size_select,
     ihtml.page_size_default = page_size_default,
     ihtml.page_size_values = page_size_values,
-    ihtml.pagination_type = pagination_type
+    ihtml.pagination_type = pagination_type,
+    ihtml.height = height
   )
 }
 

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -166,6 +166,7 @@ render_as_ihtml <- function(data, id) {
 
   # Get options settable in `tab_options()`
   opt_val <- dt_options_get_value
+  height <- opt_val(data = data, option = "ihtml_height")
   use_pagination <- opt_val(data = data, option = "ihtml_use_pagination")
   use_pagination_info <- opt_val(data = data, option = "ihtml_use_pagination_info")
   use_search <- opt_val(data = data, option = "ihtml_use_search")
@@ -505,7 +506,7 @@ render_as_ihtml <- function(data, id) {
       rowStyle = NULL,
       fullWidth = TRUE,
       width = table_width,
-      height = "auto",
+      height = height,
       theme = tbl_theme,
       language = lang_defs,
       elementId = id,

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -4347,6 +4347,10 @@ set_style.cells_source_notes <- function(loc, data, style) {
 #'   page number. With `"simple"`, only the 'previous' and 'next' buttons are
 #'   displayed.
 #'
+#' @param ihtml.height *Height of interactive HTML table*
+#'
+#'   Height of the table in pixels. Defaults to `"auto"` for automatic sizing.
+#'
 #' @param page.orientation *Set RTF page orientation*
 #'
 #'   For RTF output, this provides an two options for page
@@ -4711,6 +4715,7 @@ tab_options <- function(
     ihtml.page_size_default = NULL,
     ihtml.page_size_values = NULL,
     ihtml.pagination_type = NULL,
+    ihtml.height = NULL,
     page.orientation = NULL,
     page.numbering = NULL,
     page.header.use_tbl_headings = NULL,

--- a/man/opt_interactive.Rd
+++ b/man/opt_interactive.Rd
@@ -19,7 +19,8 @@ opt_interactive(
   use_page_size_select = FALSE,
   page_size_default = 10,
   page_size_values = c(10, 25, 50, 100),
-  pagination_type = c("numbers", "jump", "simple")
+  pagination_type = c("numbers", "jump", "simple"),
+  height = "auto"
 )
 }
 \arguments{
@@ -139,6 +140,8 @@ one of three options for the layout of pagination controls. The default is
 'previous' and 'next' buttons. The \code{"jump"} option provides an input field
 with a stepper for the page number. With \code{"simple"}, only the 'previous'
 and 'next' buttons are displayed.}
+
+\item{height}{Height of the table in pixels. Defaults to \code{"auto"} for automatic sizing.}
 }
 \value{
 An object of class \code{gt_tbl}.
@@ -166,6 +169,7 @@ This function serves as a shortcut for setting the following options in
 \item \code{ihtml.page_size_default}
 \item \code{ihtml.page_size_values}
 \item \code{ihtml.pagination_type}
+\item \code{ihtml.height}
 }
 }
 \section{Examples}{

--- a/man/opt_interactive.Rd
+++ b/man/opt_interactive.Rd
@@ -141,7 +141,9 @@ one of three options for the layout of pagination controls. The default is
 with a stepper for the page number. With \code{"simple"}, only the 'previous'
 and 'next' buttons are displayed.}
 
-\item{height}{Height of the table in pixels. Defaults to \code{"auto"} for automatic sizing.}
+\item{height}{\emph{Height of interactive HTML table}
+
+Height of the table in pixels. Defaults to \code{"auto"} for automatic sizing.}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -177,6 +177,7 @@ tab_options(
   ihtml.page_size_default = NULL,
   ihtml.page_size_values = NULL,
   ihtml.pagination_type = NULL,
+  ihtml.height = NULL,
   page.orientation = NULL,
   page.numbering = NULL,
   page.header.use_tbl_headings = NULL,
@@ -587,6 +588,10 @@ series of page-number buttons is presented along with 'previous' and 'next'
 buttons. The \code{"jump"} option provides an input field with a stepper for the
 page number. With \code{"simple"}, only the 'previous' and 'next' buttons are
 displayed.}
+
+\item{ihtml.height}{\emph{Height of interactive HTML table}
+
+Height of the table in pixels. Defaults to \code{"auto"} for automatic sizing.}
 
 \item{page.orientation}{\emph{Set RTF page orientation}
 

--- a/tests/testthat/helper-gt_attr_expectations.R
+++ b/tests/testthat/helper-gt_attr_expectations.R
@@ -102,7 +102,7 @@ expect_tab <- function(tab, df) {
 
   dt_options_get(data = tab) %>%
     dim() %>%
-    expect_equal(c(190, 5))
+    expect_equal(c(191, 5))
 
   dt_transforms_get(data = tab) %>%
     expect_length(0)


### PR DESCRIPTION
To mitigate #1544, specifying manually height could be useful.

Before, there was no way to prevent overflowing with  `opt_interactive()`. Let me know if there is a better way to do this. I tried modifying the `height` value to `NULL`, or `"auto"` in the `reactable::reactable()` call in `render_as_ihtml()`, but couldn't find a way to do this well. The only way I found was with manual override. Figure a way to find out the RStudio viewer's size. But after my research, I figured that giving the option to user exactly how to set their widget's height was a good way to go?

I am not too familiar with setting options, and this will likely ignore static options set. I don't know which `tab_options()` are expected to have an effect in both interactive and non-interactive?

Before:

```r
mtcars %>% gt() %>% opt_interactive()
```
![image](https://github.com/rstudio/gt/assets/52606734/57f3210b-ca52-4a8a-9984-793ec51f48fc)

This PR:

```r
mtcars %>% gt() %>% opt_interactive(height = 300)
```
![image](https://github.com/rstudio/gt/assets/52606734/357933b1-8f6c-46f7-b991-5691eb3621af)



