### PR TITLE
grid context that formats text as-is

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -1180,7 +1180,7 @@ as_word_tbl_body <- function(
 #' @export
 as_gtable <- function(data, plot = FALSE, text_grob = grid::textGrob) {
 
-  data <- build_data(data = data, context = "html")
+  data <- build_data(data = data, context = "grid")
   data <- add_css_styles(data = data)
 
   caption_component <- create_caption_component_g(data = data)

--- a/R/utils.R
+++ b/R/utils.R
@@ -998,6 +998,9 @@ process_text <- function(text, context = "html") {
 
     return(text)
 
+  } else if (context == "grid") {
+    # Skip any formatting
+    return(as.character(text))
   } else {
 
     # Text processing in the default case

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -615,6 +615,7 @@ context_missing_text <- function(missing_text, context) {
     switch(
       context,
       html = ,
+      grid = ,
       latex = ,
       word =
         {

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -347,6 +347,10 @@ create_body_component_g <- function(data) {
     }
   }
 
+  if (identical(rows, list())) {
+    return(NULL)
+  }
+
   sizes <- vctrs::list_sizes(rows)
   row_num <- rep(cumsum(sizes > 0), sizes)
 


### PR DESCRIPTION
# Summary

This PR aims to fix #1701. Briefly, it swaps the html context for grid context in `as_gtable()`.
This context will format text with `as.character()` only, to avoid the html escape mechanism that renders poorly in graphics.

Please be forewarned that I only have a partial understanding of how contexts work in {gt}, so somebody who is more familiar should double-check whether this is the correct approach.

Here is a reprex from the linked issue, notice that the symbols on the left are now rendered as actual symbols.

``` r
library(tibble)
devtools::load_all("~/packages/gt")
#> ℹ Loading gt

# symbol
gt0 <- tibble(symbol = c(">", "%", "£", "&")
              , value = c(100, 200, 300, 400)) |> 
  gt() |> 
  fmt_currency(currency = "GBP") |>
  as_gtable() |>
  plot()
```

![](https://i.imgur.com/yVeZMlf.png)<!-- -->

<sup>Created on 2024-06-20 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

The currency formatting is still quite poor as it displays 'GBP' instead of '£', but I'm not familiar enough with the codebase to know where this should be fixed (the 'how' is just passing unicode symbols).

# Related GitHub Issues and PRs

- Ref: #1701

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
