### PR TITLE
Autocoloroptions

### DIFF
--- a/R/data_color.R
+++ b/R/data_color.R
@@ -57,7 +57,8 @@
 #' text
 #' - text autocoloring: if colorizing the cell background, `data_color()` will
 #' automatically recolor the foreground text to provide the best contrast (can
-#' be deactivated with `autocolor_text = FALSE`)
+#' be deactivated with `autocolor_text = FALSE`; a light and dark color to be
+#' used can be specified with `autocolor_light` and `autocolor_dark`)
 #'
 #' `data_color()` won't fail with the default options used, but
 #' that won't typically provide you the type of colorization you really need.
@@ -233,6 +234,22 @@
 #'   default this is `"apca"` (Accessible Perceptual Contrast Algorithm) and the
 #'   alternative to this is `"wcag"` (Web Content Accessibility Guidelines).
 #'
+#' @param autocolor_light
+#'
+#'   `scalar<character>` // *default:* `"white"`
+#'
+#'   The light color to use when `autocolor_text = TRUE`. By default the color
+#'   `"white"` will be used (`#FFFFFF"`). Alpha channel values will be set to
+#'   1.0 (fully opaque).
+#'
+#' @param autocolor_dark
+#'
+#'   `scalar<character>` // *default:* `"black"`
+#'
+#'   The dark color to use when `autocolor_text = TRUE`. By default the color
+#'   `"black"` will be used (`#000000"`). Alpha channel values will be set to
+#'   1.0 (fully opaque).
+#'
 #' @param colors *[Deprecated] Color mapping function*
 #'
 #'   `function` // *default:* `NULL` (`optional`)
@@ -363,7 +380,9 @@
 #' setting `autocolor_text` to `FALSE`. The `contrast_algo` argument lets us
 #' choose between two color contrast algorithms: `"apca"` (*Accessible
 #' Perceptual Contrast Algorithm*, the default algo) and `"wcag"` (*Web Content
-#' Accessibility Guidelines*).
+#' Accessibility Guidelines*). `autocolor_light` and `autocolor_dark` allow for
+#' further customization, however, should only be used if you are sure that
+#' accessibility criteria are guaranteed.
 #'
 #' @section Examples:
 #'
