### PR TITLE
docs: fix documentation of `rows` and `columns` arguments

### DIFF
--- a/R/fmt_number.R
+++ b/R/fmt_number.R
@@ -60,7 +60,7 @@
 #'
 #' @param rows *Rows to target*
 #'
-#'   [`<column-targeting expression>`][`rows-columns`] // *default:* `everything()`
+#'   [`<row-targeting expression>`][`rows-columns`] // *default:* `everything()`
 #'
 #'   In conjunction with `columns`, we can specify which of their rows should
 #'   undergo formatting. The default [everything()] results in all rows in

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1909,8 +1909,9 @@ cells_stub <- function(rows = everything()) {
 #'   results in all rows in `columns` being formatted. Alternatively, we can
 #'   supply a vector of row IDs within `c()`, a vector of row indices, or a
 #'   select helper function (e.g. [starts_with()], [ends_with()], [contains()],
-#'   [matches()], [num_range()], and [everything()]). We can also use expressions to
-#'   filter down to the rows we need (e.g., `[colname_1] > 100 & [colname_2] < 50`).
+#'   [matches()], [num_range()], and [everything()]). We can also use
+#'   expressions to filter down to the rows we need
+#'   (e.g., `[colname_1] > 100 & [colname_2] < 50`).
 #'
 #' @return A list object with the classes `cells_body` and `location_cells`.
 #'
@@ -2376,8 +2377,8 @@ cells_stub_summary <- function(
 #'   results in all rows in `columns` being formatted. Alternatively, we can
 #'   supply a vector of row IDs within `c()`, a vector of row indices, or a
 #'   select helper function (e.g. [starts_with()], [ends_with()], [contains()],
-#'   [matches()], [num_range()] and [everything()]). We can also use expressions
-#'   to filter down to the rows we need
+#'   [matches()], [num_range()], and [everything()]). We can also use
+#'   expressions to filter down to the rows we need
 #'   (e.g., `[colname_1] > 100 & [colname_2] < 50`).
 #'
 #' @return A list object with the classes `cells_stub_grand_summary` and

--- a/R/modify_columns.R
+++ b/R/modify_columns.R
@@ -4065,7 +4065,7 @@ cols_merge <- function(
 #'   all rows in `columns` being formatted. Alternatively, we can supply a
 #'   vector of row IDs within `c()`, a vector of row indices, or a select
 #'   helper function (e.g. [starts_with()], [ends_with()], [contains()],
-#'   [matches()],  [num_range()], and [everything()]). We can also use
+#'   [matches()], [num_range()], and [everything()]). We can also use
 #'   expressions to filter down to the rows we need
 #'   (e.g., `[colname_1] > 100 & [colname_2] < 50`).
 #'

--- a/R/substitution.R
+++ b/R/substitution.R
@@ -51,7 +51,7 @@
 #'   results in all rows in `columns` being formatted. Alternatively, we can
 #'   supply a vector of row IDs within `c()`, a vector of row indices, or a
 #'   select helper function (e.g. [starts_with()], [ends_with()], [contains()],
-#'   [matches()], [num_range()], and [everything()]. We can also use
+#'   [matches()], [num_range()], and [everything()]). We can also use
 #'   expressions to filter down to the rows we need
 #'   (e.g., `[colname_1] > 100 & [colname_2] < 50`).
 #'

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -244,7 +244,7 @@ tab_header <- function(
 #'   The columns to serve as components of the spanner. Can either be a series
 #'   of column names provided in `c()`, a vector of column indices, or a select
 #'   helper function (e.g. [starts_with()], [ends_with()], [contains()],
-#'   [matches()], [num_range()], and [everything()]. This argument works in
+#'   [matches()], [num_range()], and [everything()]). This argument works in
 #'   tandem with the `spanners` argument.
 #'
 #' @param spanners *Spanners to target*
@@ -1455,7 +1455,7 @@ str_split_across <- function(
 #'   The rows to be made components of the row group. We can supply a vector of
 #'   row ID values within `c()`, a vector of row indices, or use select helpers
 #'   (e.g. [starts_with()], [ends_with()], [contains()], [matches()],
-#'   [num_range()], and [everything()]. We can also use expressions to filter
+#'   [num_range()], and [everything()]). We can also use expressions to filter
 #'   down to the rows we need (e.g., `[colname_1] > 100 & [colname_2] < 50`).
 #'
 #' @param id *Row group ID*

--- a/R/tab_style_body.R
+++ b/R/tab_style_body.R
@@ -23,7 +23,7 @@
 #' `indent`)
 #' - the cell borders ([cell_borders()])
 #'
-#' @inheritParams fmt_number
+#' @inheritParams sub_missing
 #'
 #' @param style *Style declarations*
 #'
@@ -34,29 +34,6 @@
 #'   If using more than one helper function to define styles, all calls must be
 #'   enclosed in a [list()]. Custom CSS declarations can be used for HTML output
 #'   by including a [css()]-based statement as a list item.
-#'
-#' @param columns *Columns to target*
-#'
-#'   `<column-targeting expression>` // *default:* `everything()`
-#'
-#'   The columns to which the targeting operations are constrained.  Can either
-#'   be a series of column names provided in `c()`, a vector of column indices,
-#'   or a select helper function (e.g. [starts_with()], [ends_with()],
-#'   [contains()], [matches()], [num_range()], and [everything()]). This argument
-#'   works in tandem with the `spanners` argument.
-#'
-#' @param rows *Rows to target*
-#'
-#'   `<row-targeting expression>` // *default:* `everything()`
-#'
-#'   In conjunction with `columns`, we can specify which of their rows should
-#'   form a constraint for targeting operations. The default [everything()]
-#'   results in all rows in `columns` being formatted. Alternatively, we can
-#'   supply a vector of row IDs within `c()`, a vector of row indices, or a
-#'   select helper function (e.g. [starts_with()], [ends_with()], [contains()],
-#'   [matches()],  [num_range()], and [everything()]). We can also use
-#'   expressions to filter down to the rows we need
-#'   (e.g., `[colname_1] > 100 & [colname_2] < 50`).
 #'
 #' @param values *Values for targeting*
 #'

--- a/R/tab_style_body.R
+++ b/R/tab_style_body.R
@@ -80,42 +80,6 @@
 #'
 #' @return An object of class `gt_tbl`.
 #'
-#' @section Targeting cells with `columns` and `rows`:
-#'
-#' Targeting of values is done through `columns` and additionally by `rows` (if
-#' nothing is provided for `rows` then entire columns are selected). The
-#' `columns` argument allows us to constrain a subset of cells contained in the
-#' resolved columns. We say resolved because aside from declaring column names
-#' in `c()` (with bare column names or names in quotes) we can use
-#' **tidyselect**-style expressions. This can be as basic as supplying a select
-#' helper like `starts_with()`, or, providing a more complex incantation like
-#'
-#' `where(~ is.numeric(.x) & max(.x, na.rm = TRUE) > 1E6)`
-#'
-#' which targets numeric columns that have a maximum value greater than
-#' 1,000,000 (excluding any `NA`s from consideration).
-#'
-#' By default all columns and rows are selected (with the `everything()`
-#' defaults). Cell values that are incompatible with a given search will be
-#' skipped over. So it's safe to select all columns with a type of search (only
-#' those values that can be formatted will be formatted), but, you may not want
-#' that. One strategy is to format the bulk of cell values with one formatting
-#' function and then constrain the columns for later passes with other types of
-#' formatting (the last formatting done to a cell is what you get in the final
-#' output).
-#'
-#' Once the columns are targeted, we may also target the `rows` within those
-#' columns. This can be done in a variety of ways. If a stub is present, then we
-#' potentially have row identifiers. Those can be used much like column names in
-#' the `columns`-targeting scenario. We can use simpler **tidyselect**-style
-#' expressions (the select helpers should work well here) and we can use quoted
-#' row identifiers in `c()`. It's also possible to use row indices (e.g.,
-#' `c(3, 5, 6)`) though these index values must correspond to the row numbers of
-#' the input data (the indices won't necessarily match those of rearranged rows
-#' if row groups are present). One more type of expression is possible, an
-#' expression that takes column values (can involve any of the available columns
-#' in the table) and returns a logical vector.
-#'
 #' @section Examples:
 #'
 #' Use `exibble` to create a **gt** table with a stub and row groups. This

--- a/man/cells_body.Rd
+++ b/man/cells_body.Rd
@@ -25,8 +25,9 @@ form a constraint for targeting operations. The default \code{\link[=everything]
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use expressions to
-filter down to the rows we need (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
+expressions to filter down to the rows we need
+(e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 }
 \value{
 A list object with the classes \code{cells_body} and \code{location_cells}.

--- a/man/cells_grand_summary.Rd
+++ b/man/cells_grand_summary.Rd
@@ -25,8 +25,9 @@ form a constraint for targeting operations. The default \code{\link[=everything]
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use expressions to
-filter down to the rows we need (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
+expressions to filter down to the rows we need
+(e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 }
 \value{
 A list object with the classes \code{cells_grand_summary} and

--- a/man/cells_stub_grand_summary.Rd
+++ b/man/cells_stub_grand_summary.Rd
@@ -15,8 +15,8 @@ We can specify which rows should be targeted. The default \code{\link[=everythin
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}} and \code{\link[=everything]{everything()}}). We can also use expressions
-to filter down to the rows we need
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
+expressions to filter down to the rows we need
 (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 }
 \value{

--- a/man/cells_summary.Rd
+++ b/man/cells_summary.Rd
@@ -39,8 +39,9 @@ form a constraint for targeting operations. The default \code{\link[=everything]
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use expressions to
-filter down to the rows we need (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
+expressions to filter down to the rows we need
+(e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 }
 \value{
 A list object with the classes \code{cells_summary} and \code{location_cells}.

--- a/man/cols_merge_uncert.Rd
+++ b/man/cols_merge_uncert.Rd
@@ -52,7 +52,7 @@ participate in the merging process. The default \code{\link[=everything]{everyth
 all rows in \code{columns} being formatted. Alternatively, we can supply a
 vector of row IDs within \code{c()}, a vector of row indices, or a select
 helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}},  \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
 expressions to filter down to the rows we need
 (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 

--- a/man/fmt.Rd
+++ b/man/fmt.Rd
@@ -24,7 +24,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_auto.Rd
+++ b/man/fmt_auto.Rd
@@ -31,7 +31,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_bins.Rd
+++ b/man/fmt_bins.Rd
@@ -30,7 +30,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_bytes.Rd
+++ b/man/fmt_bytes.Rd
@@ -40,7 +40,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_chem.Rd
+++ b/man/fmt_chem.Rd
@@ -24,7 +24,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_country.Rd
+++ b/man/fmt_country.Rd
@@ -31,7 +31,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_currency.Rd
+++ b/man/fmt_currency.Rd
@@ -44,7 +44,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_date.Rd
+++ b/man/fmt_date.Rd
@@ -31,7 +31,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_datetime.Rd
+++ b/man/fmt_datetime.Rd
@@ -35,7 +35,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_duration.Rd
+++ b/man/fmt_duration.Rd
@@ -39,7 +39,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_email.Rd
+++ b/man/fmt_email.Rd
@@ -36,7 +36,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -39,7 +39,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_flag.Rd
+++ b/man/fmt_flag.Rd
@@ -32,7 +32,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_fraction.Rd
+++ b/man/fmt_fraction.Rd
@@ -36,7 +36,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_icon.Rd
+++ b/man/fmt_icon.Rd
@@ -39,7 +39,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_image.Rd
+++ b/man/fmt_image.Rd
@@ -34,7 +34,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_index.Rd
+++ b/man/fmt_index.Rd
@@ -32,7 +32,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_integer.Rd
+++ b/man/fmt_integer.Rd
@@ -37,7 +37,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_markdown.Rd
+++ b/man/fmt_markdown.Rd
@@ -29,7 +29,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_missing.Rd
+++ b/man/fmt_missing.Rd
@@ -29,7 +29,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -42,7 +42,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_partsper.Rd
+++ b/man/fmt_partsper.Rd
@@ -42,7 +42,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_passthrough.Rd
+++ b/man/fmt_passthrough.Rd
@@ -30,7 +30,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_percent.Rd
+++ b/man/fmt_percent.Rd
@@ -42,7 +42,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_roman.Rd
+++ b/man/fmt_roman.Rd
@@ -30,7 +30,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -40,7 +40,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_spelled_num.Rd
+++ b/man/fmt_spelled_num.Rd
@@ -30,7 +30,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_tf.Rd
+++ b/man/fmt_tf.Rd
@@ -36,7 +36,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_time.Rd
+++ b/man/fmt_time.Rd
@@ -31,7 +31,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_units.Rd
+++ b/man/fmt_units.Rd
@@ -24,7 +24,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/fmt_url.Rd
+++ b/man/fmt_url.Rd
@@ -39,7 +39,7 @@ column indices, or a select helper function (e.g. \code{\link[=starts_with]{star
 
 \item{rows}{\emph{Rows to target}
 
-\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 undergo formatting. The default \code{\link[=everything]{everything()}} results in all rows in

--- a/man/sub_large_vals.Rd
+++ b/man/sub_large_vals.Rd
@@ -39,7 +39,7 @@ form a constraint for targeting operations. The default \code{\link[=everything]
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}. We can also use
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
 expressions to filter down to the rows we need
 (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 

--- a/man/sub_missing.Rd
+++ b/man/sub_missing.Rd
@@ -37,7 +37,7 @@ form a constraint for targeting operations. The default \code{\link[=everything]
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}. We can also use
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
 expressions to filter down to the rows we need
 (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 

--- a/man/sub_small_vals.Rd
+++ b/man/sub_small_vals.Rd
@@ -39,7 +39,7 @@ form a constraint for targeting operations. The default \code{\link[=everything]
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}. We can also use
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
 expressions to filter down to the rows we need
 (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 

--- a/man/sub_values.Rd
+++ b/man/sub_values.Rd
@@ -41,7 +41,7 @@ form a constraint for targeting operations. The default \code{\link[=everything]
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}. We can also use
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
 expressions to filter down to the rows we need
 (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 

--- a/man/sub_zero.Rd
+++ b/man/sub_zero.Rd
@@ -32,7 +32,7 @@ form a constraint for targeting operations. The default \code{\link[=everything]
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}. We can also use
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
 expressions to filter down to the rows we need
 (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 

--- a/man/tab_row_group.Rd
+++ b/man/tab_row_group.Rd
@@ -28,7 +28,7 @@ The text to use for the row group label. We can optionally use \code{\link[=md]{
 The rows to be made components of the row group. We can supply a vector of
 row ID values within \code{c()}, a vector of row indices, or use select helpers
 (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}}, \code{\link[=matches]{matches()}},
-\code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}. We can also use expressions to filter
+\code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use expressions to filter
 down to the rows we need (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 
 \item{id}{\emph{Row group ID}

--- a/man/tab_spanner.Rd
+++ b/man/tab_spanner.Rd
@@ -38,7 +38,7 @@ in the text.}
 The columns to serve as components of the spanner. Can either be a series
 of column names provided in \code{c()}, a vector of column indices, or a select
 helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}. This argument works in
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). This argument works in
 tandem with the \code{spanners} argument.}
 
 \item{spanners}{\emph{Spanners to target}

--- a/man/tab_style_body.Rd
+++ b/man/tab_style_body.Rd
@@ -36,24 +36,23 @@ by including a \code{\link[=css]{css()}}-based statement as a list item.}
 
 \item{columns}{\emph{Columns to target}
 
-\verb{<column-targeting expression>} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<column-targeting expression>}} // \emph{default:} \code{everything()}
 
-The columns to which the targeting operations are constrained.  Can either
+The columns to which substitution operations are constrained. Can either
 be a series of column names provided in \code{c()}, a vector of column indices,
 or a select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}},
-\code{\link[=contains]{contains()}}, \code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). This argument
-works in tandem with the \code{spanners} argument.}
+\code{\link[=contains]{contains()}}, \code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}).}
 
 \item{rows}{\emph{Rows to target}
 
-\verb{<row-targeting expression>} // \emph{default:} \code{everything()}
+\code{\link[=rows-columns]{<row-targeting expression>}} // \emph{default:} \code{everything()}
 
 In conjunction with \code{columns}, we can specify which of their rows should
 form a constraint for targeting operations. The default \code{\link[=everything]{everything()}}
 results in all rows in \code{columns} being formatted. Alternatively, we can
 supply a vector of row IDs within \code{c()}, a vector of row indices, or a
 select helper function (e.g. \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}},
-\code{\link[=matches]{matches()}},  \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
+\code{\link[=matches]{matches()}}, \code{\link[=num_range]{num_range()}}, and \code{\link[=everything]{everything()}}). We can also use
 expressions to filter down to the rows we need
 (e.g., \verb{[colname_1] > 100 & [colname_2] < 50}).}
 

--- a/man/tab_style_body.Rd
+++ b/man/tab_style_body.Rd
@@ -125,44 +125,6 @@ bold text (the degree of choice is greater with variable fonts)
 \item the cell borders (\code{\link[=cell_borders]{cell_borders()}})
 }
 }
-\section{Targeting cells with \code{columns} and \code{rows}}{
-
-
-Targeting of values is done through \code{columns} and additionally by \code{rows} (if
-nothing is provided for \code{rows} then entire columns are selected). The
-\code{columns} argument allows us to constrain a subset of cells contained in the
-resolved columns. We say resolved because aside from declaring column names
-in \code{c()} (with bare column names or names in quotes) we can use
-\strong{tidyselect}-style expressions. This can be as basic as supplying a select
-helper like \code{starts_with()}, or, providing a more complex incantation like
-
-\code{where(~ is.numeric(.x) & max(.x, na.rm = TRUE) > 1E6)}
-
-which targets numeric columns that have a maximum value greater than
-1,000,000 (excluding any \code{NA}s from consideration).
-
-By default all columns and rows are selected (with the \code{everything()}
-defaults). Cell values that are incompatible with a given search will be
-skipped over. So it's safe to select all columns with a type of search (only
-those values that can be formatted will be formatted), but, you may not want
-that. One strategy is to format the bulk of cell values with one formatting
-function and then constrain the columns for later passes with other types of
-formatting (the last formatting done to a cell is what you get in the final
-output).
-
-Once the columns are targeted, we may also target the \code{rows} within those
-columns. This can be done in a variety of ways. If a stub is present, then we
-potentially have row identifiers. Those can be used much like column names in
-the \code{columns}-targeting scenario. We can use simpler \strong{tidyselect}-style
-expressions (the select helpers should work well here) and we can use quoted
-row identifiers in \code{c()}. It's also possible to use row indices (e.g.,
-\code{c(3, 5, 6)}) though these index values must correspond to the row numbers of
-the input data (the indices won't necessarily match those of rearranged rows
-if row groups are present). One more type of expression is possible, an
-expression that takes column values (can involve any of the available columns
-in the table) and returns a logical vector.
-}
-
 \section{Examples}{
 
 


### PR DESCRIPTION
# Summary

fixes a small typo introduced in #1784. I noticed some tiny mistakes also that I corrected here. #1676 

Inheriting `tab_style_body()` docs from `sub_missing()` fixes a small copy-paste error (4a229f3)
