### PR TITLE
Pct column widths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 * `tab_row_group()` gives a more precise error message when `rows` can't be resolved correctly (#1535). (@olivroy, #1770)
 
 * Fixed an issue where `md("")` would fail in Quarto. (@olivroy, #1769)
+
+* Fixed a bug in using `pct()` column widths with `as_gtable()` (@teunbrand, #1771)
  
 # gt 0.11.0
 

--- a/R/export.R
+++ b/R/export.R
@@ -1414,7 +1414,7 @@ grid_align_gtable <- function(gtable, data) {
 
   } else {
 
-    right <- grid::unit(grid::unit(parse_px_to_pt(left), "pt"))
+    right <- grid::unit(parse_px_to_pt(left), "pt")
   }
 
   gtable <- gtable::gtable_add_cols(gtable, left,  pos = 0)

--- a/R/export.R
+++ b/R/export.R
@@ -1438,13 +1438,20 @@ grid_layout_widths <- function(layout, data) {
 
   # Enlarge columns if fixed column widths have been set
   column_width <- unlist(dt_boxhead_get(data)$column_width)
-  fixed <- integer(0L)
+  fixed    <- integer(0)
+  relative <- rep(NA_real_, length(widths))
 
   if (any(nzchar(column_width)) && length(column_width) == length(widths)) {
-
-    fixed <- which(nzchar(column_width))
-    widths[fixed] <- pmax(parse_px_to_pt(column_width[fixed]), widths[fixed])
+    fixed <- which(endsWith(column_width, "px"))
+    if (length(fixed) > 0) {
+      widths[fixed] <- pmax(parse_px_to_pt(column_width[fixed]), widths[fixed])
+    }
+    pct <- which(endsWith(column_width, "%"))
+    if (length(pct) > 0) {
+      relative[pct] <- as.numeric(gsub("\\%$", "", column_width[pct])) / 100
+    }
   }
+  pct <- which(!is.na(relative))
 
   spanner <- spanner[order(spanner$key$left, spanner$key$right), ]
 
@@ -1475,8 +1482,11 @@ grid_layout_widths <- function(layout, data) {
 
     change <- setdiff(seq_along(widths), fixed)
     widths[change] <- widths[change] + extra_width / (length(widths[change]))
-
-    return(grid::unit(widths, .grid_unit))
+    widths <- grid::unit(widths, .grid_unit)
+    if (length(pct) > 0) {
+      widths[pct] <- grid::unit(relative[pct], "npc")
+    }
+    return(widths)
   }
 
   if (grepl("\\%$", total_width)) {
@@ -1494,10 +1504,15 @@ grid_layout_widths <- function(layout, data) {
 
     # Take pairwise max between minimal size and relative size
     widths <- grid::unit.pmax(grid::unit(widths, .grid_unit), extra_width)
+    if (length(pct) > 0) {
+      widths[pct] <- grid::unit(relative[pct], "npc")
+    }
     return(widths)
   }
-
-  grid::unit(widths, .grid_unit)
+  grid::unit(
+    ifelse(is.na(relative), widths, relative),
+    ifelse(is.na(relative), .grid_unit, "npc")
+  )
 }
 
 #' Extract the table body from a **gt** object

--- a/tests/testthat/test-render_as_gtable.R
+++ b/tests/testthat/test-render_as_gtable.R
@@ -138,4 +138,13 @@ test_that("gtable widths are set appropriately", {
     as.numeric(test$widths)[1] * 3,
     as.numeric(test$widths)[4]
   )
+
+  test <- tbl %>%
+    cols_width(x ~ pct(20), y ~ px(200)) %>%
+    as_gtable(tbl, text_grob = dummy_text)
+
+  expect_equal(
+    as.character(test$widths),
+    c("0.5null", "0.2npc", "150.5625points", "0.5null")
+  )
 })


### PR DESCRIPTION
# Summary

This PR aims to fix #1771.
Briefly, it works by accounting for `pct()`-widths in `grid_layout_widths()`.
The reprex from the issue now renders:

``` r
devtools::load_all("~/packages/gt/")
#> ℹ Loading gt

start_date <- "2010-06-07"
end_date <- "2010-06-08"

sp_tab <- 
  sp500 |>
  dplyr::filter(date >= start_date & date <= end_date) |>
  gt() |>
  cols_width(date ~ pct(50)) |>
  as_gtable(plot = TRUE)
```

![](https://i.imgur.com/5wtGBlQ.png)<!-- -->

<sup>Created on 2024-07-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


# Related GitHub Issues and PRs

- Ref: #1771

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
