### PR TITLE
Adding `all_of()` when selecting from vector of colnames

### DIFF
--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -4003,7 +4003,7 @@ cols_merge <- function(
       data <-
         cols_hide(
           data = data,
-          columns = hide_columns_from_supplied
+          columns = dplyr::all_of(hide_columns_from_supplied)
         )
     }
   }
@@ -4201,7 +4201,7 @@ cols_merge_uncert <- function(
     data <-
       cols_hide(
         data = data,
-        columns = col_uncert
+        columns = dplyr::all_of(col_uncert)
       )
   }
 
@@ -4412,7 +4412,7 @@ cols_merge_range <- function(
     data <-
       cols_hide(
         data = data,
-        columns = col_end
+        columns = dplyr::all_of(col_end)
       )
   }
 
@@ -4638,7 +4638,7 @@ cols_merge_n_pct <- function(
     data <-
       cols_hide(
         data = data,
-        columns = col_pct
+        columns = dplyr::all_of(col_pct)
       )
   }
 


### PR DESCRIPTION
# Summary

I noticed a couple of spots in the `cols_merge()` function (and friends), where a selecting character vector of column names was not wrapped in `all_of()`. This can cause errors depending on a users' {lifecycle} messaging setting, e.g when `options(lifecycle_verbosity = "error")`.

In this PR, I just add `all_of()` around those vectors. 🕺🏼 🍁  

# Related GitHub Issues and PRs

closes #1764

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md). 
    - This doesn't seem newsworthy? 
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality. 
    - I don't think there is a needed test for this.
