### PR TITLE
Fix doc typos

### DIFF
--- a/R/cols_add.R
+++ b/R/cols_add.R
@@ -72,7 +72,7 @@
 #' @section Targeting the column for insertion with `.before` or `.after`:
 #'
 #' The targeting of a column for insertion is done through the `.before` or
-#' `.after` arguments (only one of these options should be be used). While
+#' `.after` arguments (only one of these options should be used). While
 #' **tidyselect**-style expressions or indices can used to target a column, it's
 #' advised that a single column name be used. This is to avoid the possibility
 #' of inadvertently resolving multiple columns (since the requirement is for a

--- a/R/data_color.R
+++ b/R/data_color.R
@@ -27,7 +27,7 @@
 #' @description
 #'
 #' It's possible to add color to data cells according to their values with
-#' `data_color()` There is a multitude of ways to perform data cell
+#' `data_color()`. There is a multitude of ways to perform data cell
 #' colorizing here:
 #'
 #' - targeting: we can constrain which columns and rows should receive the
@@ -44,7 +44,7 @@
 #' for finer control over color evaluation with data; the `scales::col_*()`
 #' color mapping functions can be used here or any function you might want to define
 #' - color palettes: with `palette` we could supply a vector of colors, a
-#' **virdis** or **RColorBrewer** palette name, or, a palette from the
+#' **viridis** or **RColorBrewer** palette name, or, a palette from the
 #' **paletteer** package
 #' - value domain: we can either opt to have the range of values define the
 #' domain, or, specify one explicitly with the `domain` argument

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -740,7 +740,7 @@
 #' \item `"HBDH"`: hydroxybutyrate dehydrogenase.
 #' \item `"CK"`: creatine kinase.
 #' \item `"CKMB"`: the MB fraction of creatine kinase.
-#' \item `"BNP"`: B-type natriuetic peptide.
+#' \item `"BNP"`: B-type natriuretic peptide.
 #' \item `"MYO"`: myohemoglobin.
 #' \item `"TnI"`: troponin inhibitory.
 #' \item `"CREA"`: creatinine.

--- a/R/fmt_number.R
+++ b/R/fmt_number.R
@@ -144,7 +144,7 @@
 #'   scaling.
 #'
 #'   We can alternatively provide a character vector that serves as a
-#'   specification for which symbols are to used for each of the value ranges.
+#'   specification for which symbols are to be used for each of the value ranges.
 #'   These preferred symbols will replace the defaults (e.g.,
 #'   `c("k", "Ml", "Bn", "Tr")` replaces `"K"`, `"M"`, `"B"`, and `"T"`).
 #'
@@ -215,7 +215,7 @@
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported. A locale ID can
 #'   be also set in the initial [gt()] function call (where it would be used
