### PR TITLE
Arg match replacements (`arg_match()` -> `arg_match0()`)

### DIFF
--- a/R/cols_align.R
+++ b/R/cols_align.R
@@ -114,7 +114,11 @@ cols_align <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Get the `align` value, this stops the function if there is no match
-  align <- rlang::arg_match(align)
+  align <- 
+    rlang::arg_match0(
+      align,
+      values = c("auto", "left", "center", "right")
+    )
 
   # Get the columns supplied in `columns` as a character vector
   column_names <-

--- a/R/data_color.R
+++ b/R/data_color.R
@@ -676,16 +676,20 @@ data_color <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Get the correct `direction` value
-  direction <- rlang::arg_match(direction)
+  direction <- rlang::arg_match0(direction, values = c("column", "row"))
 
   # Get the correct `method` value
-  method <- rlang::arg_match(method)
+  method <- 
+    rlang::arg_match0(
+      method,
+      values = c("auto", "numeric", "bin", "quantile", "factor")
+    )
 
   # Get the correct `apply_to` value
-  apply_to <- rlang::arg_match(apply_to)
+  apply_to <- rlang::arg_match0(apply_to, values = c("fill", "text"))
 
   # Get the correct `contrast_algo` value
-  contrast_algo <- rlang::arg_match(contrast_algo)
+  contrast_algo <- rlang::arg_match0(contrast_algo, values = c("apca", "wcag"))
 
   # If no color is provided to `na_color`, use gray as a default
   na_color <- na_color %||% "#808080"
