### PR TITLE
`text_case_match()` now works with `tab_spanner()` + `.replace = "all"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@
 
 * Improve the centering of the stubhead label in Latex when  `row_group_as_column = TRUE` and the width of the row name column is specified (@kbrevoort, #1804).
 
+* Fixed an issue with `text_case_match(.replace = "all", .locations = cells_column_spanners())` (@olivroy, #1823).
+
 * Performance improvement for footnote rendering (@olivroy, #1818).
 
 # gt 0.11.0

--- a/R/text_transform.R
+++ b/R/text_transform.R
@@ -411,7 +411,7 @@ text_case_match <- function(
 
       if (.replace == "all") {
 
-        x <- dplyr::case_match(.x = x, !!!x_list, .default = .default)
+        x <- dplyr::case_match(.x = unlist(x), !!!x_list, .default = unlist(.default))
 
       } else {
 

--- a/tests/testthat/test-text_transform.R
+++ b/tests/testthat/test-text_transform.R
@@ -338,6 +338,16 @@ test_that("text_case_match() works on the tab_spanner()", {
      new_tb,
      "awesome spanner"
   )
+  expect_no_error(new_tb2 <- gt_tbl %>%
+    text_case_match(
+      "the boring spanner" ~ "awesome spanner2",
+      .replace = "all",
+      .locations = cells_column_spanners()
+  ))
+  expect_match_html(
+    new_tb2,
+    "awesome spanner"
+  )
 })
 
 test_that("text_transform() works on row group labels", {


### PR DESCRIPTION
# Summary

Before the PR, we would get 

```r
exibble %>% gt() %>% tab_spanner("the boring spanner", columns = c(num, date)) %>%
    text_case_match(
      "the boring spanner" ~ "awesome spanner",
      .replace = "all",
      .locations = cells_column_spanners()
    )
#> Error in `dplyr::case_match()` at gt/R/text_transform.R:414:9:
#> ! Can't combine `..1 (right)` <character> and `.default` <list>.
```

Now, it works as expected!

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
