### PR TITLE
Ensure that `id` values are stripped of HTML tags when using `tab_row_group()`

### DIFF
--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1708,6 +1708,13 @@ tab_row_group <- function(
 
   stub_df <- dt_stub_df_get(data = data)
 
+  # If the label is marked as HTML or Markdown and there's no `id` set
+  # (assumed when `id` is equal to `label`), strip away HTML tags in the
+  # `id` value
+  if (id == label && (inherits(id, "html") || inherits(id, "from_markdown"))) {
+    id <- remove_html(as.character(id))
+  }
+
   # Place the `label` in the `groupname` column `stub_df`
   stub_df[resolved_rows_idx, "group_label"] <- list(list(label))
   stub_df[resolved_rows_idx, "group_id"] <- as.character(id)

--- a/tests/testthat/test-table_parts.R
+++ b/tests/testthat/test-table_parts.R
@@ -210,6 +210,42 @@ test_that("Row groups can be successfully generated with `tab_row_group()", {
     c("", "Mazda", "Mercs")
   )
 
+  # Create a `tbl_html` object with `gt()`; this table contains a single
+  # row group that has a label with the `html()` helper
+  tbl_html <-
+    gtcars %>%
+    dplyr::select(model, year, hp, trq) %>%
+    dplyr::slice(1:8) %>%
+    gt(rowname_col = "model") %>%
+    tab_row_group(
+      label = html("<div style=\"font-weight: bold;\">numbered</div>"),
+      rows = matches("^[0-9]")
+    ) %>%
+    render_as_html() %>%
+    xml2::read_html()
+
+  # Expect that the inner HTML content for the row group
+  # has the expected text
+  expect_equal(get_row_group_text(tbl_html), c("numbered", ""))
+
+  # Create a `tbl_html` object with `gt()`; this table contains a single
+  # row group that has a label with the `md()` helper
+  tbl_html <-
+    gtcars %>%
+    dplyr::select(model, year, hp, trq) %>%
+    dplyr::slice(1:8) %>%
+    gt(rowname_col = "model") %>%
+    tab_row_group(
+      label = md("**cars** that are <em>numbered</em>"),
+      rows = matches("^[0-9]")
+    ) %>%
+    render_as_html() %>%
+    xml2::read_html()
+
+  # Expect that the inner HTML content for the row group
+  # has the expected text
+  expect_equal(get_row_group_text(tbl_html), c("cars that are numbered", ""))
+
   # Create a variation on the above table where `row_group_order()`
   # leaves out `NA` (it's put at the end)
   tbl_html <-


### PR DESCRIPTION
In the case where `id` values inherit directly from the `label` value *and* the `html()` or `md()` helpers are used, strip any HTML tags from `id` to obtain a simplified string. This solves an issue where complicated tags result in problems when retrieving the label value during render.

Fixes: https://github.com/rstudio/gt/issues/1143

