### PR TITLE
Add `gt.locale` option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * PDF output now defaults to a full-width floating environment using `tabular*` (@AronGullickson, #1588). Float position can be controlled by the `latex.tbl.pos` argument in `tab_options`. Quarto users can alternatively use the `tbl-pos` argument to control positioning. To use a `longtable` environment instead, use `tab_option(latex.use_longtable = TRUE)`.
 
+* The `locale` argument of `gt()` now defaults to `getOption("gt.locale")` if set (#1894).
+
 ## Interactive table support
 
 * Interactive tables will show no border if `opt_table_lines(extent = "none")` is specified (#1307).

--- a/R/gt.R
+++ b/R/gt.R
@@ -120,12 +120,13 @@
 #'
 #' @param locale *Locale identifier*
 #'
-#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'   `scalar<character>` // *default:* `getOption("gt.locale")` (`optional`)
 #'
 #'   An optional locale identifier that can be set as the default locale for all
 #'   functions that take a `locale` argument. Examples include `"en"` for
 #'   English (United States) and `"fr"` for French (France). We can call
 #'   [info_locales()] as a useful reference for all of the locales that are supported.
+#'   If set, `options(gt.locale)` is also consulted.
 #'
 #' @param row_group.sep *Separator text for multiple row group labels*
 #'
@@ -302,7 +303,7 @@ gt <- function(
     row_group_as_column = FALSE,
     auto_align = TRUE,
     id = NULL,
-    locale = NULL,
+    locale = getOption("gt.locale"),
     row_group.sep = getOption("gt.row_group.sep", " - ")
 ) {
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -138,6 +138,8 @@ utils::globalVariables(
 #'
 #' **gt** uses the following [options()] to configure behavior:
 #'
+#' - `gt.locale`: A [locale][info_locales()] to yse by default in
+#'  the [gt()] function.
 #' - `gt.row_group.sep`: A separator between groups for the row group label. By
 #' default this is `" - "`.
 #' - `gt.html_tag_check`: A logical scalar indicating whether or not to print a

--- a/man/gt-options.Rd
+++ b/man/gt-options.Rd
@@ -11,6 +11,8 @@
 
 \strong{gt} uses the following \code{\link[=options]{options()}} to configure behavior:
 \itemize{
+\item \code{gt.locale}: A \link[=info_locales]{locale} to yse by default in
+the \code{\link[=gt]{gt()}} function.
 \item \code{gt.row_group.sep}: A separator between groups for the row group label. By
 default this is \code{" - "}.
 \item \code{gt.html_tag_check}: A logical scalar indicating whether or not to print a

--- a/man/gt.Rd
+++ b/man/gt.Rd
@@ -14,7 +14,7 @@ gt(
   row_group_as_column = FALSE,
   auto_align = TRUE,
   id = NULL,
-  locale = NULL,
+  locale = getOption("gt.locale"),
   row_group.sep = getOption("gt.row_group.sep", " - ")
 )
 }
@@ -90,12 +90,13 @@ providing a character value.}
 
 \item{locale}{\emph{Locale identifier}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{scalar<character>} // \emph{default:} \code{getOption("gt.locale")} (\code{optional})
 
 An optional locale identifier that can be set as the default locale for all
 functions that take a \code{locale} argument. Examples include \code{"en"} for
 English (United States) and \code{"fr"} for French (France). We can call
-\code{\link[=info_locales]{info_locales()}} as a useful reference for all of the locales that are supported.}
+\code{\link[=info_locales]{info_locales()}} as a useful reference for all of the locales that are supported.
+If set, \code{options(gt.locale)} is also consulted.}
 
 \item{row_group.sep}{\emph{Separator text for multiple row group labels}
 


### PR DESCRIPTION
# Summary

The idea is to avoid stuff like this
````qmd
---
title: "un document en français"
lang: fr
---

```{r}
options(gt.locale = "fr-CA")
```

```{r}
gt(exibble) |> fmt_number()
```

```{r}
gt(exibble)
```



````
.
Of course, if you provide locale explicitly anywhere in the calls, it would have precedence on the global option. Please let me know what you think. I see it as a useful way to specify `locale` globally in a Quarto document / project. 

I hoped we could be smarter by detecting `lang` in Quarto, but it isn't possible. Let me know if you have an alternative idea! I know you are not a fan of global options 

https://github.com/quarto-dev/quarto-cli/discussions/10886

# Related GitHub Issues and PRs


# Checklist

- [ ] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
