### PR TITLE
Lint some code plus improve performance with base R and vctrs + reduce pipe

### DIFF
--- a/R/data_color.R
+++ b/R/data_color.R
@@ -897,7 +897,7 @@ data_color <- function(
   # body cells; in the end, this (along with all previously set styles) will
   # be used in a concluding `dt_styles_set()` call
   data_color_styles_tbl <-
-    dplyr::tibble(
+    vctrs::data_frame(
       locname = character(0L),
       grpname = character(0L),
       colname = character(0L),
@@ -1198,7 +1198,7 @@ data_color <- function(
 
 generate_data_color_styles_tbl <- function(columns, rows, color_styles) {
 
-  dplyr::tibble(
+  vctrs::data_frame(
     locname = "data",
     grpname = NA_character_,
     colname = columns,

--- a/R/dt_data.R
+++ b/R/dt_data.R
@@ -57,8 +57,7 @@ dt_data_init <- function(
       ))
     }
 
-    data_tbl <- dplyr::mutate(data_tbl, !!sym(rownames_to_column) := data_rownames)
-    data_tbl <- dplyr::select(data_tbl, !!sym(rownames_to_column), dplyr::everything())
+    data_tbl <- dplyr::mutate(data_tbl, !!sym(rownames_to_column) := data_rownames, .before = 0)
   }
 
   dt_data_set(data = data, data_tbl = data_tbl)

--- a/R/dt_groups_rows.R
+++ b/R/dt_groups_rows.R
@@ -94,7 +94,7 @@ dt_groups_rows_build <- function(data, context) {
       dplyr::left_join(groups_rows, group_label_df, by = "group_id")
 
     groups_rows <-
-      dplyr::rename(groups_rows, group_label = built_group_label)
+      dplyr::rename(groups_rows, group_label = "built_group_label")
 
     groups_rows <-
       dplyr::select(groups_rows, group_id, group_label, dplyr::everything())

--- a/R/dt_groups_rows.R
+++ b/R/dt_groups_rows.R
@@ -97,7 +97,7 @@ dt_groups_rows_build <- function(data, context) {
       dplyr::rename(groups_rows, group_label = "built_group_label")
 
     groups_rows <-
-      dplyr::select(groups_rows, group_id, group_label, dplyr::everything())
+      dplyr::relocate(groups_rows, "group_id", "group_label", .before = 0)
 
     others_group <-
       dt_options_get_value(

--- a/R/dt_groups_rows.R
+++ b/R/dt_groups_rows.R
@@ -57,11 +57,12 @@ dt_groups_rows_build <- function(data, context) {
     stub_df[["rowname"]] <- as.character(table_body[[stub_var]])
   }
 
+  l <- length(ordering)
   groups_rows <-
     data.frame(
-      group_id = rep(NA_character_, length(ordering)),
-      row_start = rep(NA_integer_, length(ordering)),
-      row_end = rep(NA_integer_, length(ordering)),
+      group_id = rep_len(NA_character_, l),
+      row_start = rep_len(NA_integer_, l),
+      row_end = rep_len(NA_integer_, l),
       stringsAsFactors = FALSE
     )
 
@@ -115,8 +116,8 @@ dt_groups_rows_build <- function(data, context) {
 
   if (nrow(groups_rows) > 0) {
 
-    groups_rows[["has_summary_rows"]] <- rep(FALSE, nrow(groups_rows))
-    groups_rows[["summary_row_side"]] <- rep(NA_character_, nrow(groups_rows))
+    groups_rows[["has_summary_rows"]] <- rep_len(FALSE, nrow(groups_rows))
+    groups_rows[["summary_row_side"]] <- rep_len(NA_character_, nrow(groups_rows))
 
     list_of_summaries <- dt_summary_df_get(data = data)
 

--- a/R/dt_row_groups.R
+++ b/R/dt_row_groups.R
@@ -36,10 +36,10 @@ dt_row_groups_init <- function(data) {
 
   stub_df <- dt_stub_df_get(data = data)
 
-  if (!all(is.na(stub_df[["group_id"]]))) {
-    row_groups <- unique(stub_df[["group_id"]])
-  } else {
+  if (all(is.na(stub_df[["group_id"]]))) {
     row_groups <- character(0L)
+  } else {
+    row_groups <- unique(stub_df[["group_id"]])
   }
 
   dt_row_groups_set(data = data, row_groups = row_groups)

--- a/R/dt_spanners.R
+++ b/R/dt_spanners.R
@@ -49,7 +49,7 @@ dt_spanners_init <- function(data) {
       # The spanner level
       spanner_level = integer(0L),
       # Should be columns be gathered under a single spanner label?
-      gather = logical(0),
+      gather = logical(0L),
       built = NA_character_
     )
 
@@ -275,7 +275,7 @@ dt_spanners_print_matrix <- function(
   # Get the height of the spanner matrix
   spanner_height <- max(spanners_tbl[["spanner_level"]])
 
-  vars_vec <- rep(NA_character_, length(vars))
+  vars_vec <- rep_len(NA_character_, length(vars))
   names(vars_vec) <- vars
 
   # Initialize matrix to serve as boxhead representation

--- a/R/dt_spanners.R
+++ b/R/dt_spanners.R
@@ -251,18 +251,14 @@ dt_spanners_print_matrix <- function(
   # (2) entries with no vars (after step 1) are removed, and
   # (3) `spanner_level` values have all gaps removed, being compressed
   #     down to start at 1 (e.g., 7, 5, 3, 1 -> 4, 3, 2, 1)
-  spanners_tbl <-
-    dplyr::mutate(spanners_tbl, vars = lapply(.data$vars, base::intersect, .env$vars))
+  spanners_tbl$vars <-
+    lapply(spanners_tbl$vars, base::intersect, vars)
 
-  # TODO Consider using lengths()
-  spanners_tbl <-
-    dplyr::filter(spanners_tbl, vapply(vars, length, integer(1)) > 0L)
+  # keep rows where vars is non-empty
+  spanners_tbl <- spanners_tbl[lengths(spanners_tbl$vars) > 0L, , drop = FALSE]
 
-  spanners_tbl <-
-    dplyr::mutate(
-      spanners_tbl,
-      spanner_level = match(spanner_level, sort(unique(spanner_level)))
-    )
+  spanners_tbl$spanner_level <-
+    match(spanners_tbl$spanner_level, sort(unique(spanners_tbl$spanner_level)))
 
   # If `spanners_tbl` is immediately empty then return a single-row
   # matrix of column vars/IDs (or not, if `omit_columns_row = TRUE`)

--- a/R/dt_spanners.R
+++ b/R/dt_spanners.R
@@ -82,7 +82,7 @@ dt_spanners_add <- function(
     error_vars <-
       vars[vars %in% unlist(spanners_at_level[["vars"]])]
     cli::cli_abort(c(
-      "x" ="Can't create the {.val {spanner_id}} spanner.",
+      "x" = "Can't create the {.val {spanner_id}} spanner.",
       "!" = "Column{?s} {.code {error_vars}} belong{?s/} to an existing spanner.",
       "i" = "Specify {.arg columns} appropriately by using other variable names."
       ),

--- a/R/dt_stub_df.R
+++ b/R/dt_stub_df.R
@@ -204,7 +204,7 @@ dt_stub_components <- function(data) {
     stub_components <- c(stub_components, "group_id")
   }
 
-  if (!all(is.na(stub_df[["row_id"]])) && !all(stub_df[["row_id"]] == "")) {
+  if (!all(is.na(stub_df[["row_id"]])) && !all(!nzchar(stub_df[["row_id"]]))) {
     stub_components <- c(stub_components, "row_id")
   }
 

--- a/R/dt_stub_df.R
+++ b/R/dt_stub_df.R
@@ -44,7 +44,7 @@ dt_stub_df_init <- function(
 
   # Create the `stub_df` table
   stub_df <-
-    dplyr::tibble(
+    vctrs::data_frame(
       rownum_i = seq_len(nrow(data_tbl)),
       row_id = rep(NA_character_, nrow(data_tbl)),
       group_id = rep(NA_character_, nrow(data_tbl)),

--- a/R/dt_stub_df.R
+++ b/R/dt_stub_df.R
@@ -204,7 +204,8 @@ dt_stub_components <- function(data) {
     stub_components <- c(stub_components, "group_id")
   }
 
-  if (!all(is.na(stub_df[["row_id"]])) && !all(!nzchar(stub_df[["row_id"]]))) {
+  # check if some row_id are present and have non-empty chr
+  if (!all(is.na(stub_df[["row_id"]])) && any(nzchar(stub_df[["row_id"]]))) {
     stub_components <- c(stub_components, "row_id")
   }
 

--- a/R/dt_summary.R
+++ b/R/dt_summary.R
@@ -178,8 +178,7 @@ dt_summary_build <- function(data, context) {
     if (identical(groups, grand_summary_col)) {
 
       select_data_tbl <-
-        dplyr::mutate(data_tbl, !!group_id_col_private := .env$grand_summary_col) %>%
-        dplyr::relocate(.env$group_id_col_private, .before = 1)
+        dplyr::mutate(data_tbl, !!group_id_col_private := .env$grand_summary_col, .before = 0)
 
     } else {
 

--- a/R/dt_summary.R
+++ b/R/dt_summary.R
@@ -450,8 +450,7 @@ dt_summary_build <- function(data, context) {
       group_summary_display_df <-
         dplyr::filter(summary_dfs_display, .data[[group_id_col_private]] == .env$group)
 
-      group_summary_display_df <-
-        dplyr::mutate(group_summary_display_df, `::side::` = side)
+      group_summary_display_df$`::side::` <- side
 
       summary_df_data_list <-
         c(

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -7844,9 +7844,8 @@ values_to_durations <- function(
 
     } else if (out_style == "iso") {
 
-      x_str[i] <-
-        paste0("P", paste0(x_df_i$formatted, collapse = "")) %>%
-        tidy_sub("D", "DT", fixed = TRUE)
+      x_str[i] <- paste0("P", paste0(x_df_i$formatted, collapse = ""))
+      x_str[i] <- tidy_sub(x_str[i], "D", "DT", fixed = TRUE)
 
     } else {
       x_str[i] <- paste0(x_df_i$formatted, collapse = " ")
@@ -7914,9 +7913,9 @@ get_localized_duration_patterns <- function(
         colnames(durations)
       ) |
         grepl("type", colnames(durations), fixed = TRUE)
-    ] %>%
-    dplyr::filter(type == .env$type) %>%
-    dplyr::select(-"type")
+    ]
+  pattern_tbl <- pattern_tbl[pattern_tbl$type == type, , drop = FALSE]
+  pattern_tbl$type <- NULL
 
   colnames(pattern_tbl) <- gsub("(duration|-|unitPattern-count)", "", colnames(pattern_tbl))
 

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -3390,7 +3390,6 @@ determine_output_format <- function() {
     return("latex")
   } else if (knitr_is_word_output()) {
     return("word")
-  } else {
-    return("html")
   }
+  "html"
 }

--- a/R/gt_group.R
+++ b/R/gt_group.R
@@ -915,8 +915,8 @@ generate_gt_tbl_info_list <- function(gt_tbl) {
         vapply(
           summary_list,
           FUN.VALUE = integer(1L),
-          FUN = function(x) nrow(x))
-      )
+          FUN = nrow
+      ))
 
     if (!is.null(summary_list[["::GRAND_SUMMARY"]])) {
       n_summary_rows_grand <- nrow(summary_list[["::GRAND_SUMMARY"]])

--- a/R/gt_group.R
+++ b/R/gt_group.R
@@ -787,7 +787,7 @@ grp_options <- function(
         SIMPLIFY = FALSE
       )
     )
-  new_df <- dplyr::select(new_df, -type)
+  new_df$type <- NULL
 
   # This rearranges the rows in the `opts_df` table, but this
   # shouldn't be a problem

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -3226,7 +3226,7 @@ google_font <- function(name) {
 
   import_stmt <-
     paste_between(
-      gsub(" ", "+", name),
+      gsub(" ", "+", name, fixed = TRUE),
       c(
         "@import url('https://fonts.googleapis.com/css2?family=",
         ":ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');"

--- a/R/info_tables.R
+++ b/R/info_tables.R
@@ -682,8 +682,7 @@ info_paletteer <- function(color_pkgs = NULL) {
   palettes_strips_df <-
     dplyr::filter(palettes_strips, package %in% color_pkgs)
 
-  palettes_strips <-
-    dplyr::pull(palettes_strips_df, colors)
+  palettes_strips <- palettes_strips_df$colors
 
   palettes_strips_df %>%
     dplyr::select(package, palette, length) %>%

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -1229,7 +1229,7 @@ cols_label_with <- function(
   # Apply the function call to each element of `old_label_list`
   new_label_list <- lapply(old_label_list, FUN = fn)
 
-  if (!all(vapply(new_label_list, FUN.VALUE = logical(1), FUN = is_character))) {
+  if (!all(vapply(new_label_list, FUN.VALUE = logical(1L), FUN = is_character))) {
     cli::cli_abort("{.arg fn} must return a character vector.")
   }
 

--- a/R/opts.R
+++ b/R/opts.R
@@ -1029,31 +1029,25 @@ opt_horizontal_padding <- function(
 get_padding_option_value_list <- function(scale, type) {
 
   # Stop if `scale` is beyond an acceptable range
-  if (scale < 0 | scale > 3) {
-    cli::cli_abort(
-      "The value provided for `scale` ({scale}) must be between `0` and `3`."
-    )
-  }
+  check_number_decimal(scale, min = 0, max = 3)
 
   pattern <- if (type == "vertical") "_padding" else  "_padding_horizontal"
 
   # Get the padding parameters from `dt_options_tbl` that relate
   # to the `type` (either vertical or horizontal padding)
   padding_params <-
-    dplyr::pull(
-      dplyr::filter(dt_options_tbl, grepl(paste0(pattern, "$"), parameter)),
-      parameter
-    )
+    dplyr::filter(dt_options_tbl, grepl(paste0(pattern, "$"), parameter))
+  padding_params <- padding_params$parameter
 
   padding_options <- dplyr::filter(dt_options_tbl, parameter %in% padding_params)
-  padding_options <- dplyr::select(padding_options, parameter, value)
+  padding_options <- dplyr::select(padding_options, "parameter", "value")
   padding_options <-
     dplyr::mutate(
       padding_options,
       parameter = gsub(pattern, gsub("_", ".", pattern, fixed = TRUE), parameter, fixed = TRUE)
     )
   padding_options <- dplyr::mutate(padding_options, value = unlist(value))
-  padding_options <- dplyr::mutate(padding_options, px = as.numeric(gsub("px", "", value)))
+  padding_options <- dplyr::mutate(padding_options, px = as.numeric(gsub("px", "", value, fixed = TRUE)))
   padding_options <- dplyr::mutate(padding_options, px = px * scale)
 
   create_option_value_list(

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -141,8 +141,9 @@ render_as_ihtml <- function(data, id) {
 
   # Obtain widths for each visible column label
   boxh <- dt_boxhead_get(data = data)
-  column_widths <- dplyr::filter(boxh, type %in% c("default", "stub"))
-  column_widths <- dplyr::pull(dplyr::arrange(column_widths, dplyr::desc(type)), column_width)
+  column_widths <- boxh[boxh$type %in% c("default", "stub"), , drop = FALSE]
+  # ensure that stub is first
+  column_widths <- column_widths[order(column_widths$type, decreasing = TRUE), "column_width", drop = TRUE]
   column_widths <- unlist(column_widths)
 
   # Transform any column widths to integer values

--- a/R/resolver.R
+++ b/R/resolver.R
@@ -58,9 +58,10 @@ resolve_cells_body <- function(data, object, call = rlang::caller_env()) {
       resolved_columns_idx,
       resolved_rows_idx,
       stringsAsFactors = FALSE
-    ) %>%
-    dplyr::arrange(Var1) %>%
-    dplyr::distinct()
+    )
+  expansion <- dplyr::distinct(expansion)
+  # TODO consider sort_by when depending on 4.4?
+  epansion <- expansion[order(expansion$Var1), , drop = FALSE]
 
   # Create a list object
   cells_resolved <-

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -803,21 +803,18 @@ resolve_spanner_level <- function(
   spanners_tbl <- dt_spanners_get(data = data)
 
   highest_level <- 0L
+  spanner_cols <- c("spanner_id", "vars", "spanner_level")
+  spanners_tbl <- spanners_tbl[ , spanner_cols, drop = FALSE]
 
-  spanners_tbl <- dplyr::select(spanners_tbl, spanner_id, vars, spanner_level)
-
-  highest_level <-
-    dplyr::filter(
-      spanners_tbl,
-      vapply(
-        vars,
-        FUN.VALUE = logical(1),
-        FUN = function(x) any(column_names %in% x)
-      )
-    ) %>%
-    dplyr::pull("spanner_level") %>%
-    max(0) # Max of ^ and 0
-
+  cnd_highest_level <-
+    vapply(
+      spanners_tbl$vars,
+      FUN.VALUE = logical(1L),
+      FUN = function(x) any(column_names %in% x)
+    )
+  highest_level <- spanners_tbl[cnd_highest_level, "spanner_level", drop = TRUE]
+  # Max of ^ and 0
+  highest_level <- max(c(0, highest_level))
   highest_level + 1L
 }
 

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -3731,14 +3731,14 @@ set_style.cells_column_labels <- function(loc, data, style) {
 
   cols <- resolved$columns
 
-  colnames <- names(cols)
+  col_names <- names(cols)
 
   data <-
     dt_styles_add(
       data = data,
       locname = "columns_columns",
       grpname = NA_character_,
-      colname = colnames,
+      colname = col_names,
       locnum = 4,
       rownum = NA_integer_,
       styles = style

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1044,7 +1044,7 @@ resolve_spanned_column_names <- function(
 #'     fn = function(x) gsub("pct", "%", x)
 #'   ) |>
 #'   text_transform(
-#'     fn = function(x) gsub("\\.", " - ", x),
+#'     fn = function(x) gsub(".", " - ", x, fixed = TRUE),
 #'     locations = cells_column_spanners()
 #'   ) |>
 #'   tab_style(
@@ -3615,8 +3615,8 @@ tab_style <- function(
         # to sentence case
         # cell_grand_summary_row -> grand summary row
         readable_table_part <- attr(loc, "class")[[1]]
-        readable_table_part <- sub("cells_", "", readable_table_part)
-        readable_table_part <- gsub("_", " ", readable_table_part)
+        readable_table_part <- sub("cells_", "", readable_table_part, fixed = TRUE)
+        readable_table_part <- gsub("_", " ", readable_table_part, fixed = TRUE)
 
         cli::cli_abort(
           "Failed to style the {readable_table_part} of the table.",

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -4768,7 +4768,7 @@ tab_options <- function(
         SIMPLIFY = FALSE
       )
     )
-  new_df <- dplyr::select(new_df, -type)
+  new_df$type <- NULL
 
   # This rearranges the rows in the `opts_df` table, but this
   # shouldn't be a problem

--- a/R/tab_info.R
+++ b/R/tab_info.R
@@ -58,12 +58,13 @@
 tab_info <- function(data) {
 
   empty_tbl <-
-    dplyr::tibble(
+    data.frame(
       id = character(0L),
       i = integer(0L),
       label = character(0L),
       type = character(0L),
-      location = character(0L)
+      location = character(0L),
+      stringsAsFactors = FALSE
     )
 
   built_data <- build_data(data, context = "html")
@@ -74,12 +75,12 @@ tab_info <- function(data) {
 
   boxhead <- dt_boxhead_get(data = data)
 
-  columns <- dplyr::select(boxhead, id = var, label = column_label, type)
-  columns <- dplyr::filter(columns, type %in% c("default", "stub", "hidden"))
-  columns <- dplyr::mutate(columns, label = unlist(label))
-  columns <- dplyr::mutate(columns, location = "Columns")
-  columns <- dplyr::mutate(columns, i = seq_len(nrow(columns)))
-  columns <- dplyr::select(columns, id, i, label, type, location)
+  columns <- dplyr::select(boxhead, id = "var", label = "column_label", "type")
+  columns <- columns[columns$type %in% c("default", "stub", "hidden"), ]
+  columns$label <- unlist(columns$label)
+  columns$location <- "Columns"
+  columns$i <- seq_len(nrow(columns))
+  columns <- columns[, c("id", "i", "label", "type", "location")]
 
   #
   # Rows
@@ -94,34 +95,36 @@ tab_info <- function(data) {
 
     rowname_col <- dt_boxhead_get_var_stub(data = data)
 
-    row_name_vals <- dplyr::pull(dplyr::select(data_df, dplyr::all_of(rowname_col)), 1)
+    row_name_vals <- data_df[ , rowname_col[1], drop = TRUE]
 
-    rownames <- dplyr::select(stub_df, id = row_id, i = rownum_i)
-    rownames <- dplyr::mutate(rownames, label = row_name_vals)
-    rownames <- dplyr::mutate(rownames, type = NA_character_)
-    rownames <- dplyr::mutate(rownames, location = "Rows")
-    rownames <- dplyr::select(rownames, id, i, label, type, location)
+    rownames <- dplyr::select(stub_df, id = "row_id", i = "rownum_i")
+    rownames$label <-  row_name_vals
+    rownames$type <-  NA_character_
+    rownames$location <-  "Rows"
+    rownames <- rownames[, c("id", "i", "label", "type", "location")]
 
   } else if (nrow(stub_df) == 1) {
 
     rownames <-
-      dplyr::tibble(
+      data.frame(
         id = "<< Single index value of 1 >>",
         i = NA_integer_,
         label = NA_character_,
         type = NA_character_,
-        location = "Rows"
+        location = "Rows",
+        stringsAsFactors = FALSE
       )
 
   } else if (nrow(stub_df) == 0) {
 
     rownames <-
-      dplyr::tibble(
+      data.frame(
         id = "<< No rows in table >>",
         i = NA_integer_,
         label = NA_character_,
         type = NA_character_,
-        location = "Rows"
+        location = "Rows",
+        stringsAsFactors = FALSE
       )
 
   } else {
@@ -131,12 +134,13 @@ tab_info <- function(data) {
     rownum_desc <- paste0("<< Index values ", min(rownum_i), " to ", max(rownum_i), " >>")
 
     rownames <-
-      dplyr::tibble(
+      data.frame(
         id = rownum_desc,
         i = NA_integer_,
         label = NA_character_,
         type = NA_character_,
-        location = "Rows"
+        location = "Rows",
+        stringsAsFactors = FALSE
       )
   }
 
@@ -148,12 +152,12 @@ tab_info <- function(data) {
 
     span_df <- dt_spanners_get(data = data)
 
-    spanners <- dplyr::select(span_df, id = spanner_id, label = spanner_label, i = spanner_level)
-    spanners <- dplyr::mutate(spanners, type = NA_character_)
-    spanners <- dplyr::mutate(spanners, i = as.integer(i))
-    spanners <- dplyr::mutate(spanners, label = unlist(label))
-    spanners <- dplyr::mutate(spanners, location = "Spanners")
-    spanners <- dplyr::select(spanners, id, i, label, type, location)
+    spanners <- dplyr::select(span_df, id = "spanner_id", label = "spanner_label", i = "spanner_level")
+    spanners$type <- NA_character_
+    spanners$i <- as.integer(spanners$i)
+    spanners$label <- unlist(spanners$label)
+    spanners$location <- "Spanners"
+    spanners <- spanners[, c("id", "i", "label", "type", "location")]
 
   } else {
     spanners <- empty_tbl
@@ -168,12 +172,11 @@ tab_info <- function(data) {
     groups_rows <- dt_row_groups_get(data = data)
 
     row_groups <- dplyr::select(stub_df, id = group_id, label = group_label)
-    row_groups <- dplyr::group_by(row_groups, id)
-    row_groups <- dplyr::filter(row_groups, dplyr::row_number() == 1)
+    row_groups <- dplyr::filter(row_groups, dplyr::row_number() == 1, .by = "id")
     row_groups <- dplyr::mutate(row_groups, i = which(groups_rows %in% id))
-    row_groups <- dplyr::mutate(row_groups, type = NA_character_)
-    row_groups <- dplyr::mutate(row_groups, label = unlist(label))
-    row_groups <- dplyr::mutate(row_groups, location = "Row Groups")
+    row_groups$type <- NA_character_
+    row_groups$label <- unlist(row_groups$label)
+    row_groups$location <- "Row Groups"
     row_groups <- dplyr::select(row_groups, id, i, label, type, location)
 
   } else {
@@ -205,15 +208,15 @@ tab_info <- function(data) {
             names(list_of_summaries$summary_df_data_list[[group_id]][["rowname"]])
 
           group_summary_i <-
-            dplyr::bind_rows(
-              dplyr::tibble(
+            vctrs::vec_rbind(
+              vctrs::data_frame(
                 id = group_id,
                 i = NA_integer_,
                 label = NA_character_,
                 type = "::group_id::",
                 location = "Group Summary"
               ),
-              dplyr::tibble(
+              vctrs::data_frame(
                 id = group_summary_row_id,
                 i = seq_along(group_summary_row_id),
                 label = group_summary_row_id,
@@ -241,7 +244,7 @@ tab_info <- function(data) {
         names(list_of_summaries$summary_df_data_list[[grand_summary_col]][["rowname"]])
 
       grand_summary <-
-        dplyr::tibble(
+        vctrs::data_frame(
           id = grand_summary_row_id,
           i = seq_along(grand_summary_row_id),
           label = grand_summary_row_id,
@@ -253,7 +256,7 @@ tab_info <- function(data) {
     }
 
     summaries <-
-      dplyr::bind_rows(
+      vctrs::vec_rbind(
         group_summary,
         grand_summary
       )
@@ -267,7 +270,7 @@ tab_info <- function(data) {
   #
 
   combined_tbl <-
-    dplyr::bind_rows(
+    vctrs::vec_rbind(
       columns,
       rownames,
       spanners,

--- a/R/utils.R
+++ b/R/utils.R
@@ -557,7 +557,7 @@ get_alignment_at_body_cell <- function(
   # Get cell alignment set by `tab_style`
   styles_tbl <- dt_styles_get(data = data)
 
-  if (nrow(styles_tbl) < 1) {
+  if (nrow(styles_tbl) < 1L) {
     return(column_alignment)
   }
 
@@ -1993,8 +1993,8 @@ num_suffix_ind <- function(
   suffix_index[is.na(suffix_index)] <- 0
 
   # Add a leading space to all non-empty suffix labels
-  suffix_labels[suffix_labels != ""] <-
-    paste0(" ", suffix_labels[suffix_labels != ""])
+  suffix_labels[nzchar(suffix_labels)] <-
+    paste0(" ", suffix_labels[nzchar(suffix_labels)])
 
   # Create and return a tibble with `scale_by`
   # and `suffix` values

--- a/R/utils.R
+++ b/R/utils.R
@@ -566,22 +566,23 @@ get_alignment_at_body_cell <- function(
   # set there (this has higher specificity)
   #
 
-  styles_filtered_tbl <-
-    dplyr::filter(
-      styles_tbl,
-      locname == "data" & colname == .env$colname & rownum == .env$rownum
-    )
+  cnd <-
+    styles_tbl$locname == "data" &
+    styles_tbl$colname == colname &
+    styles_tbl$rownum == rownum
 
-  if (nrow(styles_tbl) < 1L) {
+  styles_filtered_tbl <- styles_tbl[cnd, , drop = FALSE]
+
+  if (nrow(styles_filtered_tbl) < 1L) {
     return(column_alignment)
   }
 
   # Extract the list of styles from the table
   cell_styles_list <- styles_filtered_tbl$styles
 
-  if (length(cell_styles_list) < 1L) {
-    return(column_alignment)
-  }
+  # if (length(cell_styles_list) < 1L) {
+  #   return(column_alignment)
+  # }
 
   # Get the `align` property in `cell_styles_list` (element may not be present)
   cell_text_align <- cell_styles_list[[1L]]$cell_text$align

--- a/R/utils_examples.R
+++ b/R/utils_examples.R
@@ -39,10 +39,9 @@ get_topic_names <- function() {
   # Exclude any topics that have `.` or `-` characters within their names,
   # and, exclude the 'pipe' and 'reexports' topic
   topic_names[
-    !grepl("\\.", topic_names) &
-      !grepl("-", topic_names) &
-      !grepl("^pipe$", topic_names) &
-      !grepl("^reexports$", topic_names)
+    !grepl(".", topic_names, fixed = TRUE) &
+      !grepl("-", topic_names, fixed = TRUE) &
+      !topic_names %in% c("pipe", "reexports")
   ]
 }
 
@@ -223,7 +222,7 @@ write_gt_examples_qmd_files <- function(
         family <- as.integer(unlist(strsplit(id_val, split = "-"))[[1]])
         number <- as.integer(unlist(strsplit(id_val, split = "-"))[[2]])
 
-      } else if (any(grepl("Dataset ID ", help_file_lines))) {
+      } else if (any(grepl("Dataset ID ", help_file_lines, fixed = TRUE))) {
 
         type <- "dataset"
         id_idx <- grep("\\section{Dataset ID and Badge}{", help_file_lines, fixed = TRUE) + 2

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -80,8 +80,8 @@ validate_locale <- function(locale, call = rlang::caller_env()) {
   # isn't a valid one
   if (
     !is.null(locale) &&
-    !(gsub("_", "-", locale) %in% locales[["locale"]]) &&
-    !(gsub("_", "-", locale) %in% default_locales[["default_locale"]])
+    !(gsub("_", "-", locale, fixed = TRUE) %in% locales[["locale"]]) &&
+    !(gsub("_", "-", locale, fixed = TRUE) %in% default_locales[["default_locale"]])
   ) {
 
     cli::cli_abort(c(
@@ -287,13 +287,13 @@ get_locale_no_table_data_text <- function(locale = NULL) {
 
 get_locale_segments <- function(locale) {
 
-  if (!grepl("-", locale)) {
+  if (!grepl("-", locale, fixed = TRUE)) {
     return(locale)
   }
 
   segments <- locale
 
-  while (grepl("-", locale)) {
+  while (grepl("-", locale, fixed = TRUE)) {
 
     locale <- gsub("-[^-]*$", "", locale)
     segments <- c(segments, locale)
@@ -504,9 +504,9 @@ format_num_to_str <- function(
   # conform to the Indian numbering system
   if (system == "ind") {
 
-    is_inf <- grepl("Inf", x_str)
+    is_inf <- grepl("Inf", x_str, fixed = TRUE)
     x_str_numeric <- x_str[!is_inf]
-    has_decimal <- grepl("\\.", x_str_numeric)
+    has_decimal <- grepl(".", x_str_numeric, fixed = TRUE)
     is_negative <- grepl("^-", x_str_numeric)
 
     integer_parts <- sub("\\..*", "", x_str_numeric)

--- a/R/utils_formatters.R
+++ b/R/utils_formatters.R
@@ -111,8 +111,8 @@ validate_currency <- function(currency, call = rlang::caller_env()) {
   # Stop function if the `currency` provided isn't a valid one
   if (
     !(
-      currency_char %in% currency_symbols$curr_symbol |
-      currency_char %in% currencies$curr_code |
+      currency_char %in% currency_symbols$curr_symbol ||
+      currency_char %in% currencies$curr_code ||
       currency_char %in% currencies$curr_number
     )
   ) {

--- a/R/utils_general_str_formatting.R
+++ b/R/utils_general_str_formatting.R
@@ -622,5 +622,5 @@ rtl_modern_unicode_charset <-
     syriac_unicode_charset,
     thaana_unicode_charset,
     samaritan_unicode_charset,
-    mandaic_unicode_charset,sep = "|"
+    mandaic_unicode_charset, sep = "|"
   )

--- a/R/utils_general_str_formatting.R
+++ b/R/utils_general_str_formatting.R
@@ -375,7 +375,7 @@ str_title_case <- function(x) {
 
   title_case_i <- function(y) {
 
-    s <- strsplit(y, " ")[[1]]
+    s <- strsplit(y, " ", fixed = TRUE)[[1]]
 
     paste(
       toupper(substring(s, 1, 1)),

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -168,7 +168,7 @@ generate_nanoplot <- function(
 
   # If the number of y_vals is `1` and we requested a 'bar' plot, then
   # reset several parameters
-  if (num_y_vals == 1 && grepl("bar", plot_type)) {
+  if (num_y_vals == 1 && grepl("bar", plot_type, fixed = TRUE)) {
 
     single_horizontal_bar <- TRUE
     show_data_points <- FALSE

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -784,7 +784,7 @@ generate_nanoplot <- function(
   start_data_y_points <- start_data_y_points[is_non_na]
   end_data_y_points <- end_data_y_points[is_non_na]
 
-  is_not_length_one <- !(start_data_y_points == end_data_y_points)
+  is_not_length_one <- start_data_y_points != end_data_y_points
 
   start_data_y_points <- start_data_y_points[is_not_length_one]
   end_data_y_points <- end_data_y_points[is_not_length_one]

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -721,7 +721,7 @@ stub_rownames_has_column <- function(data) {
 stub_group_names_has_column <- function(data) {
 
   # If there aren't any row groups then the result is always FALSE
-  if (nrow(dt_groups_rows_get(data = data)) < 1) {
+  if (nrow(dt_groups_rows_get(data = data)) < 1L) {
     return(FALSE)
   }
 

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -341,7 +341,7 @@ reorder_styles <- function(data) {
   for (i in seq_len(sz)) {
     if (
       !is.na(styles_tbl$rownum[i]) &&
-      !grepl("summary_cells", styles_tbl$locname[i])
+      !grepl("summary_cells", styles_tbl$locname[i], fixed = TRUE)
     ) {
       tmp_mask[i] <- TRUE
       tmp_rownum[i] <- which(rownum_final == styles_tbl$rownum[i])

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -806,21 +806,19 @@ get_body_component_cell_matrix <- function(data) {
 
   if ("group_label" %in% stub_layout) {
 
-    groups_rows_df <-
-      dt_groups_rows_get(data = data) %>%
-      dplyr::select(group_id, group_label, row_start)
+    groups_rows_df <- dt_groups_rows_get(data = data)
+    groups_rows_df <- groups_rows_df[, c("group_id", "group_label", "row_start"), drop = FALSE]
 
-    group_label_matrix <-
-      dt_stub_df_get(data = data) %>%
-      dplyr::select(-row_id, -group_label) %>%
-      dplyr::inner_join(groups_rows_df, by = "group_id") %>%
-      dplyr::mutate(
-        row = dplyr::row_number(),
-        built = dplyr::if_else(row_start != row, "", built_group_label)
-      ) %>%
-      dplyr::select(built) %>%
-      as.matrix() %>%
-      unname()
+    stub_df <- dt_stub_df_get(data = data)
+    stub_df$row_id <- NULL
+    stub_df$group_label <- NULL
+    stub_df <- dplyr::inner_join(stub_df, groups_rows_df, by = "group_id")
+    stub_df$row <- seq_len(nrow(stub_df))
+    stub_df$built <- ""
+    cnd <- stub_df$row_start == stub_df$row
+    # Use built_group_label for row = row start
+    stub_df$built[cnd] <- stub_df$built_group_label[cnd]
+    group_label_matrix <- as.matrix(stub_df$built)
 
     body_matrix <- cbind(group_label_matrix, body_matrix)
   }

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -285,9 +285,10 @@ get_row_reorder_df <- function(groups, stub_df) {
     indices <- seq_len(nrow(stub_df))
 
     return(
-      dplyr::tibble(
+      data.frame(
         rownum_start = indices,
-        rownum_final = indices
+        rownum_final = indices,
+        stringsAsFactors = FALSE
       )
     )
   }
@@ -297,9 +298,10 @@ get_row_reorder_df <- function(groups, stub_df) {
   indices <- unlist(indices)
   indices <- order(indices)
 
-  dplyr::tibble(
+  data.frame(
     rownum_start = seq_along(indices),
-    rownum_final = indices
+    rownum_final = indices,
+    stringsAsFactors = FALSE
   )
 }
 

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -902,17 +902,16 @@ render_grid_svg <- function(label, style, margin) {
   # and they cannot be displayed interactively in {grid} anyway.
   label <- gsub("<title(.*?)</title>", "", label)
 
-  svg_string <- regexpr("<svg(.*?)>.*</svg>", label) %>%
-    regmatches(x = label) %>%
-    gsub(pattern = "\n", replacement = "") %>%
-    trimws()
+  svg_string <- regexpr("<svg(.*?)>.*</svg>", label)
+  svg_string <- regmatches(label, svg_string)
+  svg_string <- gsub("\n", "", svg_string)
+  svg_string <- trimws(svg_string)
 
-  svg_style <- regexpr("style=\"(.*?)\"", svg_string) %>%
-    regmatches(x = svg_string) %>%
-    gsub(pattern = "^style=\"|\"$", replacement = "") %>%
-    strsplit(";") %>%
-    unlist() %>%
-    trimws()
+  svg_style <- regexpr("style=\"(.*?)\"", svg_string)
+  svg_style <- regmatches(svg_string, svg_style)
+  svg_style <- gsub("^style=\"|\"$", "", svg_style)
+  svg_style <- strsplit(svg_style, ";", fixed = TRUE)
+  svg_style <- trimws(unlist(svg_style))
 
   width <- height <- NULL
 

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -943,7 +943,7 @@ render_grid_svg <- function(label, style, margin) {
       viewbox <- c(0, 0, 0, 0)
       svg_tag <- regexpr("^<svg(.*?)>", svg_string) %>%
         regmatches(x = svg_string)
-      if (grepl("width", svg_tag) && grepl("height", svg_tag)) {
+      if (grepl("width", svg_tag, fixed = TRUE) && grepl("height", svg_tag, fixed = TRUE)) {
         # Try extract width from tag
         w <- regexpr("width=(.*?) ", svg_tag) %>%
           regmatches(x = svg_tag)

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -768,7 +768,7 @@ create_footnotes_component_g <- function(data) {
   styles_tbl <- dt_styles_get(data = data)
   n_cols_total <- get_effective_number_of_columns(data = data)
 
-  footnotes_tbl <- dplyr::distinct(dplyr::select(footnotes_tbl, fs_id, footnotes))
+  footnotes_tbl <- dplyr::distinct(footnotes_tbl, fs_id, footnotes)
 
   style <- NA
   if ("footnotes" %in% styles_tbl$locname) {

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -447,7 +447,7 @@ body_cells_g <- function(data) {
   }
 
   # Weave even/odd classes into matrix
-  cell_classes <- rep(list(odd_class, even_class), length.out = n_rows)
+  cell_classes <- rep_len(list(odd_class, even_class), n_rows)
   cell_classes <- inject(rbind(!!!cell_classes))
 
   # Set column alignment

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -53,19 +53,19 @@ footnote_mark_to_html <- function(
 
   is_sup <- grepl("\\^", spec)
 
-  if (grepl("\\.", spec)) mark <- paste0(mark, ".")
-  if (grepl("\\(", spec)) mark <- paste0("(", mark)
-  if (grepl("\\[", spec)) mark <- paste0("[", mark)
-  if (grepl("\\)", spec)) mark <- paste0(mark, ")")
-  if (grepl("\\]", spec)) mark <- paste0(mark, "]")
+  if (grepl(".", spec, fixed = TRUE)) mark <- paste0(mark, ".")
+  if (grepl("(", spec, fixed = TRUE)) mark <- paste0("(", mark)
+  if (grepl("[", spec, fixed = TRUE)) mark <- paste0("[", mark)
+  if (grepl(")", spec, fixed = TRUE)) mark <- paste0(mark, ")")
+  if (grepl("]", spec, fixed = TRUE)) mark <- paste0(mark, "]")
 
-  if (grepl("i", spec)) {
+  if (grepl("i", spec, fixed = TRUE)) {
     font_style <- "italic"
   } else {
     font_style <- "normal"
   }
 
-  if (grepl("b", spec)) {
+  if (grepl("b", spec, fixed = TRUE)) {
     font_weight <- "bold"
   } else {
     font_weight <- "normal"

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -268,12 +268,10 @@ get_table_defs <- function(data) {
       option = "table_width"
     )
 
-  widths <-
-    boxh %>%
-    dplyr::filter(type %in% c("default", "stub")) %>%
-    dplyr::arrange(dplyr::desc(type)) %>% # This ensures that the `stub` is first
-    .$column_width %>%
-    unlist()
+  widths <- boxh[boxh$type %in% c("default", "stub"), , drop = FALSE]
+  # ensure that stub is first
+  widths <- widths[order(widths$type, decreasing = TRUE), "column_width", drop = TRUE]
+  widths <- unlist(widths)
 
   # Stop function if all length dimensions (where provided)
   # don't conform to accepted CSS length definitions

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1683,7 +1683,7 @@ create_footnotes_component_h <- function(data) {
   n_cols_total <- get_effective_number_of_columns(data = data)
 
   # Get the distinct set of `fs_id` & `footnotes` values in the `footnotes_tbl`
-  footnotes_tbl <- dplyr::distinct(dplyr::select(footnotes_tbl, fs_id, footnotes))
+  footnotes_tbl <- dplyr::distinct(footnotes_tbl, fs_id, footnotes)
 
   # Get the style attrs for the footnotes
   if ("footnotes" %in% styles_tbl$locname) {

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -904,8 +904,7 @@ summary_rows_for_group_l <- function(
   summary_df <-
     dplyr::select(
       list_of_summaries$summary_df_display_list[[group_id]],
-      dplyr::all_of(rowname_col_private),
-      dplyr::all_of(default_vars)
+      dplyr::all_of(c(rowname_col_private, default_vars))
     )
 
   for (col_name in names(summary_df)) {
@@ -1029,8 +1028,7 @@ create_footer_component_l <- function(data) {
   # Create a formatted footnotes string
   if (nrow(footnotes_tbl) > 0) {
 
-    footnotes_tbl <-
-      dplyr::distinct(dplyr::select(footnotes_tbl, fs_id, footnotes))
+    footnotes_tbl <- dplyr::distinct(footnotes_tbl, fs_id, footnotes)
 
     # Create a vector of formatted footnotes
     footnotes <-
@@ -1359,9 +1357,8 @@ derive_table_width_statement_l <- function(data) {
 
     tw <- as.numeric(gsub('%', '', table_width))
 
-    side_width <-
-      ((100 - tw) / 200) %>%
-      format(scientific = FALSE, trim = TRUE)
+    side_width <- (100 - tw) / 200
+    side_width <- format(side_width, scientific = FALSE, trim = TRUE)
 
     statement <- paste0(
       "\\setlength\\",

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -180,7 +180,7 @@ create_table_start_l <- function(data) {
 
   if (!is.null(col_widths)) {
 
-    col_defs <- c()
+    col_defs <- NULL
 
     # TODO: check that length of `col_widths` is equal to that
     # of `col_alignment`
@@ -1584,7 +1584,7 @@ apply_cell_styles_l <- function(content, style_obj) {
   if (is.null(use_indent)) return(NULL)
 
   # Documentation says numbers without units default to px
-  if (is.numeric(use_indent)) use_indent <- paste0(use_indent, 'px')
+  if (is.numeric(use_indent)) use_indent <- paste0(use_indent, "px")
 
   paste0(
     "\\hspace{",
@@ -1676,7 +1676,7 @@ create_colwidth_df_l <- function(data) {
     } else if (endsWith(raw, "%")) {
       pct <- as.numeric(gsub("%", "", raw))
 
-      if (tbl_width == 'auto') {
+      if (tbl_width == "auto") {
         width_df$lw[i] <- pct
       } else if (endsWith(tbl_width, "%")) {
         width_df$lw[i] <- pct * as.numeric(gsub("%", "", tbl_width))
@@ -1753,4 +1753,3 @@ calculate_multicolumn_width_text_l <- function(begins, ends, colwidth_df) {
 
   out_text
 }
-

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -911,12 +911,12 @@ summary_rows_for_group_l <- function(
 
     loc_type <- if(summary_row_type == "grand") "grand_summary_cells" else "summary_cells"
 
-    styles_summary <- dt_styles_get(data) %>%
-      dplyr::filter(locname == loc_type,
-                    grpname == group_id) %>%
-      dplyr::mutate(colname = ifelse(is.na(colname) & colnum == 0,
-                              "::rowname::", colname)) %>%
-      dplyr::filter(colname == col_name)
+    styles_df <- dt_styles_get(data)
+    styles_df <- styles_df[styles_df$locname == loc_type & styles_df$grpname == group_id, , drop = FALSE]
+    # set colname to ::rowname:: if colname is present and colnum = 0
+    styles_df$colname[is.na(styles_df$colname) & styles_df$colnum == 0] <- "::rowname::"
+
+    styles_summary <- styles_df[styles_df$colname == col_name, , drop = FALSE]
 
     if (dim(styles_summary)[1L] > 0L) {
 
@@ -929,8 +929,9 @@ summary_rows_for_group_l <- function(
           row_pos <- row_num
         }
 
-        row_style <- dplyr::filter(styles_summary, rownum == row_num) %>%
-          consolidate_cell_styles_l()
+        # style each row
+        row_style <- styles_summary[styles_summary$rownum == row_num, , drop = FALSE]
+        row_style <- consolidate_cell_styles_l(row_style)
 
         summary_df[[col_name]][row_pos] <- apply_cell_styles_l(summary_df[[col_name]][row_pos], row_style)
       }

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -51,9 +51,9 @@ footnote_mark_to_latex <- function(
     spec <- "^i"
   }
 
-  if (grepl("\\.", spec)) mark <- sprintf_unless_na("%s.", mark)
-  if (grepl("b", spec)) mark <- sprintf_unless_na("\\textbf{%s}", mark)
-  if (grepl("i", spec)) mark <- sprintf_unless_na("\\textit{%s}", mark)
+  if (grepl(".", spec, fixed = TRUE)) mark <- sprintf_unless_na("%s.", mark)
+  if (grepl("b", spec, fixed = TRUE)) mark <- sprintf_unless_na("\\textbf{%s}", mark)
+  if (grepl("i", spec, fixed = TRUE)) mark <- sprintf_unless_na("\\textit{%s}", mark)
   if (grepl("\\(|\\[", spec)) mark <- sprintf_unless_na("(%s", mark)
   if (grepl("\\)|\\]", spec)) mark <- sprintf_unless_na("%s)", mark)
 
@@ -1674,7 +1674,7 @@ create_colwidth_df_l <- function(data) {
     if (is.null(raw) || raw == "") {
       next
     } else if (endsWith(raw, "%")) {
-      pct <- as.numeric(gsub("%", "", raw))
+      pct <- as.numeric(gsub("%", "", raw, fixed = TRUE))
 
       if (tbl_width == "auto") {
         width_df$lw[i] <- pct

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -1562,10 +1562,8 @@ create_body_component_rtf <- function(data) {
           # stub case where summary rows follow
           if (x == 1) {
 
-            row_limits <-
-              groups_rows_df %>%
-              dplyr::filter(row_end == i) %>%
-              dplyr::select(group_id)
+            row_limits <- dplyr::filter(groups_rows_df, row_end == i)
+            row_limits <- row_limits[ , "group_id", drop = FALSE]
 
             if (nrow(row_limits) > 0) {
 

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -388,7 +388,7 @@ parse_length_str <- function(
   if (
     !allow_negative &&
     length(non_na_vals) > 0 &&
-    any(!is.na(non_na_vals)) &&
+    !all(is.na(non_na_vals)) &&
     is.numeric(non_na_vals) &&
     any(non_na_vals < 0)
   ) {
@@ -1459,7 +1459,7 @@ create_body_component_rtf <- function(data) {
     )
 
   # Replace an NA group with an empty string
-  if (any(is.na(groups_rows_df$group_label))) {
+  if (anyNA(groups_rows_df$group_label)) {
 
     groups_rows_df <-
       dplyr::mutate(
@@ -1468,7 +1468,7 @@ create_body_component_rtf <- function(data) {
       )
   }
 
-  row_groups_present <- nrow(groups_rows_df) > 0
+  row_groups_present <- nrow(groups_rows_df) > 0L
   row_group_rows <- groups_rows_df$row_start
   row_group_labels <- groups_rows_df$group_label
 

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -808,8 +808,8 @@ footnote_mark_to_rtf <- function(
       paste0(
       "{",
       if (grepl("\\^", spec)) "\\super " else NULL,
-      if (grepl("i", spec)) "\\i " else NULL,
-      if (grepl("b", spec)) "\\b " else NULL
+      if (grepl("i", spec, fixed = TRUE)) "\\i " else NULL,
+      if (grepl("b", spec, fixed = TRUE)) "\\b " else NULL
       )
     ),
     mark,
@@ -852,7 +852,7 @@ escape_rtf_unicode <- function(x) {
     x <- enc2utf8(x)
   }
 
-  chars <- unlist(strsplit(x, ""))
+  chars <- unlist(strsplit(x, "", fixed = TRUE))
   codepoints <- utf8ToInt(x)
   needs_escape <- codepoints > 127
   codepoints_subset <- codepoints[needs_escape]

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -1461,11 +1461,7 @@ create_body_component_rtf <- function(data) {
   # Replace an NA group with an empty string
   if (anyNA(groups_rows_df$group_label)) {
 
-    groups_rows_df <-
-      dplyr::mutate(
-        groups_rows_df,
-        group_label = ifelse(is.na(group_label), "", group_label)
-      )
+    groups_rows_df$group_label[is.na(groups_rows_df$label)] <- ""
   }
 
   row_groups_present <- nrow(groups_rows_df) > 0L

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -1715,8 +1715,7 @@ create_body_component_rtf <- function(data) {
     grand_summary_df <-
       dplyr::select(
         list_of_summaries$summary_df_display_list[[grand_summary_col]],
-        dplyr::all_of(rowname_col_private),
-        dplyr::all_of(default_vars_names)
+        dplyr::all_of(c(rowname_col_private, default_vars_names))
       )
 
     for (j in seq_len(nrow(grand_summary_df))) {
@@ -1944,7 +1943,7 @@ generate_notes_list <- function(
   if (nrow(footnotes_tbl) > 0) {
 
     footnotes_tbl <-
-      dplyr::distinct(dplyr::select(footnotes_tbl, fs_id, footnotes))
+      dplyr::distinct(footnotes_tbl, fs_id, footnotes)
 
     footnote_text <- footnotes_tbl[["footnotes"]]
     footnote_mark <- footnotes_tbl[["fs_id"]]

--- a/R/utils_render_xml.R
+++ b/R/utils_render_xml.R
@@ -397,8 +397,7 @@ xml_ilvl <- function(..., val, app = "word") {
 
 xml_numId <- function(..., val, app = "word") {
 
-  stopifnot(is.numeric(val))
-  stopifnot(val > 0)
+  stopifnot(is.numeric(val), val > 0)
 
   htmltools::tag(
     `_tag_name` = xml_tag_type("numId", app),
@@ -921,7 +920,7 @@ xml_a_graphic_frame_locks <- function(noChangeAspect = TRUE, noCrop = FALSE, noR
   htmltools::tag(
     `_tag_name` = "a:graphicFrameLocks",
     varArgs = as.list(c(
-      `xmlns:a`="http://schemas.openxmlformats.org/drawingml/2006/main",
+      `xmlns:a` = "http://schemas.openxmlformats.org/drawingml/2006/main",
       locks_list
     ))
   )
@@ -955,7 +954,7 @@ xml_pic_pic <- function(...) {
   htmltools::tag(
     `_tag_name` = "pic:pic",
     varArgs = list(
-      `xmlns:pic`="http://schemas.openxmlformats.org/drawingml/2006/picture",
+      `xmlns:pic` = "http://schemas.openxmlformats.org/drawingml/2006/picture",
       ...
     )
   )
@@ -1045,7 +1044,7 @@ xml_a_stretch_rect <- function() {
     `_tag_name` = "a:stretch",
     varArgs = list(
       htmltools::tag(
-        `_tag_name` = "a:fillRect",varArgs = list()
+        `_tag_name` = "a:fillRect", varArgs = list()
       )
     )
   )
@@ -1185,7 +1184,7 @@ create_table_props_component_xml <- function(data, align = c("center", "start", 
       ),
       xml_tblW(type = "auto", w = 0),
       xml_tblLook(),
-      xml_jc(val = c(center="center",start = "start",end = "end",end = "right",start = "left")[[align]])
+      xml_jc(val = c(center = "center", start = "start", end = "end", end = "right", start = "left")[[align]])
     )
 
   # table_cols <- xml_tblGrid(

--- a/R/utils_render_xml.R
+++ b/R/utils_render_xml.R
@@ -297,7 +297,7 @@ xml_border <- function(
       bottom = "bottom"
     )
 
-  color <- toupper(gsub("#", "", color))
+  color <- toupper(gsub("#", "", color, fixed = TRUE))
 
   htmltools::tag(
     `_tag_name` = xml_tag_type(dir, app),
@@ -757,8 +757,8 @@ footnote_mark_to_xml <- function(
         xml_baseline_adj(
           v_align = if (grepl("\\^", spec)) "superscript" else "baseline"
         ),
-        if (grepl("i", spec)) xml_i(active = TRUE) else NULL,
-        if (grepl("b", spec)) xml_b(active = TRUE) else NULL
+        if (grepl("i", spec, fixed = TRUE)) xml_i(active = TRUE) else NULL,
+        if (grepl("b", spec, fixed = TRUE)) xml_b(active = TRUE) else NULL
       ),
       xml_t(mark)
     )

--- a/R/utils_units.R
+++ b/R/utils_units.R
@@ -119,7 +119,7 @@ define_units <- function(units_notation, is_chemical_formula = FALSE) {
           }
 
           # Superscript following closing ']'
-          if (grepl("\\]", x) && grepl("[0-9+-]", x) && nchar(x) > 1) {
+          if (grepl("]", x, fixed = TRUE) && grepl("[0-9+-]", x) && nchar(x) > 1) {
             x <- gsub("^(.*)(\\])([0-9+-]*)$", "\\1\\2^\\3", x)
           }
 

--- a/R/z_utils_render_footnotes.R
+++ b/R/z_utils_render_footnotes.R
@@ -140,7 +140,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
     }
 
     # Re-combine `tbl_data` with `tbl`
-    tbl <- dplyr::bind_rows(tbl_not_data, tbl_data)
+    tbl <- vctrs::vec_rbind(tbl_not_data, tbl_data)
 
   } else {
     tbl$colnum <- NA_integer_
@@ -165,7 +165,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
     tbl_row_groups$group_label <- NULL
 
     # Re-combine `tbl_not_row_groups` with `tbl_row_groups`
-    tbl <- dplyr::bind_rows(tbl_not_row_groups, tbl_row_groups)
+    tbl <- vctrs::vec_rbind(tbl_not_row_groups, tbl_row_groups)
   }
 
   # For the summary cells, insert a `rownum` based
@@ -304,11 +304,12 @@ resolve_footnotes_styles <- function(data, tbl_type) {
     }
 
     spanner_label_df <-
-      dplyr::tibble(
+      data.frame(
         grpname = spanner_id,
         colname = spanner_start_colname,
         colnum = spanner_start_colnum,
-        rownum = level
+        rownum = level,
+        stringsAsFactors = FALSE
       )
 
     if (nrow(spanner_label_df) > 0L) {
@@ -324,7 +325,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
 
       # Re-combine `tbl_not_col_spanner_cells` with `tbl_not_col_spanner_cells`
       tbl <-
-        dplyr::bind_rows(
+        vctrs::vec_rbind(
           tbl_not_col_spanner_cells,
           tbl_column_spanner_cells
         )
@@ -375,7 +376,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
         tbl$fs_id <- process_footnote_marks(tbl$fs_id, marks = footnote_marks)
       }
 
-      tbl <- dplyr::bind_rows(tbl_no_loc, tbl)
+      tbl <- vctrs::vec_rbind(tbl_no_loc, tbl)
     }
   }
 

--- a/R/z_utils_render_footnotes.R
+++ b/R/z_utils_render_footnotes.R
@@ -311,7 +311,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
         rownum = level
       )
 
-    if (nrow(spanner_label_df) > 0) {
+    if (nrow(spanner_label_df) > 0L) {
 
       tmp <- tbl
       tmp$colnum <- NULL
@@ -361,7 +361,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
     tbl <- dplyr::left_join(tbl, lookup_tbl, by = "footnotes")
     tbl$fs_id <- ifelse(tbl$locname == "none", NA_character_, tbl$fs_id)
 
-    if (nrow(tbl) > 0) {
+    if (nrow(tbl) > 0L) {
 
       # Retain the row that only contain `locname == "none"`
       tbl_no_loc <- dplyr::filter(tbl, locname == "none")
@@ -369,7 +369,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
       # Modify `fs_id` to contain the footnote marks we need
       tbl <- dplyr::filter(tbl, locname != "none")
 
-      if (nrow(tbl) > 0) {
+      if (nrow(tbl) > 0L) {
 
         tbl$fs_id <- as.integer(tbl$fs_id)
         tbl$fs_id <- process_footnote_marks(tbl$fs_id, marks = footnote_marks)
@@ -667,8 +667,7 @@ set_footnote_marks_row_groups <- function(data, context = "html") {
       dplyr::group_by(grpname) %>%
       dplyr::mutate(fs_id_coalesced = paste(fs_id, collapse = ",")) %>%
       dplyr::ungroup() %>%
-      dplyr::select(grpname, fs_id_coalesced) %>%
-      dplyr::distinct()
+      dplyr::distinct(grpname, fs_id_coalesced)
 
     for (i in seq_len(nrow(footnotes_row_groups_marks))) {
 

--- a/data-raw/X05-google_fonts.R
+++ b/data-raw/X05-google_fonts.R
@@ -122,8 +122,7 @@ for (file in all_files) {
         dplyr::bind_rows(
           google_axes_tbl,
           dplyr::as_tibble(read.dcf(textConnection(axes[[i]]))) %>%
-            dplyr::mutate(name = font_name) %>%
-            dplyr::select(name, dplyr::everything())
+            dplyr::mutate(name = font_name, .before = 0)
         )
     }
   }

--- a/man/tab_spanner_delim.Rd
+++ b/man/tab_spanner_delim.Rd
@@ -216,7 +216,7 @@ two levels of spanners. We can further touch up the labels after that with
     fn = function(x) gsub("pct", "\%", x)
   ) |>
   text_transform(
-    fn = function(x) gsub("\\\\.", " - ", x),
+    fn = function(x) gsub(".", " - ", x, fixed = TRUE),
     locations = cells_column_spanners()
   ) |>
   tab_style(

--- a/tests/testthat/test-as_latex.R
+++ b/tests/testthat/test-as_latex.R
@@ -66,7 +66,7 @@ test_that("Table styles correctly applied", {
     tab_style(style = cell_text(transform = 'uppercase'),
               locations = cells_column_labels(columns = c('num', 'fctr', 'datetime'))) %>%
     tab_style(style = gt::cell_text(style = 'italic'),
-              locations = cells_column_spanners(spanner = 'a1')) %>%
+              locations = cells_column_spanners(spanners = 'a1')) %>%
 
     # Body styles
     tab_style(style = cell_text(size = 20,

--- a/tests/testthat/test-cols_width.R
+++ b/tests/testthat/test-cols_width.R
@@ -919,7 +919,7 @@ test_that("cols_width() correctly specifies LaTeX table when column widths are s
         c(...),
         "\\}\\n"
       ),
-      collapse = ''
+      collapse = ""
     )
 
   }
@@ -934,7 +934,7 @@ test_that("cols_width() correctly specifies LaTeX table when column widths are s
                c(5L, 3L, 2L, 1L)),
         "\\}\\n"
       ),
-      collapse = ''
+      collapse = ""
     )
 
   # Expect that all column widths are expressed as percentage of \linewidth

--- a/tests/testthat/test-fmt_percent.R
+++ b/tests/testthat/test-fmt_percent.R
@@ -427,17 +427,17 @@ test_that("fmt_percent() works correctly with stubs", {
   # stub as markdown
 
   for (test_case in c("raw", "markdown", "html")) {
-    tab <- tbl |>
-      gt(rowname_col = test_case) |>
-      fmt_percent(columns = pct_col, decimals = 2, dec_mark = ".") |>
+    tab <- tbl %>%
+      gt(rowname_col = test_case) %>%
+      fmt_percent(columns = pct_col, decimals = 2, dec_mark = ".") %>%
       render_formats_test(context = "html")
 
     expect_equal(tab[["pct_col"]], c("75.00%", "25.00%"))
 
     # with row filter
-    tab <- tbl |>
-      gt(rowname_col = test_case) |>
-      fmt_percent(columns = pct_col, decimals = 2, dec_mark = ".", rows = contains("gt")) |>
+    tab <- tbl %>%
+      gt(rowname_col = test_case) %>%
+      fmt_percent(columns = pct_col, decimals = 2, dec_mark = ".", rows = contains("gt")) %>%
       render_formats_test(context = "html")
 
     expect_equal(tab[["pct_col"]], c("0.75", "25.00%"))

--- a/tests/testthat/test-gt_object.R
+++ b/tests/testthat/test-gt_object.R
@@ -790,16 +790,17 @@ test_that("Escapable characters in rownames are handled correctly in each output
     "\\intbl {\\f0 {\\f0\\fs20 rtf}}\\cell",
     fixed = TRUE
   )
+  tib <- dplyr::as_tibble(tbl)
 
   # Using a tibble (removes row names) and setting `column_1` as the stub
   expect_match( # stub from `column_1`
-    gt(dplyr::as_tibble(tbl), rowname_col = "column_1") %>%
+    gt(tib, rowname_col = "column_1") %>%
       as_rtf() %>% as.character(),
     "\\intbl {\\f0 {\\f0\\fs20 \\'7brtf\\'7d}}\\cell",
     fixed = TRUE
   )
   expect_match( # `column_2`
-    gt(dplyr::as_tibble(tbl), rowname_col = "column_1") %>%
+    gt(tib, rowname_col = "column_1") %>%
       as_rtf() %>% as.character(),
     "\\intbl {\\f0 {\\f0\\fs20 rtf}}\\cell",
     fixed = TRUE

--- a/tests/testthat/test-gtsave.R
+++ b/tests/testthat/test-gtsave.R
@@ -133,7 +133,7 @@ test_that("HTML saving with `gtsave()` is successful with different path defs", 
   #
 
   # Form final path, check for non-existence
-  path_1 <- normalizePath(tempfile(fileext = ".html"), winslash = "/", mustWork = F)
+  path_1 <- normalizePath(tempfile(fileext = ".html"), winslash = "/", mustWork = FALSE)
   on.exit(unlink(path_1))
   expect_false(file.exists(path_1))
 
@@ -485,7 +485,7 @@ test_that("gtsave() creates docx files as expected", {
 
   gt_exibble <- exibble %>% gt()
 
-  temp_docx <- file.path(tempdir(),"test.docx")
+  temp_docx <- file.path(tempdir(), "test.docx")
   on.exit(unlink(temp_docx))
   expect_false(file.exists(temp_docx))
 
@@ -494,7 +494,7 @@ test_that("gtsave() creates docx files as expected", {
   # Check for existence
   expect_true(file.exists(temp_docx))
 
-  temp_docx_xml <- xml2::read_xml(unz(temp_docx,"word/document.xml"))
+  temp_docx_xml <- xml2::read_xml(unz(temp_docx, "word/document.xml"))
 
   temp_docx_xml %>%
     xml2::xml_find_first(".//w:tbl") %>%
@@ -517,7 +517,7 @@ test_that("gtsave() creates docx files even when a table has special characters"
     ) %>%
     gt()
 
-  temp_docx <- file.path(tempdir(),"test.docx")
+  temp_docx <- file.path(tempdir(), "test.docx")
   on.exit(unlink(temp_docx))
   expect_false(file.exists(temp_docx))
 
@@ -526,7 +526,7 @@ test_that("gtsave() creates docx files even when a table has special characters"
   # Check for existence
   expect_true(file.exists(temp_docx))
 
-  temp_docx_xml <- xml2::read_xml(unz(temp_docx,"word/document.xml"))
+  temp_docx_xml <- xml2::read_xml(unz(temp_docx, "word/document.xml"))
 
   temp_docx_xml %>%
     xml2::xml_find_first(".//w:tbl") %>%


### PR DESCRIPTION
# Summary

This PR updates some code and has 2 goals

## Performance

Partially inspired by https://www.tidyverse.org/blog/2023/04/performant-packages/

* Use more vctrs and base R instead of dplyr when possible
* use `fixed = TRUE`
* Simplify some dplyr code
* a tibble is not always necessary. and can be replaced with `vctrs::data_frame()` for complex cases or `data.frame()`

## linting / code consistency

* Reduce magrittr pipe in codebase
* Use magrittr pipe in test-fmt_percent.R
* linting suggested by lintr
* space and quotes



# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.

* Follows-up on #968 + #1470

#performance

Other possibilities, see if we can reduce `as_tibble()` calls

# Profiling

Before:
![image](https://github.com/rstudio/gt/assets/52606734/15f735c1-9af4-4aee-b42e-aab00ebaf94d)
This PR
![image](https://github.com/rstudio/gt/assets/52606734/2ad72125-ff28-4217-a31c-293fcb796769)

Seems to be a significant memory usage gain!


with the following example:



The overall impact may not be that big, but still base R has some interesting improvements



```r

bench::mark(
  mtcars |> dplyr::filter(vs > 5) |> dplyr::pull(cyl),
  mtcars[mtcars$vs > 5, "cyl", drop = TRUE]
)
#> # A tibble: 2 × 6
#>   expression                            min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                        <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 "dplyr::pull(dplyr::filter(mtcar…  1.08ms  1.43ms      556.    4.05MB     8.46
#> 2 "mtcars[mtcars$vs > 5, \"cyl\", …  16.7µs  19.5µs    36483.      184B     7.30

bench::mark(
  mtcars |> dplyr::arrange(cyl),
  mtcars[order(mtcars$cyl), ]
)
#> # A tibble: 2 × 6
#>   expression                       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 dplyr::arrange(mtcars, cyl)    1.6ms   1.93ms      468.    4.24MB     6.36
#> 2 mtcars[order(mtcars$cyl), ]  107.8µs  122.7µs     6326.    3.86KB    12.6
```


I used this example


```r
library(dplyr)
library(gt) # or load_all()
best_gas_mileage_city <- 
  gtcars |> 
  arrange(desc(mpg_c)) |>
  slice(1) |>
  mutate(car = paste(mfr, model)) |>
  pull(car)

# Use dplyr functions to get the car with the highest horsepower
# this will be used to target the correct cell for a footnote
highest_horsepower <- 
  gtcars |> 
  arrange(desc(hp)) |>
  slice(1) |>
  mutate(car = paste(mfr, model)) |>
  pull(car)

# Define our preferred order for `ctry_origin`
order_countries <- c("Germany", "Italy", "United States", "Japan")

# Create a display table with `gtcars`, using all of the previous
# statements piped together + additional `tab_footnote()` stmts
tab <-
  gtcars |>
  arrange(
    factor(ctry_origin, levels = order_countries),
    mfr, desc(msrp)
  ) |>
  mutate(car = paste(mfr, model)) |>
  select(-mfr, -model) |>
  group_by(ctry_origin) |>
  gt(rowname_col = "car") |>
  cols_hide(columns = c(drivetrain, bdy_style)) |>
  cols_move(
    columns = c(trsmn, mpg_c, mpg_h),
    after = trim
  ) |>
  tab_spanner(
    label = "Performance",
    columns = c(mpg_c, mpg_h, hp, hp_rpm, trq, trq_rpm)
  ) |>
  cols_merge(
    columns = c(mpg_c, mpg_h),
    pattern = "<<{1}c<br>{2}h>>"
  ) |>
  cols_merge(
    columns = c(hp, hp_rpm),
    pattern = "{1}<br>@{2}rpm"
  ) |>
  cols_merge(
    columns = c(trq, trq_rpm),
    pattern = "{1}<br>@{2}rpm"
  ) |>
  cols_label(
    mpg_c = "MPG",
    hp = "HP",
    trq = "Torque",
    year = "Year",
    trim = "Trim",
    trsmn = "Transmission",
    msrp = "MSRP"
  ) |>
  fmt_currency(columns = msrp, decimals = 0) |>
  cols_align(
    align = "center",
    columns = c(mpg_c, hp, trq)
  ) |>
  tab_style(
    style = cell_text(size = px(12)),
    locations = cells_body(
      columns = c(trim, trsmn, mpg_c, hp, trq)
    )
  ) |>
  text_transform(
    locations = cells_body(columns = trsmn),
    fn = function(x) {
      
      speed <- substr(x, 1, 1)
      
      type <-
        dplyr::case_when(
          substr(x, 2, 3) == "am" ~ "Automatic/Manual",
          substr(x, 2, 2) == "m" ~ "Manual",
          substr(x, 2, 2) == "a" ~ "Automatic",
          substr(x, 2, 3) == "dd" ~ "Direct Drive"
        )
      
      paste(speed, " Speed<br><em>", type, "</em>")
    }
  ) |>
  tab_header(
    title = md("The Cars of **gtcars**"),
    subtitle = "These are some fine automobiles"
  ) |>
  tab_source_note(
    source_note = md(
      "Source: Various pages within the Edmonds website."
    )
  ) |>
  tab_footnote(
    footnote = md("Best gas mileage (city) of all the **gtcars**."),
    locations = cells_body(
      columns = mpg_c,
      rows = best_gas_mileage_city
    )
  ) |>
  tab_footnote(
    footnote = md("The highest horsepower of all the **gtcars**."),
    locations = cells_body(
      columns = hp,
      rows = highest_horsepower
    )
  ) |>
  tab_footnote(
    footnote = "All prices in U.S. dollars (USD).",
    locations = cells_column_labels(columns = msrp)
  ) 
tab %>% gt:::render_as_html()
```
