### PR TITLE
More efficient `rownum_translation()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt (development version)
 
+* Significantly faster rendering of certain large tables, by optimizing the internal `rownum_translation()` utility. (@magnusdv, #1924) 
+
 * Interactive tables can support selection through the `ihtml.selection_mode` option. (@jonthegeek, #1909)
 
 * Tables embedded in Shiny apps with `gt_output()` and `render_gt()` with `ihtml.selection_mode` enabled also act as inputs, reporting the row numbers that are selected (#354, #1368). (@jonthegeek, #1909)

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -63,19 +63,7 @@ colname_to_colnum <- function(
 # Utility function to generate finalized row numbers;
 # used in: `resolve_footnotes_styles()`
 rownum_translation <- function(body, rownum_start) {
-
-  rownum_final <- c()
-
-  for (rownum_s in rownum_start) {
-
-    rownum_final <-
-      c(
-        rownum_final,
-        which(as.numeric(rownames(body)) == rownum_s)
-      )
-  }
-
-  rownum_final
+  match(rownum_start, as.numeric(rownames(body)))
 }
 
 #' Render any formatting directives available in the `formats` list


### PR DESCRIPTION
# Summary

This PR improves the performance of `rownum_translation()`, replacing an inefficient loop with `match()`. Closes #1924.

# Related GitHub Issues and PRs

- Ref: #1924

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.