@@ -1276,7 +1280,7 @@ ideal_fgnd_color <- function(
 ) {
 
   # Get the correct `algo` value
-  algo <- rlang::arg_match(algo)
+  algo <- rlang::arg_match0(algo, values = c("apca", "wcag"))
 
   # Normalize color to hexadecimal color if it is in the 'rgba()' string format
   bgnd_color <- rgba_to_hex(colors = bgnd_color)

--- a/R/export.R
+++ b/R/export.R
@@ -499,7 +499,11 @@ as_word <- function(
   # Perform input object validation
   stop_if_not_gt_tbl(data = data)
 
-  caption_location <- rlang::arg_match(caption_location)
+  caption_location <- 
+    rlang::arg_match0(
+      caption_location,
+      values = c("top", "bottom", "embed")
+    )
 
   # Build all table data objects through a common pipeline
   value <- build_data(data = data, context = "word")

--- a/R/extract.R
+++ b/R/extract.R
@@ -206,7 +206,12 @@ extract_body <- function(
   }
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <-
+    rlang::arg_match0(
+      output,
+      values = c("html", "latex", "rtf", "word", "grid")
+    )
+  
   rlang::check_dots_empty()
 
   # Generate vector of columns to include in output  
@@ -613,7 +618,11 @@ extract_cells <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- 
+    rlang::arg_match0(
+      output,
+      values = c("auto", "plain", "html", "latex", "rtf", "word", "grid")
+    )
 
   if (output == "auto") {
     output <- determine_output_format()

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -1089,7 +1089,7 @@ fmt_symbol <- function(
 ) {
 
   # Ensure that arguments are matched
-  system <- rlang::arg_match(system)
+  system <- rlang::arg_match0(system, values = c("intl", "ind"))
 
   # Use locale-based marks if a locale ID is provided
   sep_mark <- get_locale_sep_mark(locale, sep_mark, use_seps)
@@ -1462,7 +1462,7 @@ fmt_percent <- function(
   #
 
   # Ensure that arguments are matched
-  system <- rlang::arg_match(system)
+  system <- rlang::arg_match0(system, values = c("intl", "ind"))
 
   # Stop function if `locale` does not have a valid value; normalize locale
   # and resolve one that might be set globally
@@ -1763,8 +1763,12 @@ fmt_partsper <- function(
   #
 
   # Ensure that arguments are matched
-  to_units <- rlang::arg_match(to_units)
-  system <- rlang::arg_match(system)
+  to_units <- 
+    rlang::arg_match0(
+      to_units,
+      values = c("per-mille", "per-myriad", "pcm", "ppm", "ppb", "ppt", "ppq")
+    )
+  system <- rlang::arg_match0(system, values = c("intl", "ind"))
 
   # Stop function if `locale` does not have a valid value; normalize locale
   # and resolve one that might be set globally
@@ -2119,8 +2123,8 @@ fmt_fraction <- function(
   #
 
   # Ensure that arguments are matched
-  system <- rlang::arg_match(system)
-  layout <- rlang::arg_match(layout)
+  system <- rlang::arg_match0(system, values = c("intl", "ind"))
+  layout <- rlang::arg_match0(layout, values = c("inline", "diagonal"))
 
   # Stop function if `locale` does not have a valid value; normalize locale
   # and resolve one that might be set globally
@@ -2857,7 +2861,7 @@ fmt_currency <- function(
   #
 
   # Ensure that arguments are matched
-  system <- rlang::arg_match(system)
+  system <- rlang::arg_match0(system, values = c("intl", "ind"))
 
   # Stop function if `locale` does not have a valid value; normalize locale
   # and resolve one that might be set globally
@@ -3068,7 +3072,7 @@ fmt_roman <- function(
   #
 
   # Ensure that arguments are matched
-  case <- rlang::arg_match(case)
+  case <- rlang::arg_match0(case, values = c("upper", "lower"))
 
   valid_class <- c("numeric", "integer")
   check_columns_valid_if_strict(data, {{ columns }}, valid_class)
@@ -3296,8 +3300,8 @@ fmt_index <- function(
   #
 
   # Ensure that arguments are matched
-  case <- rlang::arg_match(case)
-  index_algo <- rlang::arg_match(index_algo)
+  case <- rlang::arg_match0(case, values = c("upper", "lower"))
+  index_algo <- rlang::arg_match0(index_algo, values = c("repeat", "excel"))
 
   # Stop function if `locale` does not have a valid value; normalize locale
   # and resolve one that might be set globally
@@ -3978,7 +3982,7 @@ fmt_bytes <- function(
   #
 
   # Ensure that arguments are matched
-  standard <- rlang::arg_match(standard)
+  standard <- rlang::arg_match0(standard, values = c("decimal", "binary"))
 
   # Stop function if `locale` does not have a valid value; normalize locale
   # and resolve one that might be set globally
@@ -4236,8 +4240,12 @@ fmt_duration <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Ensure that arguments are matched
-  duration_style <- rlang::arg_match(duration_style)
-  system <- rlang::arg_match(system)
+  duration_style <- 
+    rlang::arg_match0(
+      duration_style,
+      values = c("narrow", "wide", "colon-sep", "iso")
+    )
+  system <- rlang::arg_match0(system, values = c("intl", "ind"))
 
   check_chr_has_length(output_units, allow_null = TRUE, allow_0 = FALSE)
   check_chr_has_length(input_units, allow_null = TRUE, allow_0 = FALSE)
@@ -9301,7 +9309,7 @@ fmt_icon <- function(
   #
 
   # Ensure that arguments are matched
-  a11y <- rlang::arg_match(a11y)
+  a11y <- rlang::arg_match0(a11y, values = c("semantic", "decorative", "none"))
 
   if (a11y == "semantic") {
     a11y <- "sem"
@@ -9657,7 +9665,11 @@ fmt_markdown <- function(
   #
 
   # Ensure that arguments are matched
-  md_engine <- rlang::arg_match(md_engine)
+  md_engine <- 
+    rlang::arg_match0(
+      md_engine,
+      values = c("markdown", "commonmark")
+    )
 
   # Pass `data`, `columns`, `rows`, and the formatting
   # functions as a function list to `fmt()`
@@ -10036,7 +10048,7 @@ fmt_auto <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Ensure that arguments are matched
-  lg_num_pref <- rlang::arg_match(lg_num_pref)
+  lg_num_pref <- rlang::arg_match0(lg_num_pref, values = c("sci", "suf"))
 
   # Resolve the `locale` value here with the global locale value
   locale <- resolve_locale(data = data, locale = locale)

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -21,6 +21,7 @@
 #
 #------------------------------------------------------------------------------#
 
+output_types <- c("auto", "plain", "html", "latex", "rtf", "word")
 
 # vec_fmt_number() -------------------------------------------------------------
 #' Format a vector as numeric values
@@ -177,7 +178,7 @@ vec_fmt_number <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -469,7 +470,7 @@ vec_fmt_scientific <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -626,7 +627,7 @@ vec_fmt_engineering <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -797,7 +798,7 @@ vec_fmt_percent <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -976,10 +977,14 @@ vec_fmt_partsper <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `to_units` is matched correctly to one option
-  to_units <- rlang::arg_match(to_units)
+  to_units <- 
+    rlang::arg_match0(
+      to_units,
+      values = c("per-mille", "per-myriad", "pcm", "ppm", "ppb", "ppt", "ppq")
+    )
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1115,10 +1120,10 @@ vec_fmt_fraction <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `layout` is matched correctly to one option
-  layout <- rlang::arg_match(layout)
+  layout <- rlang::arg_match0(layout, values = c("inline", "diagonal"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1309,7 +1314,7 @@ vec_fmt_currency <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1421,8 +1426,8 @@ vec_fmt_roman <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `case` and `output` are matched correctly to one option
-  case <- rlang::arg_match(case)
-  output <- rlang::arg_match(output)
+  case <- rlang::arg_match0(case, values = c("upper", "lower"))
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1543,9 +1548,9 @@ vec_fmt_index <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `case`, `index_algo` and `output` are matched correctly to one option
-  case <- rlang::arg_match(case)
-  index_algo <- rlang::arg_match(index_algo)
-  output <- rlang::arg_match(output)
+  case <- rlang::arg_match0(case, values = c("upper", "lower"))
+  index_algo <- rlang::arg_match0(index_algo, values = c("repeat", "excel"))
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1682,7 +1687,7 @@ vec_fmt_spelled_num <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -1832,8 +1837,8 @@ vec_fmt_bytes <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer"))
 
   # Ensure that `standard` and `output` are matched correctly to one option
-  standard <- rlang::arg_match(standard)
-  output <- rlang::arg_match(output)
+  standard <- rlang::arg_match0(standard, values = c("decimal", "binary"))
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -2025,7 +2030,7 @@ vec_fmt_date <- function(
   check_vector_valid(x, valid_classes = c("Date", "POSIXt", "character"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -2197,7 +2202,7 @@ vec_fmt_time <- function(
   check_vector_valid(x, valid_classes = c("Date", "POSIXt", "character"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -3018,7 +3023,7 @@ vec_fmt_datetime <- function(
   check_vector_valid(x, valid_classes = c("Date", "POSIXct", "character"))
 
   # Ensure that `output` is matched correctly to one option
-  output <- rlang::arg_match(output)
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -3215,8 +3220,12 @@ vec_fmt_duration <- function(
   check_vector_valid(x, valid_classes = c("numeric", "integer", "difftime"))
 
   # Ensure that `duration_style` and `ouput` are matched correctly to one option
-  duration_style <- rlang::arg_match(duration_style)
-  output <- rlang::arg_match(output)
+  duration_style <- 
+    rlang::arg_match0(
+      duration_style,
+      values = c("narrow", "wide", "colon-sep", "iso")
+    )
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()
@@ -3310,8 +3319,12 @@ vec_fmt_markdown <- function(
   check_vector_valid(x)
 
   # Ensure that arguments are matched
-  md_engine <- rlang::arg_match(md_engine)
-  output <- rlang::arg_match(output)
+  md_engine <- 
+    rlang::arg_match0(
+      md_engine,
+      values = c("markdown", "commonmark")
+    )
+  output <- rlang::arg_match0(output, values = output_types)
 
   if (output == "auto") {
     output <- determine_output_format()

--- a/R/image.R
+++ b/R/image.R
@@ -420,7 +420,7 @@ ggplot_image <- function(
 #' @export
 test_image <- function(type = c("png", "svg")) {
 
-  type <- rlang::arg_match(type)
+  type <- rlang::arg_match0(type, values = c("png", "svg"))
 
   system_file(file = paste0("graphics/test_image.", type))
 }

--- a/R/info_tables.R
+++ b/R/info_tables.R
@@ -482,7 +482,7 @@ info_currencies <- function(
 ) {
 
   # Get the correct `type` value
-  type <- rlang::arg_match(type)
+  type <- rlang::arg_match0(type, values = c("code", "symbol"))
 
   if (type == "code") {
 

--- a/R/nanoplot.R
+++ b/R/nanoplot.R
@@ -743,8 +743,16 @@ cols_nanoplot <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Ensure that arguments are matched
-  missing_vals <- rlang::arg_match(missing_vals)
-  plot_type <- rlang::arg_match(plot_type)
+  missing_vals <- 
+    rlang::arg_match0(
+      missing_vals,
+      values = c("gap", "marker", "zero", "remove")
+    )
+  plot_type <- 
+    rlang::arg_match0(
+      plot_type,
+      values = c("line", "bar", "boxplot")
+    )
 
   #
   # Resolution of columns and rows as character vectors

--- a/R/opts.R
+++ b/R/opts.R
@@ -424,7 +424,8 @@ opt_interactive <- function(
   # Perform input object validation
   stop_if_not_gt_tbl(data = data)
 
-  pagination_type <- rlang::arg_match(pagination_type)
+  pagination_type <- 
+    rlang::arg_match0(pagination_type, values = c("numbers", "jump", "simple"))
 
   tab_options(
     data = data,
@@ -838,7 +839,7 @@ opt_align_table_header <- function(
   # Perform input object validation
   stop_if_not_gt_tbl(data = data)
 
-  align <- rlang::arg_match(align)
+  align <- rlang::arg_match0(align, values = c("left", "center", "right"))
 
   tab_options(
     data = data,
@@ -1264,7 +1265,7 @@ opt_table_lines <- function(
   # Perform input object validation
   stop_if_not_gt_tbl(data = data)
 
-  extent <- rlang::arg_match(extent)
+  extent <- rlang::arg_match0(extent, values = c("all", "none", "default"))
 
   # Normalize `extent` values to property values
   values_vec <- if (extent == "all") "solid" else extent

--- a/R/summary_rows.R
+++ b/R/summary_rows.R
@@ -379,11 +379,10 @@ summary_rows <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Get the correct `side` value
-  side <- rlang::arg_match(side)
+  side <- rlang::arg_match0(side, values = c("bottom", "top"))
 
   # Collect all provided formatting options in a list
   formatter_options <- list(...)
-
 
   # Perform a partial build of the table to obtain the current
   # state of `group_id` values in the table; we should not assign this
@@ -777,7 +776,7 @@ grand_summary_rows <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Get the correct `side` value
-  side <- rlang::arg_match(side)
+  side <- rlang::arg_match0(side, values = c("bottom", "top"))
 
   summary_rows(
     data = data,

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1129,7 +1129,7 @@ tab_spanner_delim <- function(
   stop_if_not_gt_tbl(data = data)
 
   # Ensure that arguments are matched
-  split <- rlang::arg_match(split)
+  split <- rlang::arg_match0(split, values = c("last", "first"))
 
   # Perform various input checks for `limit` if it is provided
   check_number_whole(limit, min = 1, allow_null = TRUE, allow_infinite = FALSE)

--- a/R/tab_footnote.R
+++ b/R/tab_footnote.R
@@ -369,7 +369,7 @@ tab_footnote <- function(
   # Perform input object validation
   stop_if_not_gt_tbl(data = data)
 
-  placement <- rlang::arg_match(placement)
+  placement <- rlang::arg_match0(placement, values = c("auto", "right", "left"))
   rlang::check_required(footnote)
 
   if (is.null(locations)) {

--- a/R/text_transform.R
+++ b/R/text_transform.R
@@ -370,7 +370,7 @@ text_case_match <- function(
   stop_if_not_gt_tbl(data = .data)
 
   # Ensure that arguments are matched
-  .replace <- rlang::arg_match(.replace)
+  .replace <- rlang::arg_match0(.replace, values = c("all", "partial"))
 
   x_list <- list(...)
 

--- a/R/utils_color_contrast.R
+++ b/R/utils_color_contrast.R
@@ -54,7 +54,7 @@ get_contrast_ratio <- function(
 ) {
 
   # Get the correct `algo` value
-  algo <- rlang::arg_match(algo)
+  algo <- rlang::arg_match0(algo, values = c("apca", "wcag"))
 
   if (length(color_1) < 1L || length(color_2) < 1L) {
     cli::cli_abort(

--- a/R/utils_plots.R
+++ b/R/utils_plots.R
@@ -2059,7 +2059,7 @@ get_extreme_value <- function(..., stat = c("max", "min")) {
 
   value_list <- list(...)
 
-  stat <- rlang::arg_match(stat)
+  stat <- rlang::arg_match0(stat, values = c("max", "min"))
 
   value_list_vec <- unlist(value_list)
 


### PR DESCRIPTION
Continuing on the work @olivroy has been doing, this PR makes a few more replacements of `arg_match()` to `arg_match0()` to increase performance.

With a particularly demanding set of nanoplots in the table of the following code, we get a pretty decent speedup.

```r
library(gt)

gibraltar |>
    dplyr::filter(date <= "2023-05-14") |>
    dplyr::mutate(time = as.numeric(hms::as_hms(paste0(time, ":00")))) |>
    dplyr::mutate(humidity = humidity * 100) |>
    dplyr::select(date, time, temp, humidity, wind_speed) |>
    dplyr::group_by(date) |>
    dplyr::summarize(
      time = paste(time, collapse = ","),
      temp = paste(temp, collapse = ","),
      humidity = paste(humidity, collapse = ","),
      wind_speed = paste(wind_speed, collapse = ","),
    ) |>
    dplyr::mutate(is_satsun = lubridate::wday(date) %in% c(1, 7)) |>
    gt(rowname_col = "date") |>
    tab_header(
      title = "Meteorological Summary of Gibraltar Station",
      subtitle = "Data taken from May 1-14, 2023."
    ) |>
    fmt_date(columns = stub(), date_style = "wd_m_day_year") |>
    cols_nanoplot(
      columns = temp,
      columns_x_vals = time,
      expand_x = c(0, 86400),
      autoscale = TRUE,
      new_col_name = "temperature_nano",
      new_col_label = "Temperature"
    ) |>
    cols_nanoplot(
      columns = humidity,
      columns_x_vals = time,
      expand_x = c(0, 86400),
      autoscale = TRUE,
      new_col_name = "humidity_nano",
      new_col_label = "Humidity"
    ) |>
    cols_nanoplot(
      columns = wind_speed,
      columns_x_vals = time,
      expand_x = c(0, 86400),
      autoscale = TRUE,
      new_col_name = "wind_speed_nano",
      new_col_label = "Wind Speed"
    ) |>
    cols_units(
      temperature_nano = ":degree:C",
      humidity_nano = "% (RH)",
      wind_speed_nano = "m s^-1"
    ) |>
    cols_hide(columns = is_satsun) |>
    tab_style_body(
      style = cell_fill(color = "#E5FEFE"),
      values = TRUE,
      targets = "row",
      extents = c("body", "stub")
    ) |>
    tab_style(
      style = cell_text(align = "center"),
      locations = cells_column_labels()
    )
``` 

Here are the profvis results...

...before PR:

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/b2d3aa90-9fd8-40a2-bc81-cabc176fa57d">

...after PR:

<img width="1232" alt="image" src="https://github.com/user-attachments/assets/b2763b9c-220b-4c19-a445-725e48e48431">
