### PR TITLE
Improve error message for `tab_options()` wrong input

### DIFF
--- a/R/gt_group.R
+++ b/R/gt_group.R
@@ -778,14 +778,11 @@ grp_options <- function(
       dplyr::select(opts_df, parameter, type),
       by = "parameter"
     )
-  new_df <-
-    dplyr::mutate(
-      new_df,
-      value = mapply(
-        preprocess_tab_option,
-        option = value, var_name = parameter, type = type,
-        SIMPLIFY = FALSE
-      )
+  new_df$value <-
+    mapply(
+      preprocess_tab_option,
+      option = new_df$value, var_name = new_df$parameter, type = new_df$type,
+      SIMPLIFY = FALSE
     )
   new_df$type <- NULL
 

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -4809,7 +4809,8 @@ tab_options <- function(
   data
 }
 
-preprocess_tab_option <- function(option, var_name, type) {
+# call is set to caller_env(2) to skip the mapply() call in tab_options() and grp_options()
+preprocess_tab_option <- function(option, var_name, type, call = rlang::caller_env(2)) {
 
   # Perform pre-processing on the option depending on `type`
   option <-
@@ -4834,14 +4835,14 @@ preprocess_tab_option <- function(option, var_name, type) {
       option
     )
 
-  # Perform `stopifnot()` checks by `type`
+  # Perform `check_*()` checks by `type`
   switch(
     type,
-    logical = stopifnot(rlang::is_scalar_logical(option), !anyNA(option)),
+    logical = check_bool(option, arg = var_name, call = call),
     overflow = ,
     px = ,
-    value = stopifnot(rlang::is_scalar_character(option), !anyNA(option)),
-    values = stopifnot(rlang::is_character(option), length(option) >= 1L, !anyNA(option))
+    value = check_string(option, arg = var_name, allow_na = FALSE, call = call),
+    values = check_chr_has_length(option, arg = var_name, call = call)
   )
 
   option

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -4756,15 +4756,11 @@ tab_options <- function(
       dplyr::select(opts_df, parameter, type),
       by = "parameter"
     )
-  new_df <-
-    dplyr::mutate(
-      new_df,
-      value = mapply(
+  new_df$value <- mapply(
         preprocess_tab_option,
-        option = value, var_name = parameter, type = type,
+        option = new_df$value, var_name = new_df$parameter, type = new_df$type,
         SIMPLIFY = FALSE
       )
-    )
   new_df$type <- NULL
 
   # This rearranges the rows in the `opts_df` table, but this

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1686,7 +1686,7 @@ create_footnotes_component_h <- function(data) {
   # Get the style attrs for the footnotes
   if ("footnotes" %in% styles_tbl$locname) {
 
-    footnotes_style <- dplyr::filter(styles_tbl, locname == "footnotes")
+    footnotes_style <- styles_tbl[styles_tbl$locname == "footnotes", ]
 
     footnotes_styles <-
       if (nrow(footnotes_style) > 0) {

--- a/R/utils_render_xml.R
+++ b/R/utils_render_xml.R
@@ -644,7 +644,7 @@ xml_fldChar <- function(
 ) {
 
   fldCharType <- rlang::arg_match(fldCharType)
-  stopifnot(is_bool(dirty))
+  check_bool(dirty)
 
   htmltools::tag(
     `_tag_name` = xml_tag_type("fldChar", app),


### PR DESCRIPTION
# Summary

While working on something else, I noticed that the error message for wrong type for options was not informative.

`check_*()` won't allow `NA` by default, although it is possible to override this!

Using `arg = var_name` allows to include the faulty argument's name. (although it will loose its `.` for `_` due to `tidy_gsub()`, but will still be informative!

```r
# Before
exibble |> gt() |> tab_options(footnotes.multiline = "\n")
#> Error in `dplyr::mutate()`:
ℹ In argument: `value = mapply(...)`.
Caused by error:
! rlang::is_scalar_logical(option) is not TRUE

# This PR
#> Error in `tab_options()`:
#> ! `footnotes_multiline` must be `TRUE` or `FALSE`, not the string "\n".

```

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
