### PR TITLE
Misc performance improvements for nanoplots / `vec_*()` functions.

### DIFF
--- a/R/dt_spanners.R
+++ b/R/dt_spanners.R
@@ -35,7 +35,7 @@ dt_spanners_set <- function(data, spanners) {
 dt_spanners_init <- function(data) {
 
   spanners <-
-    dplyr::tibble(
+    vctrs::data_frame(
       # Column names that are part of the spanner
       vars = list(),
       # The spanner label

--- a/R/fmt.R
+++ b/R/fmt.R
@@ -552,7 +552,7 @@ format_num_to_str <- function(
     system = c("intl", "ind")
 ) {
 
-  system <- rlang::arg_match(system)
+  system <- rlang::arg_match0(system, c("intl", "ind"))
 
   # If this hardcoding is ever to change, then we need to
   # modify the regexes below
@@ -604,7 +604,7 @@ format_num_to_str <- function(
 
   # Remove `-` for any signed zeros returned by `formatC()`
   x_str_signed_zero <- grepl("^(-0|-0\\.0*?)$", x_str)
-  x_str[x_str_signed_zero] <- gsub("-", "", x_str[x_str_signed_zero])
+  x_str[x_str_signed_zero] <- gsub("-", "", x_str[x_str_signed_zero], fixed = TRUE)
 
   # If a trailing decimal mark is to be retained (not the
   # default option but sometimes desirable), affix the `dec_mark`
@@ -633,7 +633,7 @@ format_num_to_str <- function(
         FUN = insert_seps_ind
       )
 
-    decimal_str <- rep("", length(x_str_numeric))
+    decimal_str <- rep_len("", length(x_str_numeric))
 
     decimal_str[has_decimal] <-
       gsub("^.*?(\\..*)", "\\1", x_str_numeric[has_decimal])
@@ -670,7 +670,7 @@ format_num_to_str_c <- function(
     system = c("intl", "ind")
 ) {
 
-  system <- rlang::arg_match(system)
+  system <- rlang::arg_match0(system, c("intl", "ind"))
 
   format_num_to_str(
     x = x,

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -9667,6 +9667,10 @@ fmt_markdown <- function(
     rows = {{ rows }},
     fns = list(
       html = function(x) {
+        # Ensure input is x (e.g. for factors)
+        if (!is.character(x)) {
+          x <- as.character(x)
+        }
         process_text(md(x), context = "html")
       },
       latex = function(x) {

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -3341,7 +3341,7 @@ vec_fmt_markdown <- function(
 }
 
 gt_one_col <- function(x) {
-  gt(dplyr::tibble(x = x), auto_align = FALSE, process_md = FALSE)
+  gt(data.frame(x = x, stringsAsFactors = FALSE), auto_align = FALSE, process_md = FALSE, groupname_col = NULL)
 }
 
 # Similar as `stop_if_not_vector()` if `valid_classes` is not supplied.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -70,8 +70,6 @@
 #'
 #' @export
 md <- function(text) {
-  # Ensure input is text (e.g. for factors)
-  text <- as.character(text)
   # Apply the `from_markdown` class
   class(text) <- "from_markdown"
   text

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -471,7 +471,7 @@ perform_col_merge <- function(data, context) {
           }
         )
 
-      glue_src_data <- stats::setNames(glue_src_data, seq_len(length(glue_src_data)))
+      glue_src_data <- stats::setNames(glue_src_data, seq_along(glue_src_data))
 
       glued_cols <- as.character(glue_gt(glue_src_data, pattern))
 


### PR DESCRIPTION
# Summary

Improve a little performance for `vec_*()` by avoiding converting to a tibble and remove some dplyr calls to `group_vars()`.

This could probably be improved further, but saw these quick fixes so I added that.

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.


I wonder if this could be improved further. I used the first example of `cols_nanoplot()` 
```r
illness |>
  dplyr::slice_head(n = 10) |>
  gt(rowname_col = "test") |>
  tab_header("Partial summary of daily tests performed on YF patient") |>
  tab_stubhead(label = md("**Test**")) |>
  cols_hide(columns = starts_with("norm")) |>
  fmt_units(columns = units) |>
  cols_nanoplot(
    columns = starts_with("day"),
    new_col_name = "nanoplots",
    new_col_label = md("*Progression*")
  ) |>
  cols_align(align = "center", columns = nanoplots) |>
  cols_merge(columns = c(test, units), pattern = "{1} ({2})") |>
  tab_footnote(
    footnote = "Measurements from Day 3 through to Day 8.",
    locations = cells_column_labels(columns = nanoplots)
  )
```

Before 

![image](https://github.com/user-attachments/assets/929c6bdf-6084-497c-831d-800c99f7bd84)

This PR:
![image](https://github.com/user-attachments/assets/625aab1e-5b6a-4769-bc7b-aca7a57bb4ae)

~8% gain! Not that bad I guess?

