### PR TITLE
Setup standard pkgdown workflow + install Quarto

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,38 +1,56 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: master
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: pkgdown
+
+permissions: read-all
 
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:
-       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
-      GITHUB_PAT: ${{ secrets.GHA_PAT }}
-
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-
-      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Install package
-        run: R CMD INSTALL .
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
 
-      - name: Build and deploy pkgdown site
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/vignettes/case-study-gtcars.Rmd
+++ b/vignettes/case-study-gtcars.Rmd
@@ -18,7 +18,7 @@ library(dplyr)
 library(tibble)
 ```
 
-<p align="center"><img src="../reference/figures/gtcars.svg" width=50%></p>
+<p align="center"><img src="man/figures/gtcars.svg" width=50%></p>
 
 Let's make a display table using the `gtcars` dataset. We all know `mtcars`... what is `gtcars`? It's basically a modernized `mtcars` for the **gt** age. It's part of the **gt** package, and here is a preview of the tibble using `dplyr::glimpse()`:
 
@@ -341,7 +341,7 @@ best_gas_mileage_city <-
   pull(car)
 
 # Use dplyr functions to get the car with the highest horsepower
-# this will be used to target the correct cell for a footnote
+# this will be used to target the correct celgl for a footnote
 highest_horsepower <- 
   gtcars |> 
   arrange(desc(hp)) |>

--- a/vignettes/case-study-gtcars.Rmd
+++ b/vignettes/case-study-gtcars.Rmd
@@ -341,7 +341,7 @@ best_gas_mileage_city <-
   pull(car)
 
 # Use dplyr functions to get the car with the highest horsepower
-# this will be used to target the correct celgl for a footnote
+# this will be used to target the correct cell for a footnote
 highest_horsepower <- 
   gtcars |> 
   arrange(desc(hp)) |>

--- a/vignettes/case-study-gtcars.Rmd
+++ b/vignettes/case-study-gtcars.Rmd
@@ -18,7 +18,7 @@ library(dplyr)
 library(tibble)
 ```
 
-<p align="center"><img src="man/figures/gtcars.svg" width=50%></p>
+<p align="center"><img src="../man/figures/gtcars.svg" width=50%></p>
 
 Let's make a display table using the `gtcars` dataset. We all know `mtcars`... what is `gtcars`? It's basically a modernized `mtcars` for the **gt** age. It's part of the **gt** package, and here is a preview of the tibble using `dplyr::glimpse()`:
 

--- a/vignettes/gt-datasets.Rmd
+++ b/vignettes/gt-datasets.Rmd
@@ -20,9 +20,9 @@ library(tidyr)
 
 The **gt** package comes with six built-in datasets for experimenting with the **gt** API: `countrypops`, `sza`, `gtcars`, `sp500`, `pizzaplace`, and `exibble`. While each dataset has different subject matter, all of them will be used to develop **gt** examples with consistent syntax.
 
-<img src="man/figures/countrypops.png" width=30%><img src="man/figures/sza.svg" width=30%><img src="man/figures/gtcars.svg" width=30%>
+<img src="../man/figures/countrypops.png" width=30%><img src="../man/figures/sza.svg" width=30%><img src="../man/figures/gtcars.svg" width=30%>
 
