### PR TITLE
Fix empty `md("")` in Quarto

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt (development version)
 
+* Fixed an issue where `md("")` would fail in Quarto (@olivroy, #1769).
+
 # gt 0.11.0
 
 ## New features

--- a/R/quarto.R
+++ b/R/quarto.R
@@ -22,6 +22,6 @@
 #------------------------------------------------------------------------------#
 
 
-check_dbnb <- function() {
-  Sys.getenv("DATABRICKS_RUNTIME_VERSION") != ""
+check_quarto <- function() {
+  Sys.getenv("QUARTO_BIN_PATH") != ""
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -710,12 +710,12 @@ process_text <- function(text, context = "html") {
       # Markdown text handling for Quarto
       #
       if (in_quarto) {
-
-        non_na_text <- text[!is.na(text)]
+        # exclude "" and NA #1769
+        non_na_text <- text[nzchar(text, keepNA = FALSE)]
 
         non_na_text_processed <-
           vapply(
-            as.character(text[!is.na(text)]),
+            non_na_text,
             FUN.VALUE = character(1L),
             USE.NAMES = FALSE,
             FUN = function(text) {
@@ -732,6 +732,7 @@ process_text <- function(text, context = "html") {
             FUN.VALUE = character(1L),
             USE.NAMES = FALSE,
             FUN = function(text) {
+              # charToRaw("") returns character(0)
               base64enc::base64encode(charToRaw(as.character(text)))
             }
           )
@@ -745,7 +746,7 @@ process_text <- function(text, context = "html") {
             non_na_text_processed, "</div></div>"
           )
 
-        text[!is.na(text)] <- non_na_text
+        text[nzchar(text, keepNA = FALSE)] <- non_na_text
 
         return(text)
       }

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -994,6 +994,7 @@ render_grid_svg <- function(label, style, margin) {
   raster <- try_fetch(
     {
       svg_string %>%
+        # charToRaw("") return character(0)
         charToRaw() %>%
         rsvg::rsvg_nativeraster(width = w) %>%
         grid::rasterGrob(

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -50,6 +50,31 @@ expect_match_html <- function(object,
   }
 }
 
+
+# shortcut for expect_match(render_as_html(object), regexp)
+expect_no_match_html <- function(object,
+                              regexp,
+                              perl = FALSE,
+                              fixed = FALSE,
+                              ...,
+                              all = TRUE,
+                              info = NULL,
+                              label = NULL) {
+  rendered <- render_as_html(object)
+  for (i in seq_along(regexp)) {
+    testthat::expect_no_match(
+      object = rendered,
+      regexp = regexp[i],
+      perl = perl,
+      fixed = fixed,
+      ...,
+      all = all,
+      info = info,
+      label = label
+    )
+  }
+}
+
 expect_merge_locale_sep <- function(locale = NULL, global_locale = NULL, sep = NULL, expected_sep) {
   tbl <- data.frame(
     col_1 = 1,

--- a/tests/testthat/test-quarto.R
+++ b/tests/testthat/test-quarto.R
@@ -1,0 +1,17 @@
+skip_on_cran()
+test_that("Rendering in Quarto doesn't error with empty string (#1769)", {
+  local_mocked_bindings(check_quarto = function() TRUE)
+  tbl <-  mtcars_short %>%
+    dplyr::select(mpg, cyl) %>% gt()
+  # note that these don't produce the same output.
+  # render_as_html(tbl %>% cols_label(mpg = "")),
+  # render_as_html(tbl %>% cols_label(mpg = md("")))
+  expect_no_match_html(
+    tbl %>% cols_label(mpg = gt::md("")),
+    ">mpg</th>", fixed = TRUE
+    )
+  expect_match_html(
+    tbl %>% cols_label(mpg = gt::md("")),
+    ">cyl</th>", fixed = TRUE
+  )
+})


### PR DESCRIPTION
# Summary

Basically, the underlying problem was that `charToRaw("")` gives `character(0)`.

I therefore replaced the condition `!is.na(x)` by `nzchar(x, keepNA = FALSE)` (a more elegent `!is.na(x) & x != ""`)

I added a mocking mechanism to allow for testing in Quarto functions. I think it is worth adding to it.


For more on mocking, see https://www.tidyverse.org/blog/2023/10/testthat-3-2-0/#mocking.

I could have set a temp env var with `withr::local_envvar()`, but thought it read more clearly this way.

I tested my test and it indeed fails with current main!

# Related GitHub Issues and PRs

Fixes #1769, amends https://github.com/rstudio/gt/pull/1690

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
