### PR TITLE
Fix grid output with unique groups in `groupname_col` and  `row_group_as_column = TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,10 @@
 
 * Fixed a bug in using `pct()` column widths with `as_gtable()` (@teunbrand, #1771)
 
+* Fixed a bug where `gt(row_group_as_column = TRUE)` would create the wrong layout with `as_gtable()` when all groups are unique (@olivroy, #1803).
+
+* grid output has been improved. Namely, showing currency symbols now works (@olivroy, #1788). 
+
 * `data_color()` no longer errors when a tidyselect selection is empty (like `fmt_*()` functions) (@olivroy, #1665).
 
 # gt 0.11.0

--- a/R/utils_render_grid.R
+++ b/R/utils_render_grid.R
@@ -542,7 +542,7 @@ body_cells_g <- function(data) {
   )
 
   if (has_two_col_stub) {
-    # Set stub row group
+    # Set stub row group(s)
     group_cell <- which(cell_rows %in% groups$row_start & cell_cols == 1)
     group <- match(cell_rows[group_cell], groups$row_start)
     extra_rows <- (groups$row_end - groups$row_start + 1)[group]
@@ -562,8 +562,13 @@ body_cells_g <- function(data) {
 
     # Delete empty cells
     delete <- which(!(cell_rows %in% groups$row_start) & cell_cols == 1)
-    layout <- vctrs::vec_slice(layout, -delete)
-    cell_rows <- vctrs::vec_slice(cell_rows, -delete)
+
+    if (rlang::has_length(delete)) {
+      # don't attempt delete doesn't have length
+      # will likely occur in the case of all groups of length 1 #1803
+      layout <- vctrs::vec_slice(layout, -delete)
+      cell_rows <- vctrs::vec_slice(cell_rows, -delete)
+    }
   }
 
   # Split by row

--- a/tests/testthat/test-as_gtable.R
+++ b/tests/testthat/test-as_gtable.R
@@ -177,3 +177,21 @@ test_that("gtable outputs works well for currencies", {
     as_gtable(tbl)
   )
 })
+
+test_that("gtable output works when row groups are unique (#1802).", {
+  # using groupname_col = "row" to ensure uniqueness
+  tbl <- exibble %>%
+    gt(groupname_col = "row")
+  expect_no_error(test <- as_gtable(tbl))
+  expect_equal(
+    test$layout$name[8],
+    "column_label_8"
+  )
+  tbl <- exibble %>%
+    gt(groupname_col = "row", row_group_as_column = TRUE)
+  expect_no_error(test <- as_gtable(tbl))
+  expect_equal(
+    test$layout$name[8],
+    "column_label_8"
+  )
+})


### PR DESCRIPTION
Split of.

Basically, just due to the fact that like base subsetting,

```r
vctrs::vec_slice(c(1, 2), -integer(0))
#> numeric(0)
c(1, 2)[-integer(0)]
#> numeric(0)
```

which ends up creating an empty layout in this particular case. I have been bitten by this before ;) 

```r
# bug before this PR
df <- data.frame(x = 1:3, y = 4:6, row = c("A", "B", "C"))
gt(df, groupname_col = "row", row_group_as_column = T) |> plot()
#> Error in body[vertical] + n : 
 #> Non-numeric argument
```

This PR:  
![image](https://github.com/user-attachments/assets/a217a99b-f8ee-4594-b433-a576b48cc71f)


Split from #1801 as I am still trying to understand what is going on. What currently works, and what doesn't. I'd like to narrow down the issues and I thought this was a straightforward bug fix!

