### PR TITLE
Update visual-tests-latex.R to show Quarto version

### DIFF
--- a/scripts/visual-tests-latex.R
+++ b/scripts/visual-tests-latex.R
@@ -156,8 +156,9 @@ c(
   "## --------",
   # Comment / uncomment here to compare between released version and current.
   # "library(gt)",
-  "devtools::load_all(\".\")",
+  "pkgload::load_all(\".\")",
   "packageVersion('gt')",
+  "quarto::quarto_version()",
   "",
   "#'",
   "#' {{< pagebreak >}}",


### PR DESCRIPTION
Seems like the visual tests are off to a great start! https://github.com/rstudio/gt/pull/1804#issuecomment-2236314015. Let's add the Quarto version there as an extra layer of safety / reproducibility. 

