### PR TITLE
Improve performance of vec_fmt_*() by not building the full data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,8 @@
 
 * Fixed an issue where `md()` and `fmt_markdown()` would render factors as their numeric levels rather than their text labels (@rossellhayes, #1883).
 
+* `vec_fmt_*()` (and incidentally `cols_nanoplot()`) should be faster now (@olivroy, #1888, #1891).
+
 # gt 0.11.0
 
 ## New features

--- a/R/build_data.R
+++ b/R/build_data.R
@@ -88,3 +88,16 @@ build_data <- function(data, context) {
 
   data
 }
+
+
+# Faster implementation that avoids some operations
+# for vec_*() functions
+# only build the body correctly.
+build_data_body <- function(data, context) {
+  
+  data <- dt_body_build(data = data)
+  data <- render_formats(data = data, context = context)
+  data <- migrate_unformatted_to_output(data = data, context = context)
+  
+  data
+}

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -3394,7 +3394,7 @@ check_columns_valid_if_strict <- function(
 }
 
 render_as_vector <- function(data, output) {
-  dt_body_get(build_data(data, context = output))[["x"]]
+  dt_body_get(build_data_body(data, context = output))[["x"]]
 }
 
 determine_output_format <- function() {


### PR DESCRIPTION
# Summary

By removing some unnecessary build stage operations, we are able to speed up significantly the rendering of the `vec_fmt_*()`  functions and hence `cols_nanoplot()`.

This seems to double speed by avoiding unnecessary operations!


# Related GitHub Issues and PRs

- follow up to #1888

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
