### PR TITLE
fix bookdown::html_document2 cross-ref

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt (development version)
 
+* Fixed an issue where cross-references would fail in bookdown::html_document2 (@olivroy, #1948)
+
 * Significantly faster rendering of certain large tables, by optimizing the internal `rownum_translation()` utility. (@magnusdv, #1924) 
 
 * Interactive tables can support selection through the `ihtml.selection_mode` option. (@jonthegeek, #1909)

--- a/R/knitr-utils.R
+++ b/R/knitr-utils.R
@@ -40,7 +40,11 @@ kable_caption <- function(label, caption, format) {
 
 create_label <- function(..., latex = FALSE) {
   if (isTRUE(knitr::opts_knit$get("bookdown.internal.label"))) {
-    lab1 <- "(\\#"
+    if (latex) {
+      lab1 <- "(\\#"
+    } else {
+      lab1 <- "(#"
+    }
     lab2 <- ")"
   } else if (latex) {
     lab1 <- "\\label{"

--- a/tests/testthat/test-utils_render_html.R
+++ b/tests/testthat/test-utils_render_html.R
@@ -41,7 +41,7 @@ test_that("bookdown-style crossrefs are added when appropriate", {
 
   # If bookdown, then ref is generated
   knitr::opts_knit$set(bookdown.internal.label = TRUE)
-  expect_caption_eq("test", "(\\#tab:foo)test")
+  expect_caption_eq("test", "(#tab:foo)test")
 
   expect_null(create_caption_component_h(exibble %>% gt()))
 


### PR DESCRIPTION
# Summary

@nielsbock I verified that the captions still work with pdf documents.

In #1800, there was 

```diff
-   lab1 <- "(#"
+   lab1 <- "(\\#"
```

I suspect this was required to make it work with LaTeX?

Therefore, I just branched it and make gt emit a different string whether latex or not.

Verified that the example in the linked issue renders in both bookdown::html_document2 and bookdown::pdf_document2.

(edit: pkgdown CI failure unrelated) 

# Related GitHub Issues and PRs

- Ref: Fixes #1948

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
