### PR TITLE
Add light-switch option for pkgdown site

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -7,6 +7,7 @@ home:
 
 template:
   bootstrap: 5
+  light-switch: true
   assets: pkgdown/assets
 
 authors:


### PR DESCRIPTION
This simply adds the light-switch option (for switching between light and dark mode) for the pkgdown website.