@@ -669,6 +688,8 @@ data_color <- function(
     apply_to = c("fill", "text"),
     autocolor_text = TRUE,
     contrast_algo = c("apca", "wcag"),
+    autocolor_light = "#FFFFFF",
+    autocolor_dark = "#000000",
     colors = NULL
 ) {
 
@@ -679,7 +700,7 @@ data_color <- function(
   direction <- rlang::arg_match0(direction, values = c("column", "row"))
 
   # Get the correct `method` value
-  method <- 
+  method <-
     rlang::arg_match0(
       method,
       values = c("auto", "numeric", "bin", "quantile", "factor")
@@ -1122,6 +1143,8 @@ data_color <- function(
       color_vals <-
         ideal_fgnd_color(
           bgnd_color = color_vals,
+          light = autocolor_light,
+          dark = autocolor_dark,
           algo = contrast_algo
         )
 
@@ -1268,8 +1291,10 @@ expand_short_hex <- function(colors) {
 
 #' For a background color, which foreground color provides better contrast?
 #'
-#' The input for this function is a single color value in 'rgba()' format. The
-#' output is a single color value in #RRGGBB hexadecimal format
+#' The `bgnd_color` input for this function is a single color value in 'rgba()'
+#' format. The output is a single color value in #RRGGBB hexadecimal format.
+#' `light` and `dark` accepts every color(specification) that can be handled by
+#' {farver}.
 #'
 #' @noRd
 ideal_fgnd_color <- function(
@@ -1282,6 +1307,9 @@ ideal_fgnd_color <- function(
   # Get the correct `algo` value
   algo <- rlang::arg_match0(algo, values = c("apca", "wcag"))
 
+  light_color <- farver::encode_colour(farver::decode_colour(light))
+  dark_color <- farver::encode_colour(farver::decode_colour(dark))
+
   # Normalize color to hexadecimal color if it is in the 'rgba()' string format
   bgnd_color <- rgba_to_hex(colors = bgnd_color)
 
@@ -1291,17 +1319,17 @@ ideal_fgnd_color <- function(
   if (algo == "apca") {
 
     # Determine the ideal color for the chosen background color with APCA
-    contrast_dark <- get_contrast_ratio(color_1 = dark, color_2 = bgnd_color, algo = "apca")[, 1]
-    contrast_light <- get_contrast_ratio(color_1 = light, color_2 = bgnd_color, algo = "apca")[, 1]
+    contrast_dark <- get_contrast_ratio(color_1 = dark_color, color_2 = bgnd_color, algo = "apca")[, 1]
+    contrast_light <- get_contrast_ratio(color_1 = light_color, color_2 = bgnd_color, algo = "apca")[, 1]
 
   } else {
 
     # Determine the ideal color for the chosen background color with WCAG
-    contrast_dark <- get_contrast_ratio(color_1 = dark, color_2 = bgnd_color, algo = "wcag")
-    contrast_light <- get_contrast_ratio(color_1 = light, color_2 = bgnd_color, algo = "wcag")
+    contrast_dark <- get_contrast_ratio(color_1 = dark_color, color_2 = bgnd_color, algo = "wcag")
+    contrast_light <- get_contrast_ratio(color_1 = light_color, color_2 = bgnd_color, algo = "wcag")
   }
 
-  ifelse(abs(contrast_dark) >= abs(contrast_light), dark, light)
+  ifelse(abs(contrast_dark) >= abs(contrast_light), dark_color, light_color)
 }
 
 #' Convert colors in mixed formats (incl. rgba() strings) format to hexadecimal

--- a/R/utils_color_contrast.R
+++ b/R/utils_color_contrast.R
@@ -135,7 +135,7 @@ get_relative_luminance_wcag <- function(col) {
 
   coef <- round(c(apca_coeffs$sRco, apca_coeffs$sGco, apca_coeffs$sBco), 4)
 
-  rgb[] <- ifelse(rgb <= 0.03928, rgb / 12.92, ((rgb + 0.055) / 1.055)^2.4)
+  rgb[] <- ifelse(rgb <= 0.04045, rgb / 12.92, ((rgb + 0.055) / 1.055)^2.4)
 
   as.numeric(rgb %*% coef)
 }

--- a/man/data_color.Rd
+++ b/man/data_color.Rd
@@ -24,6 +24,8 @@ data_color(
   apply_to = c("fill", "text"),
   autocolor_text = TRUE,
   contrast_algo = c("apca", "wcag"),
+  autocolor_light = "#FFFFFF",
+  autocolor_dark = "#000000",
   colors = NULL
 )
 }
@@ -202,6 +204,18 @@ The color contrast algorithm to use when \code{autocolor_text = TRUE}. By
 default this is \code{"apca"} (Accessible Perceptual Contrast Algorithm) and the
 alternative to this is \code{"wcag"} (Web Content Accessibility Guidelines).}
 
+\item{autocolor_light}{\verb{scalar<character>} // \emph{default:} \code{"white"}
+
+The light color to use when \code{autocolor_text = TRUE}. By default the color
+\code{"white"} will be used (\verb{#FFFFFF"}). Alpha channel values will be set to
+1.0 (fully opaque).}
+
+\item{autocolor_dark}{\verb{scalar<character>} // \emph{default:} \code{"black"}
+
+The dark color to use when \code{autocolor_text = TRUE}. By default the color
+\code{"black"} will be used (\verb{#000000"}). Alpha channel values will be set to
+1.0 (fully opaque).}
+
 \item{colors}{\emph{\link{Deprecated} Color mapping function}
 
 \code{function} // \emph{default:} \code{NULL} (\code{optional})
@@ -245,7 +259,8 @@ whether to apply the cell-specific colors to the cell background or the cell
 text
 \item text autocoloring: if colorizing the cell background, \code{data_color()} will
 automatically recolor the foreground text to provide the best contrast (can
-be deactivated with \code{autocolor_text = FALSE})
+be deactivated with \code{autocolor_text = FALSE}; a light and dark color to be
+used can be specified with \code{autocolor_light} and \code{autocolor_dark})
 }
 
 \code{data_color()} won't fail with the default options used, but
@@ -383,7 +398,9 @@ when colorizing the background of data cells. This option can be disabled by
 setting \code{autocolor_text} to \code{FALSE}. The \code{contrast_algo} argument lets us
 choose between two color contrast algorithms: \code{"apca"} (\emph{Accessible
 Perceptual Contrast Algorithm}, the default algo) and \code{"wcag"} (\emph{Web Content
-Accessibility Guidelines}).
+Accessibility Guidelines}). \code{autocolor_light} and \code{autocolor_dark} allow for
+further customization, however, should only be used if you are sure that
+accessibility criteria are guaranteed.
 }
 
 \section{Examples}{


### PR DESCRIPTION
I have added light and dark `autocolor_text` color options. Often, tables are embedded in a context and in there "black" is not black, but another very dark color and analogously for white. Being able to design the tables in harmony is central.

The current implementation follows the previous design of {gt}, particularly `data_color()`, but/thus it is unattractive in that if `autocolor = FALSE`, now allready 3 arguments are irrelevant.

- [ x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.

I did not add tests (as far as now), also because I first want to be sure that the maintaineres support this feature.

Additionally, I fixed a constant in the calculation of relative luminance WCAG (according to [documentation](https://www.w3.org/TR/WCAG21/#dfn-relative-luminance)).