### PR TITLE
Add `locale` to `info_time_style()` and `info_date_style()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * gt now depends on R 3.6 (@olivroy, #1731).
 
+* `info_time_style()` and `info_date_style()` gain a `locale` argument to preview datetime formatting in a given locale.
+
 * `opt_interactive()` gains `height` to help specify your widget's height (@olivroy, #1544).
 
 * `opt_interactive()` now shows row names if `rownames_to_stub = TRUE` (@olivroy, #1702). 

--- a/R/info_tables.R
+++ b/R/info_tables.R
@@ -31,6 +31,7 @@
 #' reference to all styles, with associated format names and example outputs
 #' using a fixed date (`2000-02-29`).
 #'
+#' @param locale A locale.
 #' @return An object of class `gt_tbl`.
 #'
 #' @section Examples:
@@ -54,7 +55,7 @@
 #' `v0.2.0.5` (March 31, 2020)
 #'
 #' @export
-info_date_style <- function() {
+info_date_style <- function(locale = NULL) {
 
   date_formats() %>%
     dplyr::mutate(date = "2000-02-29") %>%
@@ -62,7 +63,7 @@ info_date_style <- function() {
       flexible ~ "FLEXIBLE",
       .default = ""
     )) %>%
-    gt(rowname_col = "format_number") %>%
+    gt(rowname_col = "format_number", locale = locale) %>%
     cols_hide(columns = format_code) %>%
     fmt_date(columns = date, rows = 1, date_style = 1) %>%
     fmt_date(columns = date, rows = 2, date_style = 2) %>%
@@ -142,6 +143,8 @@ info_date_style <- function() {
 #' reference to all styles, with associated format names and example outputs
 #' using a fixed time (`14:35`).
 #'
+#' @param locale A locale.
+#'
 #' @return An object of class `gt_tbl`.
 #'
 #' @section Examples:
@@ -165,7 +168,7 @@ info_date_style <- function() {
 #' `v0.2.0.5` (March 31, 2020)
 #'
 #' @export
-info_time_style <- function() {
+info_time_style <- function(locale = NULL) {
 
   time_formats() %>%
     dplyr::mutate(time = "14:35") %>%
@@ -173,7 +176,7 @@ info_time_style <- function() {
       flexible ~ "FLEXIBLE",
       TRUE ~ ""
     )) %>%
-    gt(rowname_col = "format_number") %>%
+    gt(rowname_col = "format_number", locale = locale) %>%
     cols_hide(columns = format_code) %>%
     fmt_time(columns = time, rows = 1, time_style = 1) %>%
     fmt_time(columns = time, rows = 2, time_style = 2) %>%

--- a/man/info_date_style.Rd
+++ b/man/info_date_style.Rd
@@ -4,7 +4,10 @@
 \alias{info_date_style}
 \title{View a table with info on date styles}
 \usage{
-info_date_style()
+info_date_style(locale = NULL)
+}
+\arguments{
+\item{locale}{A locale.}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/man/info_time_style.Rd
+++ b/man/info_time_style.Rd
@@ -4,7 +4,10 @@
 \alias{info_time_style}
 \title{View a table with info on time styles}
 \usage{
-info_time_style()
+info_time_style(locale = NULL)
+}
+\arguments{
+\item{locale}{A locale.}
 }
 \value{
 An object of class \code{gt_tbl}.


### PR DESCRIPTION
To preview time and date styles

With `locale = "fr"`, I got this

![image](https://github.com/rstudio/gt/assets/52606734/32d9c0f8-3bba-4c2d-ab4d-a2336ab2a6ca)