@@ -646,7 +646,7 @@ fmt_number <- function(
 #'   billions (`B`), and trillions (`T`) suffixes after automatic value scaling.
 #'
 #'   We can alternatively provide a character vector that serves as a
-#'   specification for which symbols are to used for each of the value ranges.
+#'   specification for which symbols are to be used for each of the value ranges.
 #'   These preferred symbols will replace the defaults (e.g.,
 #'   `c("k", "Ml", "Bn", "Tr")` replaces `"K"`, `"M"`, `"B"`, and `"T"`).
 #'

--- a/R/format_vec.R
+++ b/R/format_vec.R
@@ -67,7 +67,7 @@ output_types <- c("auto", "plain", "html", "latex", "rtf", "word")
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -235,7 +235,7 @@ vec_fmt_number <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -373,7 +373,7 @@ vec_fmt_integer <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -531,7 +531,7 @@ vec_fmt_scientific <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -687,7 +687,7 @@ vec_fmt_engineering <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -871,7 +871,7 @@ vec_fmt_percent <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -1046,7 +1046,7 @@ vec_fmt_partsper <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -1212,7 +1212,7 @@ vec_fmt_fraction <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -1464,7 +1464,7 @@ vec_fmt_roman <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for
 #'   a useful reference for all of the locales that are supported.
 #'
@@ -1589,7 +1589,7 @@ vec_fmt_index <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -1740,7 +1740,7 @@ vec_fmt_spelled_num <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -1885,7 +1885,7 @@ vec_fmt_bytes <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -2068,7 +2068,7 @@ vec_fmt_date <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -2241,7 +2241,7 @@ vec_fmt_time <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'
@@ -3086,7 +3086,7 @@ vec_fmt_datetime <- function(
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for formatting values
-#'   according the locale's rules. Examples include `"en"` for English (United
+#'   according to the locale's rules. Examples include `"en"` for English (United
 #'   States) and `"fr"` for French (France). We can call [info_locales()] for a
 #'   useful reference for all of the locales that are supported.
 #'

--- a/R/info_tables.R
+++ b/R/info_tables.R
@@ -37,7 +37,7 @@
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for displaying formatted
-#'   date values according the locale's rules. Examples include `"en"` for
+#'   date values according to the locale's rules. Examples include `"en"` for
 #'   English (United States) and `"fr"` for French (France). We can call
 #'   [info_locales()] for a useful reference for all of the locales that are
 #'   supported.
@@ -220,7 +220,7 @@ info_date_style <- function(locale = NULL) {
 #'   `scalar<character>` // *default:* `NULL` (`optional`)
 #'
 #'   An optional locale identifier that can be used for displaying formatted
-#'   time values according the locale's rules. Examples include `"en"` for
+#'   time values according to the locale's rules. Examples include `"en"` for
 #'   English (United States) and `"fr"` for French (France). We can call
 #'   [info_locales()] for a useful reference for all of the locales that are
 #'   supported.

--- a/R/rows_add.R
+++ b/R/rows_add.R
@@ -91,7 +91,7 @@
 #' @section Targeting the row for insertion with `.before` or `.after`:
 #'
 #' The targeting of a row for insertion is done through the `.before` or
-#' `.after` arguments (only one of these options should be be used). This can be
+#' `.after` arguments (only one of these options should be used). This can be
 #' done in a variety of ways. If a stub is present, then we potentially have row
 #' identifiers. This is the ideal method to use for establishing a row target.
 #' We can use **tidyselect**-style expressions to target a row. It's also

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -1800,7 +1800,7 @@ tab_row_group <- function(
 #' `r man_get_image_tag(file = "man_tab_stubhead_1.png")`
 #' }}
 #'
-#' The stuhead can contain all sorts of interesting content. How about an icon
+#' The stubhead can contain all sorts of interesting content. How about an icon
 #' for a car? We can make this happen with help from the **fontawesome**
 #' package.
 #'

--- a/man/cols_add.Rd
+++ b/man/cols_add.Rd
@@ -60,7 +60,7 @@ types (e.g., \code{NA}, \code{NA_character_}, \code{NA_real_}, etc.) for such co
 
 
 The targeting of a column for insertion is done through the \code{.before} or
-\code{.after} arguments (only one of these options should be be used). While
+\code{.after} arguments (only one of these options should be used). While
 \strong{tidyselect}-style expressions or indices can used to target a column, it's
 advised that a single column name be used. This is to avoid the possibility
 of inadvertently resolving multiple columns (since the requirement is for a

--- a/man/data_color.Rd
+++ b/man/data_color.Rd
@@ -215,7 +215,7 @@ An object of class \code{gt_tbl}.
 }
 \description{
 It's possible to add color to data cells according to their values with
-\code{data_color()} There is a multitude of ways to perform data cell
+\code{data_color()}. There is a multitude of ways to perform data cell
 colorizing here:
 \itemize{
 \item targeting: we can constrain which columns and rows should receive the
@@ -232,7 +232,7 @@ specific methods
 for finer control over color evaluation with data; the \verb{scales::col_*()}
 color mapping functions can be used here or any function you might want to define
 \item color palettes: with \code{palette} we could supply a vector of colors, a
-\strong{virdis} or \strong{RColorBrewer} palette name, or, a palette from the
+\strong{viridis} or \strong{RColorBrewer} palette name, or, a palette from the
 \strong{paletteer} package
 \item value domain: we can either opt to have the range of values define the
 domain, or, specify one explicitly with the \code{domain} argument

--- a/man/fmt_auto.Rd
+++ b/man/fmt_auto.Rd
@@ -63,7 +63,7 @@ values only).}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_bytes.Rd
+++ b/man/fmt_bytes.Rd
@@ -149,7 +149,7 @@ The default is to use a space character for separation.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_country.Rd
+++ b/man/fmt_country.Rd
@@ -63,7 +63,7 @@ character (\code{" "}).}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_currency.Rd
+++ b/man/fmt_currency.Rd
@@ -151,7 +151,7 @@ billions (\code{"B"}), and trillions (\code{"T"}) suffixes after automatic value
 scaling.
 
 We can alternatively provide a character vector that serves as a
-specification for which symbols are to used for each of the value ranges.
+specification for which symbols are to be used for each of the value ranges.
 These preferred symbols will replace the defaults (e.g.,
 \code{c("k", "Ml", "Bn", "Tr")} replaces \code{"K"}, \code{"M"}, \code{"B"}, and \code{"T"}).
 
@@ -236,7 +236,7 @@ crore, and higher quantities.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_date.Rd
+++ b/man/fmt_date.Rd
@@ -63,7 +63,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_datetime.Rd
+++ b/man/fmt_datetime.Rd
@@ -103,7 +103,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_duration.Rd
+++ b/man/fmt_duration.Rd
@@ -158,7 +158,7 @@ crore, and higher quantities.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_engineering.Rd
+++ b/man/fmt_engineering.Rd
@@ -134,7 +134,7 @@ will display a sign.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_flag.Rd
+++ b/man/fmt_flag.Rd
@@ -70,7 +70,7 @@ hovering over the flag icon.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_fraction.Rd
+++ b/man/fmt_fraction.Rd
@@ -117,7 +117,7 @@ crore, and higher quantities.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_index.Rd
+++ b/man/fmt_index.Rd
@@ -73,7 +73,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_integer.Rd
+++ b/man/fmt_integer.Rd
@@ -84,7 +84,7 @@ transformation and \code{TRUE} will apply thousands (\code{K}), millions (\code{
 billions (\code{B}), and trillions (\code{T}) suffixes after automatic value scaling.
 
 We can alternatively provide a character vector that serves as a
-specification for which symbols are to used for each of the value ranges.
+specification for which symbols are to be used for each of the value ranges.
 These preferred symbols will replace the defaults (e.g.,
 \code{c("k", "Ml", "Bn", "Tr")} replaces \code{"K"}, \code{"M"}, \code{"B"}, and \code{"T"}).
 
@@ -146,7 +146,7 @@ crore, and higher quantities.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_number.Rd
+++ b/man/fmt_number.Rd
@@ -125,7 +125,7 @@ billions (\code{"B"}), and trillions (\code{"T"}) suffixes after automatic value
 scaling.
 
 We can alternatively provide a character vector that serves as a
-specification for which symbols are to used for each of the value ranges.
+specification for which symbols are to be used for each of the value ranges.
 These preferred symbols will replace the defaults (e.g.,
 \code{c("k", "Ml", "Bn", "Tr")} replaces \code{"K"}, \code{"M"}, \code{"B"}, and \code{"T"}).
 
@@ -196,7 +196,7 @@ crore, and higher quantities.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_partsper.Rd
+++ b/man/fmt_partsper.Rd
@@ -172,7 +172,7 @@ crore, and higher quantities.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_percent.Rd
+++ b/man/fmt_percent.Rd
@@ -167,7 +167,7 @@ crore, and higher quantities.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_scientific.Rd
+++ b/man/fmt_scientific.Rd
@@ -146,7 +146,7 @@ will display a sign.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_spelled_num.Rd
+++ b/man/fmt_spelled_num.Rd
@@ -54,7 +54,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_tf.Rd
+++ b/man/fmt_tf.Rd
@@ -120,7 +120,7 @@ receive a left alignment (for words in LTR languages).}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/fmt_time.Rd
+++ b/man/fmt_time.Rd
@@ -64,7 +64,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported. A locale ID can
 be also set in the initial \code{\link[=gt]{gt()}} function call (where it would be used

--- a/man/illness.Rd
+++ b/man/illness.Rd
@@ -56,7 +56,7 @@ provides the full names of any abbreviations seen in that column.
 \item \code{"HBDH"}: hydroxybutyrate dehydrogenase.
 \item \code{"CK"}: creatine kinase.
 \item \code{"CKMB"}: the MB fraction of creatine kinase.
-\item \code{"BNP"}: B-type natriuetic peptide.
+\item \code{"BNP"}: B-type natriuretic peptide.
 \item \code{"MYO"}: myohemoglobin.
 \item \code{"TnI"}: troponin inhibitory.
 \item \code{"CREA"}: creatinine.

--- a/man/info_date_style.Rd
+++ b/man/info_date_style.Rd
@@ -12,7 +12,7 @@ info_date_style(locale = NULL)
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for displaying formatted
-date values according the locale's rules. Examples include \code{"en"} for
+date values according to the locale's rules. Examples include \code{"en"} for
 English (United States) and \code{"fr"} for French (France). We can call
 \code{\link[=info_locales]{info_locales()}} for a useful reference for all of the locales that are
 supported.}

--- a/man/info_time_style.Rd
+++ b/man/info_time_style.Rd
@@ -12,7 +12,7 @@ info_time_style(locale = NULL)
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for displaying formatted
-time values according the locale's rules. Examples include \code{"en"} for
+time values according to the locale's rules. Examples include \code{"en"} for
 English (United States) and \code{"fr"} for French (France). We can call
 \code{\link[=info_locales]{info_locales()}} for a useful reference for all of the locales that are
 supported.}

--- a/man/rows_add.Rd
+++ b/man/rows_add.Rd
@@ -81,7 +81,7 @@ table.
 
 
 The targeting of a row for insertion is done through the \code{.before} or
-\code{.after} arguments (only one of these options should be be used). This can be
+\code{.after} arguments (only one of these options should be used). This can be
 done in a variety of ways. If a stub is present, then we potentially have row
 identifiers. This is the ideal method to use for establishing a row target.
 We can use \strong{tidyselect}-style expressions to target a row. It's also

--- a/man/tab_stubhead.Rd
+++ b/man/tab_stubhead.Rd
@@ -54,7 +54,7 @@ describe what's in the stub.
 <img src="https://raw.githubusercontent.com/rstudio/gt/master/images/man_tab_stubhead_1.png" alt="This image of a table was generated from the first code example in the `tab_stubhead()` help file." style="width:100\%;">
 }}
 
-The stuhead can contain all sorts of interesting content. How about an icon
+The stubhead can contain all sorts of interesting content. How about an icon
 for a car? We can make this happen with help from the \strong{fontawesome}
 package.
 

--- a/man/vec_fmt_bytes.Rd
+++ b/man/vec_fmt_bytes.Rd
@@ -128,7 +128,7 @@ The default is to use a space character for separation.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_currency.Rd
+++ b/man/vec_fmt_currency.Rd
@@ -121,7 +121,7 @@ billions (\code{"B"}), and trillions (\code{"T"}) suffixes after automatic value
 scaling.
 
 We can alternatively provide a character vector that serves as a
-specification for which symbols are to used for each of the value ranges.
+specification for which symbols are to be used for each of the value ranges.
 These preferred symbols will replace the defaults (e.g.,
 \code{c("k", "Ml", "Bn", "Tr")} replaces \code{"K"}, \code{"M"}, \code{"B"}, and \code{"T"}).
 
@@ -196,7 +196,7 @@ symbol. The default is to not introduce a space character.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_date.Rd
+++ b/man/vec_fmt_date.Rd
@@ -42,7 +42,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_datetime.Rd
+++ b/man/vec_fmt_datetime.Rd
@@ -82,7 +82,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_duration.Rd
+++ b/man/vec_fmt_duration.Rd
@@ -126,7 +126,7 @@ default only negative values will display a minus sign.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_engineering.Rd
+++ b/man/vec_fmt_engineering.Rd
@@ -113,7 +113,7 @@ will display a sign.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_fraction.Rd
+++ b/man/vec_fmt_fraction.Rd
@@ -85,7 +85,7 @@ value of \code{"1,000"}. This argument is ignored if a \code{locale} is supplied
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_index.Rd
+++ b/man/vec_fmt_index.Rd
@@ -52,7 +52,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for
 a useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_integer.Rd
+++ b/man/vec_fmt_integer.Rd
@@ -62,7 +62,7 @@ transformation and \code{TRUE} will apply thousands (\code{K}), millions (\code{
 billions (\code{B}), and trillions (\code{T}) suffixes after automatic value scaling.
 
 We can alternatively provide a character vector that serves as a
-specification for which symbols are to used for each of the value ranges.
+specification for which symbols are to be used for each of the value ranges.
 These preferred symbols will replace the defaults (e.g.,
 \code{c("k", "Ml", "Bn", "Tr")} replaces \code{"K"}, \code{"M"}, \code{"B"}, and \code{"T"}).
 
@@ -114,7 +114,7 @@ This option is disregarded when using accounting notation with
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_number.Rd
+++ b/man/vec_fmt_number.Rd
@@ -103,7 +103,7 @@ billions (\code{"B"}), and trillions (\code{"T"}) suffixes after automatic value
 scaling.
 
 We can alternatively provide a character vector that serves as a
-specification for which symbols are to used for each of the value ranges.
+specification for which symbols are to be used for each of the value ranges.
 These preferred symbols will replace the defaults (e.g.,
 \code{c("k", "Ml", "Bn", "Tr")} replaces \code{"K"}, \code{"M"}, \code{"B"}, and \code{"T"}).
 
@@ -164,7 +164,7 @@ This option is disregarded when using accounting notation with
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_partsper.Rd
+++ b/man/vec_fmt_partsper.Rd
@@ -140,7 +140,7 @@ the mark itself. This can be directly controlled by using either \code{TRUE} or
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_percent.Rd
+++ b/man/vec_fmt_percent.Rd
@@ -135,7 +135,7 @@ be \code{"right"} (the default) or \code{"left"}.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_scientific.Rd
+++ b/man/vec_fmt_scientific.Rd
@@ -125,7 +125,7 @@ will display a sign.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_spelled_num.Rd
+++ b/man/vec_fmt_spelled_num.Rd
@@ -33,7 +33,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 

--- a/man/vec_fmt_time.Rd
+++ b/man/vec_fmt_time.Rd
@@ -43,7 +43,7 @@ literals.}
 \verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
 
 An optional locale identifier that can be used for formatting values
-according the locale's rules. Examples include \code{"en"} for English (United
+according to the locale's rules. Examples include \code{"en"} for English (United
 States) and \code{"fr"} for French (France). We can call \code{\link[=info_locales]{info_locales()}} for a
 useful reference for all of the locales that are supported.}
 


### PR DESCRIPTION
Fixes a few typos in the documentation.
Thanks for a great package!
