### PR TITLE
Correctly output `vec_fmt_markdown()` inside Quarto

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,10 +47,11 @@
 
 * Fixed an issue where `tab_spanner_delim()` would fail to resolve a duplicate id (@olivroy, #1821).
 
-
 * Fixed an issue with multiple `text_replace()` calls would produce bad result with `cells_column_labels()` (@olivroy, #1824).
 
 * `tidyselect::where()`, `tidyselect::all_of()`, `tidyselect::any_of()` are now re-exported by gt.
+
+* `vec_fmt_markdown()` works correctly inside Quarto again (@olivroy, #1840).
 
 # gt 0.11.0
 

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -3316,7 +3316,11 @@ vec_fmt_markdown <- function(
   if (output == "auto") {
     output <- determine_output_format()
   }
-
+  # Avoid modifying the output to base64enc in Quarto
+  if (check_quarto() && output == "html") {
+    rlang::check_installed("withr", "to use vec_fmt_markdown() in Quarto.")
+    withr::local_envvar(c("QUARTO_BIN_PATH" = ""))
+  }
   vec_fmt_out <-
     render_as_vector(
       fmt_markdown(
@@ -3364,7 +3368,7 @@ check_columns_valid_if_strict <- function(
     extra_msg = NULL,
     call = rlang::caller_env()
 ) {
-  
+
   # Don't check if strict mode is not enabled
   # strict mode is opt-in, not the default
   if (!isTRUE(getOption("gt.strict_column_fmt", FALSE))) {

--- a/tests/testthat/test-quarto.R
+++ b/tests/testthat/test-quarto.R
@@ -1,6 +1,6 @@
 skip_on_cran()
 test_that("Rendering in Quarto doesn't error with empty string (#1769)", {
-  local_mocked_bindings(check_quarto = function() TRUE)
+  withr::local_envvar(c("QUARTO_BIN_PATH" = "path"))
   tbl <-  mtcars_short %>%
     dplyr::select(mpg, cyl) %>% gt()
   # note that these don't produce the same output.
@@ -13,5 +13,9 @@ test_that("Rendering in Quarto doesn't error with empty string (#1769)", {
   expect_match_html(
     tbl %>% cols_label(mpg = gt::md("")),
     ">cyl</th>", fixed = TRUE
+  )
+  expect_equal(
+    vec_fmt_markdown("**x**", output = "html"),
+    "<strong>x</strong></span>"
   )
 })


### PR DESCRIPTION
Fix #1840 

Basically, the idea is that since `vec_fmt_markdown()` calls `fmt_markdown()` (and not the other way around, we can use some code to trick `vec_fmt_markdown()` to think it is not inside Quarto.

I tried using `on.exit(Sys.unsetenv("QUARTO_BIN_PATH")` but it didn't work for some reason. Would love to not use withr here.

I know tidyselect imports it, so gt has an indirect dep on it, but since withr 3.0 has simplified its code, it is possible they remove that dep at some point.