### PR TITLE
Performance of vec_fmt_*() by avoiding checking of compatibility + coercion to tibble

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,8 @@
 
 * `vec_fmt_*()` (and incidentally `cols_nanoplot()`) should be faster now (@olivroy, #1888, #1891).
 
+* `cols_add()` works in more cases (#1893).
+
 # gt 0.11.0
 
 ## New features

--- a/R/build_data.R
+++ b/R/build_data.R
@@ -40,7 +40,7 @@ build_data <- function(data, context) {
   # Reassemble the rows and columns of `body` in
   # the correct order
   data <- dt_body_build(data = data)
-  data <- render_formats(data = data, context = context)
+  data <- render_formats(data = data, skip_compat_check = FALSE, context = context)
   data <- render_substitutions(data = data, context = context)
   data <- migrate_unformatted_to_output(data = data, context = context)
   data <- perform_col_merge(data = data, context = context)
@@ -96,7 +96,7 @@ build_data <- function(data, context) {
 build_data_body <- function(data, context) {
   
   data <- dt_body_build(data = data)
-  data <- render_formats(data = data, context = context)
+  data <- render_formats(data = data, skip_compat_check = TRUE, context = context)
   data <- migrate_unformatted_to_output(data = data, context = context)
   
   data

--- a/R/cols_add.R
+++ b/R/cols_add.R
@@ -470,49 +470,23 @@ cols_add <- function(
 
   } else if (is.null(resolved_column_before) && !is.null(resolved_column_after)) {
 
-    if (resolved_column_after == ncol(data_tbl)) {
+    after_colnum <- which(colnames(data_tbl) == resolved_column_after)
 
-      updated_data_tbl <-
-        vctrs::vec_cbind(
-          data_tbl,
-          data_tbl_new_cols
-        )
+    updated_data_tbl <-
+      dplyr::bind_cols(
+        dplyr::select(data_tbl, 1:dplyr::all_of(after_colnum)),
+        data_tbl_new_cols,
+        dplyr::select(data_tbl, (after_colnum + 1):ncol(data_tbl))
+      )
 
-      updated_boxh_df <-
-        vctrs::vec_rbind(
-          boxh_df,
-          boxh_df_new_cols
-        )
-
-    } else {
-
-      after_colnum <- which(colnames(data_tbl) == resolved_column_after)
-
-      if (after_colnum >= ncol(data_tbl)) {
-        updated_data_tbl <-
-          vctrs::vec_cbind(
-            data_tbl,
-            data_tbl_new_cols
-          )
-      } else {
-        updated_data_tbl <-
-          dplyr::bind_cols(
-            dplyr::select(data_tbl, 1:dplyr::all_of(after_colnum)),
-            data_tbl_new_cols,
-            dplyr::select(data_tbl, (after_colnum + 1):ncol(data_tbl))
-          )
-      }
-
-
-      after_colnum <- which(boxh_df[["var"]] == resolved_column_after)
+    after_colnum <- which(boxh_df[["var"]] == resolved_column_after)
       
-      updated_boxh_df <-
-        dplyr::bind_rows(
-          boxh_df[1:after_colnum, ],
-          boxh_df_new_cols,
-          boxh_df[(after_colnum + 1):nrow(boxh_df), ]
-        )
-    }
+    updated_boxh_df <-
+      dplyr::bind_rows(
+        boxh_df[1:after_colnum, ],
+        boxh_df_new_cols,
+        boxh_df[(after_colnum + 1):nrow(boxh_df), ]
+      )
   }
 
   # Modify the internal datasets

--- a/R/cols_add.R
+++ b/R/cols_add.R
@@ -242,7 +242,7 @@ cols_add <- function(
   # columns
   #
 
-  if (nrow(data_tbl) < 1 && ncol(data_tbl) < 1) {
+  if (nrow(data_tbl) == 0L && ncol(data_tbl) == 0L) {
 
     # Generate boxhead rows that correspond to the new columns
     updated_boxh_df <-
@@ -279,7 +279,7 @@ cols_add <- function(
   # however, the number of rows should be consistent across the supplied columns
   #
 
-  if (nrow(data_tbl) < 1 && ncol(data_tbl) > 0) {
+  if (nrow(data_tbl) == 0L && ncol(data_tbl) > 0) {
 
     # Generate boxhead rows that correspond to the new columns
     updated_boxh_df <-
@@ -380,14 +380,9 @@ cols_add <- function(
       null_means = "nothing"
     )
 
-  if (length(resolved_column_before) < 1) {
+  if (length(resolved_column_before) == 0) {
     resolved_column_before <- NULL
-  }
-
-  if (
-    !is.null(resolved_column_before) &&
-    length(resolved_column_before) != 1
-  ) {
+  } else if (length(resolved_column_before) != 1) {
 
     if (length(resolved_column_before) < 1) {
       cli::cli_abort("The expression used for `.before` did not resolve a column.")
@@ -405,14 +400,9 @@ cols_add <- function(
       null_means = "nothing"
     )
 
-  if (length(resolved_column_after) < 1) {
+  if (length(resolved_column_after) == 0L) {
     resolved_column_after <- NULL
-  }
-
-  if (
-    !is.null(resolved_column_after) &&
-    length(resolved_column_after) != 1
-  ) {
+  } else if (length(resolved_column_after) != 1) {
 
     if (length(resolved_column_after) < 1) {
       cli::cli_abort("The expression used for `.after` did not resolve a column.")
@@ -465,7 +455,7 @@ cols_add <- function(
     before_colnum <- which(boxh_df[["var"]] == resolved_column_before)
 
     updated_boxh_df <-
-      dplyr::bind_rows(
+      vctrs::vec_cbind(
         boxh_df[(1:before_colnum) - 1, ],
         boxh_df_new_cols,
         boxh_df[before_colnum:nrow(boxh_df), ]
@@ -476,13 +466,13 @@ cols_add <- function(
     if (resolved_column_after == nrow(data_tbl)) {
 
       updated_data_tbl <-
-        dplyr::bind_cols(
+        vctrs::vec_cbind(
           data_tbl,
           data_tbl_new_cols
         )
 
       updated_boxh_df <-
-        dplyr::bind_rows(
+        vctrs::vec_rbind(
           boxh_df,
           boxh_df_new_cols
         )

--- a/R/cols_add.R
+++ b/R/cols_add.R
@@ -444,18 +444,28 @@ cols_add <- function(
   } else if (!is.null(resolved_column_before) && is.null(resolved_column_after)) {
 
     before_colnum <- which(colnames(data_tbl) == resolved_column_before)
+    
+    if (before_colnum <= 1) {
+      # put new column first
+      updated_data_tbl <-
+        dplyr::bind_cols(
+          data_tbl_new_cols,
+          data_tbl
+        )
+    } else {
+      updated_data_tbl <-
+        dplyr::bind_cols(
+          dplyr::select(data_tbl, 1:(before_colnum - 1)),
+          data_tbl_new_cols,
+          dplyr::select(data_tbl, before_colnum:ncol(data_tbl))
+        )
+    }
 
-    updated_data_tbl <-
-      dplyr::bind_cols(
-        dplyr::select(data_tbl, 1:(before_colnum - 1)),
-        data_tbl_new_cols,
-        dplyr::select(data_tbl, before_colnum:ncol(data_tbl))
-      )
 
     before_colnum <- which(boxh_df[["var"]] == resolved_column_before)
 
     updated_boxh_df <-
-      vctrs::vec_cbind(
+      vctrs::vec_rbind(
         boxh_df[(1:before_colnum) - 1, ],
         boxh_df_new_cols,
         boxh_df[before_colnum:nrow(boxh_df), ]
@@ -481,12 +491,21 @@ cols_add <- function(
 
       after_colnum <- which(colnames(data_tbl) == resolved_column_after)
 
-      updated_data_tbl <-
-        dplyr::bind_cols(
-          dplyr::select(data_tbl, 1:after_colnum),
-          data_tbl_new_cols,
-          dplyr::select(data_tbl, (after_colnum + 1):ncol(data_tbl))
-        )
+      if (after_colnum >= ncol(data_tbl)) {
+        updated_data_tbl <-
+          dplyr::bind_cols(
+            data_tbl,
+            data_tbl_new_cols
+          )
+      } else {
+        updated_data_tbl <-
+          dplyr::bind_cols(
+            dplyr::select(data_tbl, 1:after_colnum),
+            data_tbl_new_cols,
+            dplyr::select(data_tbl, (after_colnum + 1):ncol(data_tbl))
+          )
+      }
+
 
       after_colnum <- which(boxh_df[["var"]] == resolved_column_after)
 

--- a/R/cols_align_decimal.R
+++ b/R/cols_align_decimal.R
@@ -148,7 +148,7 @@ cols_align_decimal <- function(
 
   # If the subsetting of columns finally results in no columns, return
   # the data unchanged
-  if (length(columns) < 1) {
+  if (length(columns) == 0L) {
     return(data)
   }
 

--- a/R/dt_body.R
+++ b/R/dt_body.R
@@ -36,12 +36,12 @@ dt_body_get <- function(data) {
 }
 
 dt_body_set <- function(data, body) {
-  dt__set(data, .dt_body_key, dplyr::as_tibble(body))
+  dt__set(data, .dt_body_key, body)
 }
 
 dt_body_build_init <- function(data) {
 
-  body <- dt_data_get(data = data)[, dt_boxhead_get_vars(data = data)]
+  body <- dt_data_get(data = data)[dt_boxhead_get_vars(data = data)]
 
   if (NROW(body) > 0) {
     body[] <- NA_character_

--- a/R/fmt.R
+++ b/R/fmt.R
@@ -176,22 +176,22 @@ normalize_locale <- function(locale = NULL) {
 #'   functions. This is expected as `NULL` if not supplied by the user.
 #' @noRd
 validate_locale <- function(locale, call = rlang::caller_env()) {
+  if (is.null(locale)) {
+    return(NULL)
+  }
 
-  # Stop function if the `locale` provided
-  # isn't a valid one
-  if (
-    !is.null(locale) &&
-    !(gsub("_", "-", locale, fixed = TRUE) %in% locales[["locale"]]) &&
-    !(gsub("_", "-", locale, fixed = TRUE) %in% default_locales[["default_locale"]])
-  ) {
-
-    cli::cli_abort(c(
-      "The supplied `locale` is not available in the list of supported locales.",
-      "i" = "Use {.run [info_locales()](gt::info_locales())} to see which locales can be used."
+  locale <- gsub("_", "-", locale, fixed = TRUE)
+  if (locale %in% c(locales[["locale"]], default_locales[["default_locale"]])) {
+    return(locale)
+  }
+  
+  # Stop function if the `locale` provided is invalid
+  cli::cli_abort(c(
+    "The supplied `locale` is not available in the list of supported locales.",
+    "i" = "Use {.run [info_locales()](gt::info_locales())} to see which locales can be used."
     ),
     call = call
-    )
-  }
+  )
 }
 
 #' Validate the user-supplied `currency` value
@@ -293,8 +293,8 @@ get_locale_range_pattern <- function(locale = NULL) {
   range_pattern <- locales$range_pattern[locales$locale == locale]
   validate_length_one(range_pattern)
 
-  range_pattern <- gsub("1", "2", range_pattern)
-  range_pattern <- gsub("0", "1", range_pattern)
+  range_pattern <- gsub("1", "2", range_pattern, fixed = TRUE)
+  range_pattern <- gsub("0", "1", range_pattern, fixed = TRUE)
   range_pattern
 }
 
@@ -1284,7 +1284,7 @@ create_suffix_df <- function(
 
   suffix_fn <- if (system == "intl") num_suffix else num_suffix_ind
 
-  # Create a tibble with scaled values for `x` and the
+  # Create a data frame with scaled values for `x` and the
   # suffix labels to use for character formatting
   suffix_fn(
     round(x, decimals),
@@ -1344,7 +1344,7 @@ num_fmt_factory <- function(
   function(x) {
 
     # Create `x_str` with the same length as `x`
-    x_str <- rep(NA_character_, length(x))
+    x_str <- rep_len(NA_character_, length(x))
 
     # Determine which of `x` are not NA
     non_na_x <- !is.na(x)

--- a/R/nanoplot.R
+++ b/R/nanoplot.R
@@ -894,8 +894,8 @@ cols_nanoplot <- function(
     cols_add(
       .data = data,
       nanoplots,
-      .before = before,
-      .after = after
+      .before = dplyr::all_of(before),
+      .after = dplyr::all_of(after)
     )
 
   if (!is.null(new_col_name)) {
@@ -923,7 +923,7 @@ cols_nanoplot <- function(
     data <-
       fmt_passthrough(
         data = data,
-        columns = validated_new_col_name,
+        columns = dplyr::all_of(validated_new_col_name),
         escape = FALSE
       )
 
@@ -974,7 +974,7 @@ cols_nanoplot <- function(
         "vertical-align: middle; ",
         "overflow-x: visible;"
       ),
-      locations = cells_body(columns = validated_new_col_name)
+      locations = cells_body(columns = dplyr::all_of(validated_new_col_name))
     )
 
   if (isTRUE(autohide)) {
@@ -982,7 +982,7 @@ cols_nanoplot <- function(
     data <-
       cols_hide(
         data = data,
-        columns = resolved_columns
+        columns = dplyr::all_of(resolved_columns)
       )
 
     if (length(resolved_columns_x) > 0) {
@@ -990,7 +990,7 @@ cols_nanoplot <- function(
       data <-
         cols_hide(
           data = data,
-          columns = resolved_columns_x
+          columns = dplyr::all_of(resolved_columns_x)
         )
     }
   }

--- a/R/nanoplot.R
+++ b/R/nanoplot.R
@@ -1387,7 +1387,7 @@ generate_data_vals_list <- function(
 
     } else {
 
-      data_vals_i <- dplyr::select(data_tbl, dplyr::all_of(resolved_columns))
+      data_vals_i <- data_tbl[resolved_columns]
 
       data_vals_i <- as.vector(data_vals_i[i, ])
 
@@ -1419,7 +1419,7 @@ generate_data_vals_list <- function(
 
 
         } else {
-          data_vals_j <- c(data_vals_j, unname(unlist(data_vals_i[j][[1]])))
+          data_vals_j <- c(data_vals_j, unlist(data_vals_i[j][[1]], use.names = FALSE))
         }
       }
 

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1736,7 +1736,8 @@ tab_row_group <- function(
 
   # Set the `_row_groups` vector here with the group id; new groups will
   # be placed at the front, pushing down `NA` (the 'Others' group)
-  arrange_groups_vars <- c(id, stats::na.omit(arrange_groups_vars))
+  arrange_groups_vars <- arrange_groups_vars[!is.na(arrange_groups_vars)]
+  arrange_groups_vars <- c(id, arrange_groups_vars)
   arrange_groups_vars <- unique(arrange_groups_vars)
   arrange_groups_vars <- arrange_groups_vars[arrange_groups_vars %in% stub_df$group_id]
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1866,9 +1866,10 @@ num_suffix <- function(
     }
 
     return(
-      dplyr::tibble(
-        scale_by = rep_len(scale_by, length(x)),
-        suffix = rep_len("", length(x))
+      vctrs::data_frame(
+        scale_by = scale_by,
+        suffix = "",
+        .size = length(x)
       )
     )
   }
@@ -1919,7 +1920,7 @@ num_suffix <- function(
 
   # Create and return a tibble with `scale_by`
   # and `suffix` values
-  dplyr::tibble(
+  vctrs::data_frame(
     scale_by = 1 / base^suffix_index,
     suffix = suffix_labels
   )
@@ -1947,9 +1948,10 @@ num_suffix_ind <- function(
     }
 
     return(
-      dplyr::tibble(
-        scale_by = rep_len(scale_by, length(x)),
-        suffix = rep_len("", length(x))
+      vctrs::data_frame(
+        scale_by = scale_by,
+        suffix = "",
+        .size = length(x)
       )
     )
   }
@@ -2003,7 +2005,7 @@ num_suffix_ind <- function(
 
   # Create and return a tibble with `scale_by`
   # and `suffix` values
-  dplyr::tibble(
+  vctrs::data_frame(
     scale_by = 10^(-ifelse(suffix_index == 0, 0, (suffix_index * 2) + 1)),
     suffix = suffix_labels
   )
@@ -2320,6 +2322,10 @@ check_row_group_id_unique <- function(data, row_group_id, call = rlang::caller_e
 
 flatten_list <- function(x) {
   unlist(x, recursive = FALSE)
+}
+
+omit_na <- function(x) {
+  x[!is.na(x)]
 }
 
 #' Prepend a vector

--- a/R/utils.R
+++ b/R/utils.R
@@ -226,9 +226,9 @@ tf_formats <- function() {
 
   dplyr::tribble(
     ~format_number,  ~format_name,    ~characters,              ~idx,
-    "1",	           "true-false",    NA,                       1:2,
-    "2",	           "yes-no",        NA,                       3:4,
-    "3",	           "up-down",       NA,                       5:6,
+    "1",	           "true-false",    NA_character_,            1:2,
+    "2",	           "yes-no",        NA_character_,            3:4,
+    "3",	           "up-down",       NA_character_,            5:6,
     "4",             "check-mark",    c("\U02714", "\U02718"),  NA,
     "5",             "circles",       c("\U025CF", "\U02B58"),  NA,
     "6",             "squares",       c("\U025A0", "\U025A1"),  NA,
@@ -240,7 +240,7 @@ tf_formats <- function() {
 }
 
 tf_formats_icons <- function() {
-  as.character(stats::na.omit(tf_formats()[, "characters"][[1]]))
+  as.character(omit_na(tf_formats()[, "characters"][[1]]))
 }
 
 tf_formats_text <- function() {

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -130,7 +130,7 @@ render_formats <- function(data, skip_compat_check = FALSE, context) {
         # If any of the resulting output is `NA`, that means we want
         # to NOT make changes to those particular cells' output
         # (i.e. inherit the results of the previous formatter).
-        body[[col]][rows][!is.na(result)] <- stats::na.omit(result)
+        body[[col]][rows][!is.na(result)] <- omit_na(result)
       }
     }
   }
@@ -183,7 +183,7 @@ render_substitutions <- function(
         # means we want to NOT make changes to those
         # particular cells' output (i.e. inherit the
         # results of the previous substitution).
-        body[[col]][subst$rows][!is.na(result)] <- stats::na.omit(result)
+        body[[col]][subst$rows][!is.na(result)] <- omit_na(result)
       }
     }
   }

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -81,7 +81,7 @@ rownum_translation <- function(body, rownum_start) {
 #' Render any formatting directives available in the `formats` list
 #'
 #' @noRd
-render_formats <- function(data, context) {
+render_formats <- function(data, skip_compat_check = FALSE, context) {
 
   body <- dt_body_get(data = data)
   data_tbl <- dt_data_get(data = data)
@@ -108,13 +108,17 @@ render_formats <- function(data, context) {
     for (col in fmt[["cols"]]) {
 
       # Perform rendering but only do so if the column is present
+      # Or if we are confident that we have a compatible formatter and no rows /cols are hidden
       if (
-        col %in% colnames(data_tbl) &&
-        is_compatible_formatter(
-          table = data_tbl,
-          column = col,
-          rows = rows,
-          compat = compat
+        skip_compat_check ||
+        (
+          col %in% colnames(data_tbl) &&
+          is_compatible_formatter(
+            table = data_tbl,
+            column = col,
+            rows = rows,
+            compat = compat
+          )
         )
       ) {
 

--- a/R/utils_render_rtf.R
+++ b/R/utils_render_rtf.R
@@ -1630,7 +1630,7 @@ create_body_component_rtf <- function(data) {
 
       group_id <-
         groups_rows_df[
-          stats::na.omit(groups_rows_df$row_end == i),
+          omit_na(groups_rows_df$row_end == i),
           "group_id", drop = TRUE
         ]
 

--- a/R/z_utils_render_footnotes.R
+++ b/R/z_utils_render_footnotes.R
@@ -190,7 +190,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
       )
 
     # Re-combine `tbl_not_summary_cells` with `tbl_summary_cells`
-    tbl <- dplyr::bind_rows(tbl_not_summary_cells, tbl_summary_cells)
+    tbl <- vctrs::vec_rbind(tbl_not_summary_cells, tbl_summary_cells)
   }
 
   # For the grand summary cells, insert a `colnum` based
@@ -210,7 +210,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
     # Re-combine `tbl_not_g_summary_cells`
     # with `tbl_g_summary_cells`
     tbl <-
-      dplyr::bind_rows(
+      vctrs::vec_rbind(
         tbl_not_g_summary_cells, tbl_g_summary_cells
       )
   }
@@ -226,7 +226,7 @@ resolve_footnotes_styles <- function(data, tbl_type) {
     tmp$colnum <- NULL
     tmp$rownum <- NULL
 
-    default_variables <- dplyr::tibble(
+    default_variables <- vctrs::data_frame(
       colnum = seq(default_vars),
       colname = default_vars,
       rownum = -1L

--- a/tests/testthat/_snaps/cols_add.md
+++ b/tests/testthat/_snaps/cols_add.md
@@ -1,0 +1,25 @@
+# cols_add() errors with bad input
+
+    Code
+      cols_add(tbl, x = 1, .after = 2, .before = 3)
+    Condition
+      Error in `cols_add()`:
+      ! Expressions cannot be given to both `.before` and `.after`.
+    Code
+      cols_add(tbl, x = 1, .after = 15)
+    Condition
+      Error in `vars_select_eval()`:
+      ! Can't select columns past the end.
+      i Location 15 doesn't exist.
+      i There are only 9 columns.
+    Code
+      cols_add(tbl, x = 1, .before = c(1, 2))
+    Condition
+      Error in `cols_add()`:
+      ! The expression used for `.before` resolved multiple columns.
+    Code
+      cols_add(tbl, x = 1, .after = c(1, 2))
+    Condition
+      Error in `cols_add()`:
+      ! The expression used for `.after` resolved multiple columns.
+

--- a/tests/testthat/test-cols_add.R
+++ b/tests/testthat/test-cols_add.R
@@ -1,8 +1,34 @@
 test_that("cols_add() works", {
   tbl <- gt(exibble)
   expect_no_error(
-    cols_add(tbl, x = 1, .before = 3)
+    dat <- cols_add(tbl, x = 1, .before = 1)
   )
-  expect_equal(cols_add(), what)
+  expect_equal(dat$`_boxhead`$var[1], "x")
+  
+  expect_no_error(
+    dat <- cols_add(tbl, x = 1, .before = 2)
+  )
+  expect_equal(dat$`_boxhead`$var[2], "x")
+  expect_no_error(
+    dat <- cols_add(tbl, x = 1, .after = 1)
+  )
+  expect_equal(dat$`_boxhead`$var[2], "x")
+  expect_no_error(
+    dat <- cols_add(tbl, x = 1, .after = dplyr::last_col())
+  )
+})
+
+test_that("cols_add() errors with bad input", {
+  tbl <- gt(exibble)
+  
+  expect_snapshot(
+    error = TRUE, {
+      cols_add(tbl, x = 1, .after = 2, .before = 3)
+      cols_add(tbl, x = 1, .after = 15)
+      cols_add(tbl, x = 1, .before = c(1, 2))
+      cols_add(tbl, x = 1, .after = c(1, 2))
+      
+    }
+  )
 })
 

--- a/tests/testthat/test-cols_add.R
+++ b/tests/testthat/test-cols_add.R
@@ -32,3 +32,18 @@ test_that("cols_add() errors with bad input", {
   )
 })
 
+test_that("cols_add() handles empty data frames", {
+  # These 2 cases are equal
+  expect_equal_gt(
+    gt(data.frame()) %>% cols_add(x = 1),
+    gt(data.frame(x = 1))
+  )
+  
+  expect_no_error(gt(data.frame()) %>% cols_add())
+  
+  expect_no_error(
+    tab <- gt(data.frame(x = character(0), y = character(0))) %>% cols_add(z = character(0))
+    )
+  expect_named(tab$`_data`, c("x", "y", "z"))
+  
+})

--- a/tests/testthat/test-cols_add.R
+++ b/tests/testthat/test-cols_add.R
@@ -1,0 +1,8 @@
+test_that("cols_add() works", {
+  tbl <- gt(exibble)
+  expect_no_error(
+    cols_add(tbl, x = 1, .before = 3)
+  )
+  expect_equal(cols_add(), what)
+})
+

--- a/tests/testthat/test-cols_nanoplot.R
+++ b/tests/testthat/test-cols_nanoplot.R
@@ -1,0 +1,12 @@
+test_that("multiplication works", {
+  skip_on_cran()
+  # options("lifecycle_verbosity" = "error")
+  dat <- dplyr::slice_head(sp500, n = 100)
+  tbl_gt <- gt(dat)
+  expect_no_error(
+    cols_nanoplot(tbl_gt, columns = open:close)
+  )
+  expect_no_error(
+    cols_nanoplot(tbl_gt, columns = open:close, autohide = TRUE)
+  )
+})


### PR DESCRIPTION
# Summary

Hopefully, my last one. 

My example is down to about 4 seconds rendering time.

The main idea is to avoid dplyr or coercion to tibble and also avoid to check for the compatibility of the formatter unnecessarily. 

I realized `cols_add()` has some issues, so I fixed up the two corner cases `.before = 0` and `.after = last_col()` + added tests.

Also eliminated some tidyselect deprecation warnings

# Related GitHub Issues and PRs

- Ref: #1888 , #1891 

