### PR TITLE
Avoid a duplicate id error in `tab_spanner_delim()`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,8 @@
 
 * Performance improvement for footnote rendering (@olivroy, #1818).
 
+* Fixed an issue where `tab_spanner_delim()` would fail to resolve a duplicate id (@olivroy, #1821).
+
 # gt 0.11.0
 
 ## New features

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1238,7 +1238,8 @@ tab_spanner_delim <- function(
     spanners_i_values <- rle_spanners_i$values
     spanners_i_col_i <- utils::head(cumsum(c(1, spanners_i_lengths)), -1)
 
-    spanner_id_vals <- c()
+    # Initialize spanner ids to existing spanners in the data
+    spanner_id_vals <- dt_spanners_get_ids(data)
 
     for (j in seq_along(spanners_i_lengths)) {
 
@@ -1289,9 +1290,7 @@ tab_spanner_delim <- function(
 
         # Set the spanner with a call to `tab_spanner()`
         existing_spanner_ids <- dt_spanners_get_ids(data = data)
-        if (spanner_id %in% existing_spanner_ids) {
-          spanner_id <- random_id(n =5)
-        }
+
         data <-
           tab_spanner(
             data = data,

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1289,8 +1289,6 @@ tab_spanner_delim <- function(
           )
 
         # Set the spanner with a call to `tab_spanner()`
-        existing_spanner_ids <- dt_spanners_get_ids(data = data)
-
         data <-
           tab_spanner(
             data = data,

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1288,6 +1288,10 @@ tab_spanner_delim <- function(
           )
 
         # Set the spanner with a call to `tab_spanner()`
+        existing_spanner_ids <- dt_spanners_get_ids(data = data)
+        if (spanner_id %in% existing_spanner_ids) {
+          spanner_id <- random_id(n =5)
+        }
         data <-
           tab_spanner(
             data = data,

--- a/tests/testthat/test-tab_spanner_delim.R
+++ b/tests/testthat/test-tab_spanner_delim.R
@@ -1446,4 +1446,11 @@ test_that("tab_spanner_delim() resolves duplicate spanner IDs (#1821)", {
     nrow(dat$`_spanners`),
     6
   )
+  expect_equal(
+    dat$`_spanners`$spanner_id,
+    c(
+      "spanner-young_num", "spanner-old_num", "spanner-pop_rural_young_num",
+      "spanner:1-young_num", "spanner:1-old_num", "spanner-pop_urban_young_num"
+   )
+  )
 })

--- a/tests/testthat/test-tab_spanner_delim.R
+++ b/tests/testthat/test-tab_spanner_delim.R
@@ -1418,3 +1418,32 @@ test_that("tab_spanner_delim() won't overwrite any set column labels", {
     gt_tbl_last_2 %>% render_as_html()
   )
 })
+
+test_that("tab_spanner_delim() resolves duplicate spanner IDs (#1821)", {
+  df <- data.frame(
+    pop_rural_young_num = c(1000, 2000),
+    pop_rural_young_pct = c(0.33, 0.66),
+    pop_rural_old_num = c(1000, 2000),
+    pop_rural_old_pct = c(0.33, 0.66),
+    pop_urban_young_num = c(1000, 2000),
+    pop_urban_young_pct = c(0.33, 0.66),
+    pop_urban_old_num = c(1000, 2000),
+    pop_urban_old_pct = c(0.33, 0.66)
+  )
+
+  expect_no_error(dat <- gt::gt(df) %>%
+    tab_spanner_delim(
+      delim = "_",
+      contains("rural"),
+      limit = 2
+    ) %>%
+    tab_spanner_delim(
+      delim = "_",
+      contains("urban"),
+      limit = 2
+    ))
+  expect_equal(
+    nrow(dat$`_spanners`),
+    6
+  )
+})


### PR DESCRIPTION
# Summary

Avoid spanner ids collision by initializing the existing spanner ids first and then try to resolve the new spanner id

I get the result I expected with the following code

```r
  df <- data.frame(
    pop_rural_young_num = c(1000, 2000),
    pop_rural_young_pct = c(0.33, 0.66),
    pop_rural_old_num = c(1000, 2000),
    pop_rural_old_pct = c(0.33, 0.66),
    pop_urban_young_num = c(1000, 2000),
    pop_urban_young_pct = c(0.33, 0.66),
    pop_urban_old_num = c(1000, 2000),
    pop_urban_old_pct = c(0.33, 0.66)
  )

 gt::gt(df) %>%
    tab_spanner_delim(
      delim = "_",
      contains("rural"),
      limit = 2
    ) %>%
    tab_spanner_delim(
      delim = "_",
      contains("urban"),
      limit = 2
    )
```

![image](https://github.com/user-attachments/assets/e0ec2a27-e0c6-48ac-ad24-05ee9e08dbe8)

Previously, I would get this:

```
Error in `tab_spanner()`:
! The spanner `id` provided ("spanner-young_num") is
  not unique.
• The `id` must be unique across existing spanner and column
  IDs.
• Provide a unique ID value for this spanner.
```

Note that my code worked if I had only one of the `tab_spanner_delim()` calls.

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
