### PR TITLE
Add workaround for removing the trailing dec mark when sep_mark = ""

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gt (development version)
 
+* Fixed an issue in `fmt_number()` where `drop_trailing_dec_mark` would be ignored if `use_seps = FALSE` (@olivroy, #1961).
+
 * The default table position in LaTeX is now "t" instead of "!t" (@AaronGullickson, #1935).
 
 * Fixed an issue where cross-references would fail in bookdown::html_document2 (@olivroy, #1948)

--- a/R/fmt.R
+++ b/R/fmt.R
@@ -610,6 +610,10 @@ format_num_to_str <- function(
   if (!drop_trailing_dec_mark) {
     x_str_no_dec <- !grepl(dec_mark, x_str, fixed = TRUE)
     x_str[x_str_no_dec] <- paste_right(x_str[x_str_no_dec], dec_mark)
+  } else if (nzchar(dec_mark) && !nzchar(sep_mark)) {
+    # drop the trailing dec mark if sep mark is the empty ""
+    # needed in some cases https://github.com/rstudio/gt/issues/1961
+    x_str[endsWith(x_str, dec_mark)] <- sub(dec_mark, "", x_str[endsWith(x_str, dec_mark)], fixed = TRUE)
   }
 
   # Perform modifications to `x_str` values if formatting values to

--- a/tests/testthat/test-fmt_number.R
+++ b/tests/testthat/test-fmt_number.R
@@ -1092,3 +1092,10 @@ test_that("fmt_number() can render values in the Indian numbering system", {
     render_formats_test(expected_tab, context = "html")[["num"]]
   )
 })
+
+test_that("fmt_number() works with n_sigfig, drop_trailing_dec_mark = TRUE (#1961)", {
+  expect_equal(
+    format_num_to_str(1335.3, "html",  n_sigfig = 4, sep_mark = "", dec_mark = ".", drop_trailing_dec_mark = T,format = "fg"),
+    "1335"
+  )
+})


### PR DESCRIPTION
# Summary

Surgical (probably incorrect?) fix


# Related GitHub Issues and PRs

fixes #1961 


# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
