### PR TITLE
Fix issue with markdown and Quarto

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # gt (development version)
 
-* Fixed an issue where `fmt_markdown()` could create strange output in Quarto (html and Typst formats) (@olivroy, #1957, [quarto-dev/quarto-cli#11932](https://github.com/quarto-dev/quarto-cli/issues/11932)).
-  This means that using  `#| html-table-processing: none` may no longer work as expected in some cases.
+* Fixed an issue where `fmt_markdown()` could create strange output in Quarto (html and Typst formats) (@olivroy, #1957, [quarto-dev/quarto-cli#11932](https://github.com/quarto-dev/quarto-cli/issues/11932), [quarto-dev/quarto-cli#11610](https://github.com/quarto-dev/quarto-cli/issues/11610)).
  
 * The default table position in LaTeX is now "t" instead of "!t" (@AaronGullickson, #1935).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gt (development version)
 
+* Fixed an issue where `fmt_markdown()` could create strange output in Quarto (html and Typst formats) (@olivroy, #1957, [quarto-dev/quarto-cli#11932](https://github.com/quarto-dev/quarto-cli/issues/11932)).
+  This means that using  `#| html-table-processing: none` may no longer work as expected in some cases.
+ 
 * The default table position in LaTeX is now "t" instead of "!t" (@AaronGullickson, #1935).
 
 * Fixed an issue where cross-references would fail in bookdown::html_document2 (@olivroy, #1948)

--- a/R/quarto.R
+++ b/R/quarto.R
@@ -42,12 +42,15 @@ process_md_quarto <- function(text, md_engine_fn) {
 
   # Remove paragraph
   non_na_text_processed <- gsub("^<p>|</p>\n$", "", non_na_text_processed)
-  # Use base64 encoding to avoid issues with escaping internal double
+
+  # Use base64 encoding on the unprocessed text
+  # https://github.com/quarto-dev/quarto-cli/issues/11932#issuecomment-2609871584
+  # to avoid issues with escaping internal double
   # quotes; used in conjunction with the 'data-qmd-base64' attribute
   # that is recognized by Quarto
   non_na_text <-
     vapply(
-      non_na_text_processed,
+      non_na_text,
       FUN.VALUE = character(1L),
       USE.NAMES = FALSE,
       FUN = function(text) {

--- a/tests/testthat/_snaps/quarto.md
+++ b/tests/testthat/_snaps/quarto.md
@@ -6,7 +6,7 @@
       <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
         <thead>
           <tr class="gt_heading">
-            <td colspan="4" class="gt_heading gt_title gt_font_normal gt_bottom_border" style><span data-qmd-base64="PGEgaHJlZj0iaHR0cHM6Ly9nb29nbGUuY29tIj5nb2c8L2E+"><span class='gt_from_md'><a href="https://google.com">gog</a></span></span></td>
+            <td colspan="4" class="gt_heading gt_title gt_font_normal gt_bottom_border" style><span data-qmd-base64="W2dvZ10oaHR0cHM6Ly9nb29nbGUuY29tKQ=="><span class='gt_from_md'><a href="https://google.com">gog</a></span></span></td>
           </tr>
           
           <tr class="gt_col_headings gt_spanner_row">
@@ -52,7 +52,7 @@
             <td class="gt_footnote" colspan="4"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>2</sup></span> A problem because fctr is labelled with md</td>
           </tr>
           <tr>
-            <td class="gt_footnote" colspan="4"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>3</sup></span> <span data-qmd-base64="UHJvYmxlbSBiZWNhdXNlIG51bSByb3cgMSBpcyA8Y29kZT5mbXRfbWFya2Rvd24oKTwvY29kZT4gKyBhbHNvIHRoZSBmb290bm90ZSBpcyB3cmFwcGVkIGluIG1kLg=="><span class='gt_from_md'>Problem because num row 1 is <code>fmt_markdown()</code> + also the footnote is wrapped in md.</span></span></td>
+            <td class="gt_footnote" colspan="4"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>3</sup></span> <span data-qmd-base64="UHJvYmxlbSBiZWNhdXNlIG51bSByb3cgMSBpcyBgZm10X21hcmtkb3duKClgICsgYWxzbyB0aGUgZm9vdG5vdGUgaXMgd3JhcHBlZCBpbiBtZC4="><span class='gt_from_md'>Problem because num row 1 is <code>fmt_markdown()</code> + also the footnote is wrapped in md.</span></span></td>
           </tr>
         </tfoot>
       </table>

--- a/tests/testthat/_snaps/quarto.md
+++ b/tests/testthat/_snaps/quarto.md
@@ -6,7 +6,7 @@
       <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
         <thead>
           <tr class="gt_heading">
-            <td colspan="3" class="gt_heading gt_title gt_font_normal gt_bottom_border" style><span data-qmd-base64="dGl0bGU="><span class='gt_from_md'>title</span></span></td>
+            <td colspan="4" class="gt_heading gt_title gt_font_normal gt_bottom_border" style><span data-qmd-base64="PGEgaHJlZj0iaHR0cHM6Ly9nb29nbGUuY29tIj5nb2c8L2E+"><span class='gt_from_md'><a href="https://google.com">gog</a></span></span></td>
           </tr>
           
           <tr class="gt_col_headings gt_spanner_row">
@@ -14,6 +14,7 @@
             <th class="gt_center gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="problem">
               <div class="gt_column_spanner"><span data-qmd-base64="cHJvYmxlbQ=="><span class='gt_from_md'>problem</span></span></div>
             </th>
+            <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="2" colspan="1" scope="col" id="x">x</th>
           </tr>
           <tr class="gt_col_headings">
             <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="char">char<span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>1</sup></span></th>
@@ -23,30 +24,35 @@
         <tbody class="gt_table_body">
           <tr><td headers="num" class="gt_row gt_right"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>3</sup></span> <span data-qmd-base64="MC4xMTEx"><span class='gt_from_md'>0.1111</span></span></td>
       <td headers="char" class="gt_row gt_left">apricot</td>
-      <td headers="fctr" class="gt_row gt_center">one</td></tr>
+      <td headers="fctr" class="gt_row gt_center">one</td>
+      <td headers="x" class="gt_row gt_right">- 1</td></tr>
           <tr><td headers="num" class="gt_row gt_right"><span data-qmd-base64="Mi4yMjI="><span class='gt_from_md'>2.222</span></span></td>
       <td headers="char" class="gt_row gt_left">banana</td>
-      <td headers="fctr" class="gt_row gt_center">two</td></tr>
+      <td headers="fctr" class="gt_row gt_center">two</td>
+      <td headers="x" class="gt_row gt_right">- 1</td></tr>
           <tr><td headers="num" class="gt_row gt_right"><span data-qmd-base64="MzMuMzM="><span class='gt_from_md'>33.33</span></span></td>
       <td headers="char" class="gt_row gt_left">coconut</td>
-      <td headers="fctr" class="gt_row gt_center">three</td></tr>
+      <td headers="fctr" class="gt_row gt_center">three</td>
+      <td headers="x" class="gt_row gt_right">- 1</td></tr>
           <tr><td headers="num" class="gt_row gt_right"><span data-qmd-base64="NDQ0LjQ="><span class='gt_from_md'>444.4</span></span></td>
       <td headers="char" class="gt_row gt_left">durian</td>
-      <td headers="fctr" class="gt_row gt_center">four</td></tr>
+      <td headers="fctr" class="gt_row gt_center">four</td>
+      <td headers="x" class="gt_row gt_right">- 1</td></tr>
           <tr><td headers="num" class="gt_row gt_right"><span data-qmd-base64="NTU1MA=="><span class='gt_from_md'>5550</span></span></td>
       <td headers="char" class="gt_row gt_left">NA</td>
-      <td headers="fctr" class="gt_row gt_center">five</td></tr>
+      <td headers="fctr" class="gt_row gt_center">five</td>
+      <td headers="x" class="gt_row gt_right">- 1</td></tr>
         </tbody>
         
         <tfoot class="gt_footnotes">
           <tr>
-            <td class="gt_footnote" colspan="3"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>1</sup></span> Not a problem</td>
+            <td class="gt_footnote" colspan="4"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>1</sup></span> Not a problem</td>
           </tr>
           <tr>
-            <td class="gt_footnote" colspan="3"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>2</sup></span> A problem because fctr is labelled with md</td>
+            <td class="gt_footnote" colspan="4"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>2</sup></span> A problem because fctr is labelled with md</td>
           </tr>
           <tr>
-            <td class="gt_footnote" colspan="3"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>3</sup></span> <span data-qmd-base64="UHJvYmxlbSBiZWNhdXNlIG51bSByb3cgMSBpcyBmbXRfbWFya2Rvd24oKSArIGFsc28gdGhlIGZvb3Rub3RlIGlzIHdyYXBwZWQgaW4gbWQu"><span class='gt_from_md'>Problem because num row 1 is fmt_markdown() + also the footnote is wrapped in md.</span></span></td>
+            <td class="gt_footnote" colspan="4"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;line-height:0;"><sup>3</sup></span> <span data-qmd-base64="UHJvYmxlbSBiZWNhdXNlIG51bSByb3cgMSBpcyA8Y29kZT5mbXRfbWFya2Rvd24oKTwvY29kZT4gKyBhbHNvIHRoZSBmb290bm90ZSBpcyB3cmFwcGVkIGluIG1kLg=="><span class='gt_from_md'>Problem because num row 1 is <code>fmt_markdown()</code> + also the footnote is wrapped in md.</span></span></td>
           </tr>
         </tfoot>
       </table>

--- a/tests/testthat/test-quarto.R
+++ b/tests/testthat/test-quarto.R
@@ -42,11 +42,12 @@ test_that("Quarto produces the valid output", {
   withr::local_envvar(c("QUARTO_BIN_PATH" = "path"))
   tab <- exibble %>%
     dplyr::select(num, char, fctr) %>%
+    dplyr::mutate(x = "- 1") %>% # create bullet list
     dplyr::slice_head(n  = 5) %>%
     gt() %>%
     fmt_markdown(num) %>%
     tab_footnote(
-      md("Problem because num row 1 is fmt_markdown() + also the footnote is wrapped in md."),
+      md("Problem because num row 1 is `fmt_markdown()` + also the footnote is wrapped in md."),
       locations = cells_body("num", 1)
     ) %>%
     tab_footnote(
@@ -58,7 +59,7 @@ test_that("Quarto produces the valid output", {
       locations = cells_column_labels("char")
     ) %>%
     cols_label(fctr = md("Factor")) %>%
-    tab_header(md("title")) %>%
+    tab_header(md("[gog](https://google.com)")) %>%
     tab_spanner(md("problem"), c(2, 3))
 
   expect_snapshot_html(tab)


### PR DESCRIPTION
# Summary

Basically this reverts [part](https://github.com/rstudio/gt/pull/1860#discussion_r1966003385) of #1860.

As suggested in https://github.com/quarto-dev/quarto-cli/issues/11932#issuecomment-2609871584, we encode to base64 the unprocessed text.

It seems to do the trick and does not seem to introduce regressions (in particular the example in #1773 renders correctly)

For the review, it would be best to investigate this 60f19adec234093eac4fe39780bb363fec2aec85 instead of the full diff because I added tests in the first commit.

@cderv , do you think this is the right approach? 

# Related GitHub Issues and PRs

Fixes #1957 

Fixes https://github.com/quarto-dev/quarto-cli/issues/11932

Fixes https://github.com/quarto-dev/quarto-cli/issues/11610

# investigation


Here is an issue I found after this change in typst:

* Not getting anything with html-table-processing: none. So, far I haven't seen issues on html output

````qmd
---
title: test
format: typst
execute:
  echo: false
---

```{r}
devtools::load_all()
```

```{r}
#| html-table-processing: none
dplyr::tibble(
  char = LETTERS[1:2],
  num = c(1.2, -33.52),
  text = c("- x", "- y"),
  text2 = "[gog](https://google.com)"
) |>
  gt() |>
  fmt_markdown() %>% 
  gt::tab_source_note(md("[google](https://google.com)"))

```
````


With the following qmd

````qmd

---
title: test
format: html
execute:
  echo: false
---

```{r}
devtools::load_all(
)

```

```{r}
dplyr::tibble(
  char = LETTERS[1:2],
  num = c(1.2, -33.52),
  text = c("- x", "- y"),
  text2 = "[gog](https://google.com)"
) |>
  gt() |>
  fmt_markdown() %>% 
  gt::tab_source_note(md("[google](https://google.com)"))

```

```{r}
exibble %>%
    dplyr::select(num, char, fctr) %>%
    dplyr::mutate(x = "- 1") %>%
    dplyr::slice_head(n  = 5) %>%
    gt() %>%
    fmt_markdown(num) %>%
    tab_footnote(
      md("Problem because num row 1 is `fmt_markdown()` + also the footnote is wrapped in md."),
      locations = cells_body("num", 1)
    ) %>%
    tab_footnote(
      "A problem because fctr is labelled with md",
      locations = cells_column_labels("fctr")
    ) %>%
    tab_footnote(
      "Not a problem",
      locations = cells_column_labels("char")
    ) %>%
    cols_label(fctr = md("Factor")) %>%
    tab_header(md("[gog](https://google.com)")) %>%
    tab_spanner(md("problem"), c(2, 3))
```

````

gt 0.11.1:

![Image](https://github.com/user-attachments/assets/3803ec7d-e5cd-4208-93b4-58e3f8a1af83)

This PR:

![Image](https://github.com/user-attachments/assets/771f4098-7153-4955-8cb0-f14236fd65a5)


# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
