### PR TITLE
Add two useful arguments to `opt_table_font()`: `size` and `color`

### DIFF
--- a/R/opts.R
+++ b/R/opts.R
@@ -1540,9 +1540,8 @@ opt_table_outline <- function(
 #'
 #' Use a subset of the [`sp500`] dataset to create a small **gt** table. We'll
 #' use [fmt_currency()] to display a dollar sign for the first row of monetary
-#' values. Then, set a larger font size for the table and use the
-#' `"Merriweather"` font (from *Google Fonts*, via [google_font()]) with two
-#' system font fallbacks (`"Cochin"` and the generic `"serif"`).
+#' values. The `"Merriweather"` font (from *Google Fonts*, via [google_font()])
+#' with two system font fallbacks (`"Cochin"` and the generic `"serif"`).
 #'
 #' ```r
 #' sp500 |>

--- a/R/opts.R
+++ b/R/opts.R
@@ -1582,8 +1582,10 @@ opt_table_font <- function(
     data,
     font = NULL,
     stack = NULL,
+    size = NULL,
     weight = NULL,
     style = NULL,
+    color = NULL,
     add = TRUE
 ) {
 

--- a/R/opts.R
+++ b/R/opts.R
@@ -1635,7 +1635,9 @@ opt_table_font <- function(
 
   if (!is.null(weight)) {
 
-    if (is.numeric(weight)) weight <- as.character(weight)
+    if (is.numeric(weight)) {
+      weight <- as.character(weight)
+    }
 
     data <-
       tab_options(

--- a/R/opts.R
+++ b/R/opts.R
@@ -1653,6 +1653,16 @@ opt_table_font <- function(
       )
   }
 
+  if (!is.null(size)) {
+
+    data <-
+      tab_options(
+        data = data,
+        table.font.size = size
+      )
+
+  }
+
   if (!is.null(weight)) {
 
     if (is.numeric(weight)) {
@@ -1678,6 +1688,15 @@ opt_table_font <- function(
       tab_options(
         data = data,
         table.font.style = style
+      )
+  }
+
+  if (!is.null(color)) {
+
+    data <-
+      tab_options(
+        data = data,
+        table.font.color = color
       )
   }
 

--- a/R/opts.R
+++ b/R/opts.R
@@ -1456,6 +1456,17 @@ opt_table_outline <- function(
 #'   A name that is representative of a font stack (obtained via internally via
 #'   the [system_fonts()] helper function). If provided, this new stack will
 #'   replace any defined fonts and any `font` values will be prepended.
+#' 
+#' @param size *Text size*
+#' 
+#'   `scalar<character|numeric|integer>` // *default:* `NULL` (`optional`)
+#' 
+#'   The text size for the entire table can be set by providing a `size` value.
+#'   Can be specified as a single-length character vector with units of pixels
+#'   (e.g., `12px`) or as a percentage (e.g., `80%`). If provided as a
+#'   single-length numeric vector, it is assumed that the value is given in
+#'   units of pixels. The [px()] and [pct()] helper functions can also be used
+#'   to pass in numeric values and obtain values as pixel or percentage units.
 #'
 #' @param style *Text style*
 #'
@@ -1472,6 +1483,13 @@ opt_table_outline <- function(
 #'   `"normal"`, `"bold"`, `"lighter"`, `"bolder"`, or, a numeric value between
 #'   `1` and `1000`, inclusive. Please note that typefaces have varying support
 #'   for the numeric mapping of weight.
+#' 
+#' @param color *Text color*
+#' 
+#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#' 
+#'   The `color` option defines the text color used throughout the table. A
+#'   color name or a hexadecimal color code should be provided.
 #'
 #' @param add *Add to existing fonts*
 #'

--- a/man/opt_table_font.Rd
+++ b/man/opt_table_font.Rd
@@ -8,8 +8,10 @@ opt_table_font(
   data,
   font = NULL,
   stack = NULL,
+  size = NULL,
   weight = NULL,
   style = NULL,
+  color = NULL,
   add = TRUE
 )
 }
@@ -37,6 +39,17 @@ A name that is representative of a font stack (obtained via internally via
 the \code{\link[=system_fonts]{system_fonts()}} helper function). If provided, this new stack will
 replace any defined fonts and any \code{font} values will be prepended.}
 
+\item{size}{\emph{Text size}
+
+\verb{scalar<character|numeric|integer>} // \emph{default:} \code{NULL} (\code{optional})
+
+The text size for the entire table can be set by providing a \code{size} value.
+Can be specified as a single-length character vector with units of pixels
+(e.g., \verb{12px}) or as a percentage (e.g., \verb{80\%}). If provided as a
+single-length numeric vector, it is assumed that the value is given in
+units of pixels. The \code{\link[=px]{px()}} and \code{\link[=pct]{pct()}} helper functions can also be used
+to pass in numeric values and obtain values as pixel or percentage units.}
+
 \item{weight}{\emph{Text weight}
 
 \verb{scalar<character|numeric|integer>} // \emph{default:} \code{NULL} (\code{optional})
@@ -52,6 +65,13 @@ for the numeric mapping of weight.}
 
 An option to modify the text style. Can be one of either \code{"normal"},
 \code{"italic"}, or \code{"oblique"}.}
+
+\item{color}{\emph{Text color}
+
+\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+
+The \code{color} option defines the text color used throughout the table. A
+color name or a hexadecimal color code should be provided.}
 
 \item{add}{\emph{Add to existing fonts}
 
@@ -121,9 +141,8 @@ multiple computer systems. Any of the following keywords can be used:
 
 Use a subset of the \code{\link{sp500}} dataset to create a small \strong{gt} table. We'll
 use \code{\link[=fmt_currency]{fmt_currency()}} to display a dollar sign for the first row of monetary
-values. Then, set a larger font size for the table and use the
-\code{"Merriweather"} font (from \emph{Google Fonts}, via \code{\link[=google_font]{google_font()}}) with two
-system font fallbacks (\code{"Cochin"} and the generic \code{"serif"}).
+values. The \code{"Merriweather"} font (from \emph{Google Fonts}, via \code{\link[=google_font]{google_font()}})
+with two system font fallbacks (\code{"Cochin"} and the generic \code{"serif"}).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{sp500 |>
   dplyr::slice(1:10) |>

--- a/tests/testthat/test-opts.R
+++ b/tests/testthat/test-opts.R
@@ -340,6 +340,22 @@ test_that("opt_table_font() sets the correct options", {
       "font-weight: bold;",
       "font-style: italic;"
     ) %>% expect_true()
+  
+  # Expect that the `size` option is passed as a CSS value
+  tbl %>%
+    opt_table_font(size = px(32)) %>%
+    compile_scss() %>%
+    as.character() %>%
+    html_fragment_within("font-size: 32px;") %>%
+    expect_true()
+  
+  # Expect that the `color` option is passed as a CSS value
+  tbl %>%
+    opt_table_font(color = "#228B23") %>%
+    compile_scss() %>%
+    as.character() %>%
+    html_fragment_within("color: #228B23;") %>%
+    expect_true()
 
   # Expect that adding a font from the Google Fonts service
   # is possible with the `google_font()` function


### PR DESCRIPTION
This adds the arguments `size` and `color` to the `opt_table_font()` function. Text in an example is also modified since it provides an incorrect description of the code that follows.

Fixes: https://github.com/rstudio/gt/issues/1879