### PR TITLE
Support factors in `fmt_markdown()` with HTML output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,8 @@
 
 * Improved footnote rendering in Quarto with `fmt_markdown()` (@olivroy, #1773)
 
+* Fixed an issue where `md()` and `fmt_markdown()` would render factors as their numeric levels rather than their text labels (@rossellhayes, #1883).
+
 # gt 0.11.0
 
 ## New features

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -70,7 +70,8 @@
 #'
 #' @export
 md <- function(text) {
-
+  # Ensure input is text (e.g. for factors)
+  text <- as.character(text)
   # Apply the `from_markdown` class
   class(text) <- "from_markdown"
   text

--- a/tests/testthat/test-fmt_markdown.R
+++ b/tests/testthat/test-fmt_markdown.R
@@ -235,3 +235,23 @@ test_that("LaTeX formulas render correctly in HTML", {
   # Take a snapshot of `gt_tbl`
   expect_snapshot_html(gt_tbl)
 })
+
+test_that("fmt_markdown() works correctly with factors", {
+
+  text <- "This is Markdown *text*."
+
+  # Create a `gt_tbl` object with `gt()`
+  # and a tibble; format all columns with
+  # `fmt_markdown()`
+  tab <-
+    dplyr::tibble(column_1 = factor(text)) %>%
+    gt() %>%
+    fmt_markdown(columns = everything())
+
+  # Compare output of cell to the expected HTML output strings
+  expect_equal(
+    (tab %>%
+       render_formats_test(context = "html"))[["column_1"]][[1]],
+    "<span class='gt_from_md'>This is Markdown <em>text</em>.</span>"
+  )
+})


### PR DESCRIPTION
# Summary

This PR closes #1882 by ensuring factors are converted to text before converting to markdown when `fmt_markdown()` is used with HTML output. It achieves this by adding `text <- as.character(text)` as the first step in the `md()` function. It also adds a test of rendering a factor column with markdown formatting and updates the NEWS file.

``` r
gt(data.frame(x = factor("TEST"))) |> 
  fmt_markdown()
```

<div id="vydivsyvfg" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">

<table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
  <thead>
    <tr class="gt_col_headings">
      <th class="gt_col_heading gt_columns_bottom_border gt_center" rowspan="1" colspan="1" scope="col" id="x">x</th>
    </tr>
  </thead>
  <tbody class="gt_table_body">
    <tr><td headers="x" class="gt_row gt_center"><span class='gt_from_md'>TEST</span></td></tr>
  </tbody>
  &#10;  
</table>
</div>

<sup>Created on 2024-09-17 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

# Related GitHub Issues and PRs

- Ref: #1882 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