-<img src="man/figures/sp500.svg" width=30%><img src="man/figures/pizzaplace.svg" width=30%><img src="man/figures/exibble.svg" width=30%>
+<img src="../man/figures/sp500.svg" width=30%><img src="../man/figures/pizzaplace.svg" width=30%><img src="../man/figures/exibble.svg" width=30%>
 
 Each dataset is stored as a tibble, ranging from very small (like `exibble`, an example tibble of 8 rows) to quite large in size (e.g., at nearly 50,000 rows: `pizzaplace`). Larger datasets are typically impractical as **gt output tables** but they provide opportunities for demonstrating preprocessing using tidyverse tools like **dplyr** and **tidyr** (upstream of **gt**'s `gt()` entry point). 
 

--- a/vignettes/gt-datasets.Rmd
+++ b/vignettes/gt-datasets.Rmd
@@ -20,9 +20,9 @@ library(tidyr)
 
 The **gt** package comes with six built-in datasets for experimenting with the **gt** API: `countrypops`, `sza`, `gtcars`, `sp500`, `pizzaplace`, and `exibble`. While each dataset has different subject matter, all of them will be used to develop **gt** examples with consistent syntax.
 
-<img src="../reference/figures/countrypops.png" width=30%><img src="../reference/figures/sza.svg" width=30%><img src="../reference/figures/gtcars.svg" width=30%>
+<img src="man/figures/countrypops.png" width=30%><img src="man/figures/sza.svg" width=30%><img src="man/figures/gtcars.svg" width=30%>
 
-<img src="../reference/figures/sp500.svg" width=30%><img src="../reference/figures/pizzaplace.svg" width=30%><img src="../reference/figures/exibble.svg" width=30%>
+<img src="man/figures/sp500.svg" width=30%><img src="man/figures/pizzaplace.svg" width=30%><img src="man/figures/exibble.svg" width=30%>
 
 Each dataset is stored as a tibble, ranging from very small (like `exibble`, an example tibble of 8 rows) to quite large in size (e.g., at nearly 50,000 rows: `pizzaplace`). Larger datasets are typically impractical as **gt output tables** but they provide opportunities for demonstrating preprocessing using tidyverse tools like **dplyr** and **tidyr** (upstream of **gt**'s `gt()` entry point). 
 

--- a/vignettes/gt.Rmd
+++ b/vignettes/gt.Rmd
@@ -21,7 +21,7 @@ library(dplyr)
 
 The **gt** package is all about making it simple to produce nice-looking display tables. Display tables? Well yes, we are trying to distinguish between data tables (e.g., tibbles, `data.frame`s, etc.) and those tables you'd find in a web page, a journal article, or in a magazine. Such tables can likewise be called presentation tables, summary tables, or just tables really. Here are some examples, ripped straight from the web:
 
-<img src="man/figures/tables_from_the_web.png" width=100%>
+<img src="../man/figures/tables_from_the_web.png" width=100%>
 
 We can think of display tables as output only, where we'd not want to use them as input ever again. Other features include annotations, table element styling, and text transformations that serve to communicate the subject matter more clearly.
 
@@ -66,7 +66,7 @@ The **gt** package makes it relatively easy to add parts so that the resulting *
 
 This is the way the main parts of a table (and their subparts) fit together:
 
-<p align="center"><img src="man/figures/gt_parts_of_a_table.svg" width=100%></p>
+<p align="center"><img src="../man/figures/gt_parts_of_a_table.svg" width=100%></p>
 
 The parts (roughly from top to bottom) are:
 

--- a/vignettes/gt.Rmd
+++ b/vignettes/gt.Rmd
@@ -21,7 +21,7 @@ library(dplyr)
 
 The **gt** package is all about making it simple to produce nice-looking display tables. Display tables? Well yes, we are trying to distinguish between data tables (e.g., tibbles, `data.frame`s, etc.) and those tables you'd find in a web page, a journal article, or in a magazine. Such tables can likewise be called presentation tables, summary tables, or just tables really. Here are some examples, ripped straight from the web:
 
-<img src="../reference/figures/tables_from_the_web.png" width=100%>
+<img src="man/figures/tables_from_the_web.png" width=100%>
 
 We can think of display tables as output only, where we'd not want to use them as input ever again. Other features include annotations, table element styling, and text transformations that serve to communicate the subject matter more clearly.
 
@@ -66,7 +66,7 @@ The **gt** package makes it relatively easy to add parts so that the resulting *
 
 This is the way the main parts of a table (and their subparts) fit together:
 
-<p align="center"><img src="../reference/figures/gt_parts_of_a_table.svg" width=100%></p>
+<p align="center"><img src="man/figures/gt_parts_of_a_table.svg" width=100%></p>
 
 The parts (roughly from top to bottom) are:
 


### PR DESCRIPTION
This sets the ground to adding a Quarto vignette to the site, since pkgdown supports this since 2.1 (which I am working on!)

But I thought it would be useful to run the pkgdown workflow on PRs.
