### PR TITLE
Respect `tab_stubhead()` in `opt_interactive()`+ fix rendering for missing row names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * `opt_interactive()` now shows row names if `rownames_to_stub = TRUE` (@olivroy, #1702). 
 
+* `opt_ineractive()` now displays the stub header label created with `tab_stubhead()` (@olivroy, #1758).
+
 * `data_color()` throws a more informative error message if `rows` didn't resolve to anything (@olivroy, #1659).
 
 * PDF output now allows the font size of a table to be set using the table.font.size parameter in the tab_options function (#1472).  The font sizes of individual table cells (including those in the body, stubs, column headings, etc.) can be set using tab_style function. Several other options specified in tab_style are now reflected in PDF output.

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -111,7 +111,7 @@ render_as_ihtml <- function(data, id) {
       # Convert to NA string to avoid wrong output.
       # TODO figure out if there is a way to get the sub_missing value.
       # With data$`_substitutions`
-      row_names <- dplyr::coalesce(row_names, "NA")
+      row_names <- dplyr::coalesce(row_names, "")
       attr(data_tbl, "row.names") <- row_names
       row_name_col_def <- list(reactable::colDef(
           name = rowname_label

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -55,47 +55,10 @@ render_as_ihtml <- function(data, id) {
 
   # Obtain the language from the `locale`, if provided
   locale <- normalize_locale(dt_locale_get_value(data = data))
-
   # Generate a `lang_defs` object to pass to the `language` argument
-  if (is.null(locale) || locale == "en") {
-
-    lang_defs <- reactable::reactableLang()
+  lang_defs <- get_ihtml_translations(locale)
 
   } else {
-
-    locale_data <- locales[locales$locale == locale, ][1, ]
-
-    if (is.na(locale_data[["no_table_data_text"]])) {
-
-      lang_defs <- reactable::reactableLang()
-
-    } else {
-
-      lang_defs <-
-        reactable::reactableLang(
-          sortLabel = locale_data[["sort_label_text"]],
-          filterPlaceholder = "",
-          filterLabel = locale_data[["filter_label_text"]],
-          searchPlaceholder = locale_data[["search_placeholder_text"]],
-          searchLabel = locale_data[["search_placeholder_text"]],
-          noData = locale_data[["no_table_data_text"]],
-          pageNext = locale_data[["page_next_text"]],
-          pagePrevious = locale_data[["page_previous_text"]],
-          pageNumbers = locale_data[["page_numbers_text"]],
-          pageInfo = gsub("\\\\u2013", "\u2013", locale_data[["page_info_text"]]),
-          pageSizeOptions = locale_data[["page_size_options_text"]],
-          pageNextLabel = locale_data[["page_next_label_text"]],
-          pagePreviousLabel = locale_data[["page_previous_label_text"]],
-          pageNumberLabel = locale_data[["page_number_label_text"]],
-          pageJumpLabel = locale_data[["page_jump_label_text"]],
-          pageSizeOptionsLabel = locale_data[["page_size_options_label_text"]],
-          groupExpandLabel = "Toggle group",
-          detailsExpandLabel = "Toggle details",
-          selectAllRowsLabel = "Select all rows",
-          selectAllSubRowsLabel = "Select all rows in group",
-          selectRowLabel = "Select row"
-        )
-    }
   }
 
   # Obtain the underlying data table (including group rows)
@@ -807,4 +770,48 @@ create_footnotes_component_ihtml <- function(data) {
       )
     )
   )
+}
+
+get_ihtml_translations <- function(locale) {
+  if (is.null(locale) || locale == "en") {
+
+    lang_defs <- reactable::reactableLang()
+
+  } else {
+
+    locale_data <- locales[locales$locale == locale, ][1, ]
+
+    if (is.na(locale_data[["no_table_data_text"]])) {
+
+      lang_defs <- reactable::reactableLang()
+
+    } else {
+
+      lang_defs <-
+        reactable::reactableLang(
+          sortLabel = locale_data[["sort_label_text"]],
+          filterPlaceholder = "",
+          filterLabel = locale_data[["filter_label_text"]],
+          searchPlaceholder = locale_data[["search_placeholder_text"]],
+          searchLabel = locale_data[["search_placeholder_text"]],
+          noData = locale_data[["no_table_data_text"]],
+          pageNext = locale_data[["page_next_text"]],
+          pagePrevious = locale_data[["page_previous_text"]],
+          pageNumbers = locale_data[["page_numbers_text"]],
+          pageInfo = gsub("\\\\u2013", "\u2013", locale_data[["page_info_text"]]),
+          pageSizeOptions = locale_data[["page_size_options_text"]],
+          pageNextLabel = locale_data[["page_next_label_text"]],
+          pagePreviousLabel = locale_data[["page_previous_label_text"]],
+          pageNumberLabel = locale_data[["page_number_label_text"]],
+          pageJumpLabel = locale_data[["page_jump_label_text"]],
+          pageSizeOptionsLabel = locale_data[["page_size_options_label_text"]],
+          groupExpandLabel = "Toggle group",
+          detailsExpandLabel = "Toggle details",
+          selectAllRowsLabel = "Select all rows",
+          selectAllSubRowsLabel = "Select all rows in group",
+          selectRowLabel = "Select row"
+        )
+    }
+  }
+  lang_defs
 }

--- a/R/render_as_i_html.R
+++ b/R/render_as_i_html.R
@@ -303,7 +303,7 @@ render_as_ihtml <- function(data, id) {
 
       group_col_defs[[i]] <-
         reactable::colDef(
-          name = stub_label,
+          name = group_label,
           # The total number of rows is wrong in colGroup, possibly due to the JS fn
           grouped = grp_fn,
           # FIXME Should groups be sticky? (or provide a way to do this)

--- a/tests/testthat/test-i_html.R
+++ b/tests/testthat/test-i_html.R
@@ -80,7 +80,16 @@ test_that("Interactive tables won't fail when using different options", {
   tbl_gt_i_25 <-
     gt(mtcars_short, groupname_col = "vs") %>%
     opt_interactive()
-
+  # #1758 tab_stubhead() respected (shown on top of group)
+  tbl_gt_i_26 <-
+    gt(mtcars_short, groupname_col = "vs", rownames_to_stub = T) %>%
+    tab_stubhead("stub label on top of vs") %>%
+    opt_interactive()
+  # #1758 NA rows show correctly + stubhead shows on top of row
+  tbl_gt_i_27 <-
+    gt(exibble, rowname_col = "char") %>%
+    tab_stubhead("stub label on top of rowname") %>%
+    opt_interactive()
   capture_output(expect_no_error(tbl_gt_i_01))
   capture_output(expect_no_error(tbl_gt_i_02))
   capture_output(expect_no_error(tbl_gt_i_03))
@@ -106,4 +115,7 @@ test_that("Interactive tables won't fail when using different options", {
   capture_output(expect_no_error(tbl_gt_i_23))
   capture_output(expect_no_error(tbl_gt_i_24))
   capture_output(expect_no_error(tbl_gt_i_25))
+  capture_output(expect_no_error(tbl_gt_i_26))
+  capture_output(expect_no_error(tbl_gt_i_27))
+
 })

--- a/tests/testthat/test-substitution.R
+++ b/tests/testthat/test-substitution.R
@@ -26,7 +26,7 @@ test_that("sub_missing() works correctly", {
 
   # Expect an error when attempting to format a column
   # that does not exist
-  expect_error(tab %>% sub_missing(columns = "num_3"))
+  expect_error(sub_missing(tab, columns = "num_3"))
 
   expect_equal(
     (tab %>%


### PR DESCRIPTION
Follow-up to #1702, #1705. Fixes some rough edges for new feature introduced in #1711 and #1725

Intent is respecting `tab_stubhead()` in `opt_interactive()`, by adding `name` to groupname colDef() or rownames where appropriate.

I noticed that `sub_missing()` (and probably all `sub_*()` is ignored in `opt_interactive()`, but that will require more work another time!

For clarity, I also factored out the translations since the intermediate variables are not useful for the final output.

Before this PR, 
![image](https://github.com/rstudio/gt/assets/52606734/682bca92-b306-4eae-8430-cba07abb9105)

```r
exibble |> gt::gt(rowname_col = "num", groupname_col = "group") |> tab_stubhead("row name to show") |> opt_interactive()
```

With this PR, stubhead label shows and NAs are correctly marked as NA instead of `...6`
