### PR TITLE
WIP: Prefix ids with table

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -194,6 +194,8 @@ as.tags.gt_tbl <- function(x, ...) {
 
   if (is.na(table_id)) {
     id <- random_id()
+    # Store the generated ID back into the table options so it can be accessed by rendering functions
+    x <- dt_options_set_value(data = x, option = "table_id", value = id)
   } else {
     id <- table_id
   }

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1582,10 +1582,11 @@ render_row_data <- function(
   # Join with spaces to form the headers attribute
   header <- paste(unlist(header_components_prefixed), collapse = " ")
 
-  # For stub cells, also use valid_html_id with the complete ID
+  # Fix: Don't re-apply valid_html_id to row_id_i for stub cells
+  # since they were already prefixed in create_body_component_h()
   base_attributes <- ifelse(
     has_stub_class,
-    paste0("id=\"", valid_html_id(row_id_i, tbl_id), "\" ", "scope=\"", scope, "\" "),
+    paste0("id=\"", row_id_i, "\" ", "scope=\"", scope, "\" "),
     paste0("headers=\"", header, "\" ")
   )
 

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -2202,7 +2202,8 @@ valid_html_id <- function(x, tbl_id = NULL) {
   x <- gsub("\\s+", "-", x)
   
   # If a table ID is provided, prepend it to each element ID
-  if (!is.null(tbl_id) && nchar(tbl_id) > 0) {
+  # Added check for NA values in tbl_id
+  if (!is.null(tbl_id) && length(tbl_id) > 0 && !is.na(tbl_id) && nchar(tbl_id) > 0) {
     x <- paste(tbl_id, x, sep = "-")
   }
   

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -786,7 +786,7 @@ create_columns_component_h <- function(data) {
             dplyr::filter(
               spanner_style_attrs,
               locname == "columns_groups",
-              grpname == spanner_ids[level_1_index, ][i]
+              grpname = spanner_ids[level_1_index, ][i]
             )
 
           spanner_style <-
@@ -810,7 +810,7 @@ create_columns_component_h <- function(data) {
               colspan = colspans[i],
               style = spanner_style,
               scope = ifelse(colspans[i] > 1, "colgroup", "col"),
-              id = spanner_ids[level_1_index, ][i],
+              id = valid_html_id(spanner_ids[level_1_index, ][i], tbl_id), # Use valid_html_id with tbl_id
               htmltools::tags$div(
                 class = "gt_column_spanner",
                 htmltools::HTML(spanners[level_1_index, ][i])
@@ -956,7 +956,7 @@ create_columns_component_h <- function(data) {
               colspan = colspans[j],
               style = spanner_style,
               scope = ifelse(colspans[j] > 1, "colgroup", "col"),
-              id = spanner_ids_row[j],
+              id = valid_html_id(spanner_ids_row[j], tbl_id), # Use valid_html_id with tbl_id
               if (spanner_ids_row[j] != "") {
                 htmltools::tags$div(
                   class = "gt_column_spanner",
@@ -1128,7 +1128,7 @@ create_body_component_h <- function(data) {
           class = group_class,
           style = row_style_group_heading_row,
           scope = if (n_cols_total > 1) "colgroup" else "col",
-          id = group_label,
+          id = valid_html_id(group_label, tbl_id),  # Use valid_html_id with tbl_id
           htmltools::HTML(group_label)
         )
       )
@@ -1182,13 +1182,14 @@ create_body_component_h <- function(data) {
 
         row_style_group_heading_row <- row_style_row_groups_tbl[["html_style"]]
 
+        # Update TD element to use valid_html_id for both headers and id attributes
         group_col_td <-
           htmltools::tags$td(
-            headers = group_id,
+            headers = valid_html_id(group_id, tbl_id),
             rowspan = rowspan_val,
             class = "gt_row gt_left gt_stub_row_group",
             style = row_style_group_heading_row,
-            id = group_id,
+            id = valid_html_id(group_id, tbl_id),
             htmltools::HTML(group_label)
           )
 
@@ -1394,9 +1395,11 @@ create_body_component_h <- function(data) {
     if (stub_width == 0) {
       row_id_i <- character(length(col_id_i))
     } else if (stub_width == 1) {
-      row_id_i <- rep(paste0(col_id_i[1], "_", i), length(col_id_i))
+      # Add table ID prefix to row ID base, but keep the same logic
+      row_id_i <- rep(valid_html_id(paste0(col_id_i[1], "_", i), tbl_id), length(col_id_i))
     } else if (stub_width == 2) {
-      row_id_i <- rep(paste0(col_id_i[2], "_", i), length(col_id_i))
+      # Add table ID prefix to row ID base, but keep the same logic
+      row_id_i <- rep(valid_html_id(paste0(col_id_i[2], "_", i), tbl_id), length(col_id_i))
     }
 
     # In the situation where there is:

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -530,6 +530,9 @@ create_columns_component_h <- function(data) {
   stubh <- dt_stubhead_get(data = data)
   styles_tbl <- dt_styles_get(data = data)
   body <- dt_body_get(data = data)
+  
+  # Get the table ID if available
+  tbl_id <- dt_options_get_value(data = data, option = "table_id")
 
   # Get vector representation of stub layout
   stub_layout <- get_stub_layout(data = data)
@@ -587,7 +590,7 @@ create_columns_component_h <- function(data) {
     headings_vars <- prepend_vec(headings_vars, "::stub")
   }
 
-  headings_ids <- valid_html_id(headings_vars)
+  headings_ids <- valid_html_id(headings_vars, tbl_id)
 
   stubhead_label_alignment <- "left"
 
@@ -827,7 +830,7 @@ create_columns_component_h <- function(data) {
       )
     remaining_headings_labels <-
       unlist(remaining_headings_labels)
-    remaining_headings_ids <- valid_html_id(remaining_headings_vars)
+    remaining_headings_ids <- valid_html_id(remaining_headings_vars, tbl_id)
 
     col_alignment <- col_alignment[-1][!(headings_vars %in% solo_headings)]
 
@@ -1007,6 +1010,9 @@ create_body_component_h <- function(data) {
   list_of_summaries <- dt_summary_df_get(data = data)
   groups_rows_df <- dt_groups_rows_get(data = data)
   styles_tbl <- dt_styles_get(data = data)
+  
+  # Get the table ID if available
+  tbl_id <- dt_options_get_value(data = data, option = "table_id")
 
   # Get effective number of columns
   n_cols_total <- get_effective_number_of_columns(data = data)
@@ -1829,6 +1835,9 @@ summary_rows_for_group_h <- function(
 
   list_of_summaries <- dt_summary_df_get(data = data)
   styles_tbl <- dt_styles_get(data = data)
+  
+  # Get the table ID if available
+  tbl_id <- dt_options_get_value(data = data, option = "table_id")
 
   # Obtain all of the visible (`"default"`), non-stub column names
   # for the table from the `boxh` object
@@ -1981,10 +1990,11 @@ summary_rows_for_group_h <- function(
                       "th ",
                       "id=\"",
                       if (summary_row_type == "grand") {
-                        paste0("grand_summary_stub_", j, "\" ")
+                        valid_html_id(paste0("grand_summary_stub_", j), tbl_id)
                       } else {
-                        paste0("summary_stub_", group_id, "_", j, "\" ")
+                        valid_html_id(paste0("summary_stub_", group_id, "_", j), tbl_id)
                       },
+                      "\" ",
                       "scope=\"row\""
                     )
                   } else {
@@ -1994,13 +2004,13 @@ summary_rows_for_group_h <- function(
                       "headers=\"",
                       if (summary_row_type == "grand") {
                         paste0(
-                          "grand_summary_stub_",
-                          j, " ", col_name, "\""
+                          valid_html_id("grand_summary_stub_", tbl_id),
+                          j, " ", valid_html_id(col_name, tbl_id), "\""
                         )
                       } else {
                         paste0(
-                          group_id, " summary_stub_",
-                          group_id, "_", j, " ", col_name, "\""
+                          valid_html_id(group_id, tbl_id), " ", valid_html_id("summary_stub_", tbl_id),
+                          group_id, "_", j, " ", valid_html_id(col_name, tbl_id), "\""
                         )
                       }
                     )
@@ -2115,9 +2125,16 @@ as_css_font_family_attr <- function(font_vec, value_only = FALSE) {
   paste_between(value, x_2 = c("font-family: ", ";"))
 }
 
-valid_html_id <- function(x) {
+valid_html_id <- function(x, tbl_id = NULL) {
   # Make sure it starts with a letter.
   valid_ids <- grepl("^[A-z]", x)
   x[!valid_ids] <- paste0("a", x[!valid_ids])
-  gsub("\\s+", "-", x)
+  x <- gsub("\\s+", "-", x)
+  
+  # If a table ID is provided, prepend it to each element ID
+  if (!is.null(tbl_id) && nchar(tbl_id) > 0) {
+    x <- paste(tbl_id, x, sep = "-")
+  }
+  
+  x
 }

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1445,6 +1445,8 @@ create_body_component_h <- function(data) {
     # needs to be repeated to match the size of the other fields
     group_ids <- vctrs::vec_rep_each(group_ids, times = ns)
     body_rows_data_flat$current_group_id <- group_ids
+    # Pass the table_id to render_row_data
+    body_rows_data_flat$tbl_id <- tbl_id
     ## here we have to make sur the lengths can be recycled to each others.
     # vctrs::vec_recycle_common()
     body_rows_uncollapsed <- vctrs::vec_chop(
@@ -1527,7 +1529,8 @@ render_row_data <- function(
     row_span_vals,
     alignment_classes,
     extra_classes,
-    row_styles
+    row_styles,
+    tbl_id = NULL  # Add parameter for table_id
 ) {
   n <- length(row_df)
 
@@ -1546,15 +1549,18 @@ render_row_data <- function(
   scope[!is.na(row_span_vals) & row_span_vals > 1] <- "rowgroup"
 
   has_group <- !is.na(current_group_id)
+  
+  # Use tbl_id when calling valid_html_id
   header <- paste0(
-    ifelse(has_group, current_group_id, ""), ifelse(has_group, " ", ""),
+    ifelse(has_group, valid_html_id(current_group_id, tbl_id), ""), ifelse(has_group, " ", ""),
     row_id_i, ifelse(has_group | nzchar(row_id_i), " ", ""),
-    col_id_i
+    valid_html_id(col_id_i, tbl_id)
   )
 
+  # For stub cells, also use valid_html_id for consistent IDs
   base_attributes <- ifelse(
     has_stub_class,
-    paste0("id=\"", row_id_i, "\" ", "scope=\"", scope, "\" "),
+    paste0("id=\"", valid_html_id(row_id_i, tbl_id), "\" ", "scope=\"", scope, "\" "),
     paste0("headers=\"", header, "\" ")
   )
 

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1385,7 +1385,7 @@ create_body_component_h <- function(data) {
     # Situation where we have two columns in the stub and the row label
     # isn't the first (the `row_df` vector will have one less element)
     if (length(col_names_id) > length(row_df)) {
-      col_id_i <- col_names_id[-(length(col_names_id) - length(row_df))]
+      col_id_i <- col_names_id[-(length(col_names_id) - length(row_df) + 1)]
     } else {
       col_id_i <- col_names_id
     }
@@ -1398,8 +1398,15 @@ create_body_component_h <- function(data) {
       # Add table ID prefix to row ID base, but keep the same logic
       row_id_i <- rep(valid_html_id(paste0(col_id_i[1], "_", i), tbl_id), length(col_id_i))
     } else if (stub_width == 2) {
-      # Add table ID prefix to row ID base, but keep the same logic
-      row_id_i <- rep(valid_html_id(paste0(col_id_i[2], "_", i), tbl_id), length(col_id_i))
+      # For 2-column stubs, we need to handle both first and non-first rows in a group
+      if (has_two_col_stub && !group_start) {
+        # For non-first rows, use the first column ID after the group column was removed
+        # This is what was originally the second column (stub column)
+        row_id_i <- rep(valid_html_id(paste0(col_id_i[1], "_", i), tbl_id), length(col_id_i))
+      } else {
+        # First row or other cases - use the second column ID
+        row_id_i <- rep(valid_html_id(paste0(col_id_i[2], "_", i), tbl_id), length(col_id_i))
+      }
     }
 
     # In the situation where there is:

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -786,7 +786,7 @@ create_columns_component_h <- function(data) {
             dplyr::filter(
               spanner_style_attrs,
               locname == "columns_groups",
-              grpname = spanner_ids[level_1_index, ][i]
+              grpname == spanner_ids[level_1_index, ][i]
             )
 
           spanner_style <-
@@ -1551,18 +1551,26 @@ render_row_data <- function(
   scope <- rep.int("row", n)
   scope[!is.na(row_span_vals) & row_span_vals > 1] <- "rowgroup"
 
-  has_group <- !is.na(current_group_id)
-  
   # Construct complete headers before applying valid_html_id
   header_components <- list()
   
-  if (has_group) {
-    header_components <- c(header_components, current_group_id)
+  # Fix: Handle current_group_id as a vector - only include non-NA values
+  if (length(current_group_id) == 1) {
+    # Single value case
+    if (!is.na(current_group_id)) {
+      header_components <- c(header_components, current_group_id)
+    }
+  } else {
+    # Vector case - add any non-NA values
+    non_na_groups <- current_group_id[!is.na(current_group_id)]
+    if (length(non_na_groups) > 0) {
+      header_components <- c(header_components, non_na_groups)
+    }
   }
   
   if (any(nzchar(row_id_i))) {
     # Only include non-empty row IDs
-    header_components <- c(header_components, row_id_i)
+    header_components <- c(header_components, row_id_i[nzchar(row_id_i)])
   }
   
   # Add column IDs

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1554,7 +1554,7 @@ render_row_data <- function(
   # Create headers for each cell individually
   headers <- character(n)
   
-  # Get group ID if available (only once for the entire row)
+  # Identify group ID (if available)
   group_id_prefixed <- NULL
   if (length(current_group_id) == 1 && !is.na(current_group_id)) {
     group_id_prefixed <- valid_html_id(current_group_id, tbl_id)
@@ -1565,44 +1565,58 @@ render_row_data <- function(
     }
   }
   
-  # Get the row header ID (already prefixed in create_body_component_h)
-  # We'll use the first stub cell's ID as the row header for all cells
-  row_header_id <- NULL
-  if (any(has_stub_class) && any(nzchar(row_id_i))) {
-    # Find the first stub cell's ID
-    stub_indices <- which(has_stub_class)
-    if (length(stub_indices) > 0) {
-      first_stub_idx <- stub_indices[1]
-      if (nzchar(row_id_i[first_stub_idx])) {
-        row_header_id <- row_id_i[first_stub_idx]
+  # Determine row boundaries in flattened data by tracking the pattern of stubs
+  row_starts <- which(has_stub_class)
+  
+  if (length(row_starts) > 0) {
+    # For each cell, find which row it belongs to
+    for (i in seq_len(n)) {
+      # Find which row this cell belongs to
+      row_idx <- findInterval(i, row_starts)
+      if (row_idx > 0 && row_idx <= length(row_starts)) {
+        # Get the stub position for this cell's row
+        stub_pos <- row_starts[row_idx]
+        
+        # Start with an empty vector of header components
+        cell_headers <- character(0)
+        
+        # Add the group ID if available
+        if (!is.null(group_id_prefixed)) {
+          cell_headers <- c(cell_headers, group_id_prefixed)
+        }
+        
+        # If this is not a stub cell itself, add a reference to this row's stub
+        if (!has_stub_class[i] && has_stub_class[stub_pos] && nzchar(row_id_i[stub_pos])) {
+          cell_headers <- c(cell_headers, row_id_i[stub_pos])
+        }
+        
+        # Add this cell's column ID 
+        col_id_prefixed <- valid_html_id(col_id_i[i], tbl_id)
+        cell_headers <- c(cell_headers, col_id_prefixed)
+        
+        # Set headers for this cell
+        headers[i] <- paste(cell_headers, collapse = " ")
       }
     }
-  }
-  
-  # For each cell, create its specific headers attribute
-  for (i in seq_len(n)) {
-    # Start with an empty vector of header components
-    cell_headers <- character(0)
-    
-    # 1. Add the group ID if available - relevant for all cells in the group
-    if (!is.null(group_id_prefixed)) {
-      cell_headers <- c(cell_headers, group_id_prefixed)
+  } else {
+    # No stub cells, just reference column headers
+    for (i in seq_len(n)) {
+      cell_headers <- character(0)
+      
+      # Add group ID if available
+      if (!is.null(group_id_prefixed)) {
+        cell_headers <- c(cell_headers, group_id_prefixed)
+      }
+      
+      # Add column ID
+      col_id_prefixed <- valid_html_id(col_id_i[i], tbl_id)
+      cell_headers <- c(cell_headers, col_id_prefixed)
+      
+      headers[i] <- paste(cell_headers, collapse = " ")
     }
-    
-    # 2. Add the row header ID if available - relevant for all cells in the row
-    if (!is.null(row_header_id) && !has_stub_class[i]) {
-      cell_headers <- c(cell_headers, row_header_id)
-    }
-    
-    # 3. Add this cell's column ID - column headers should already be prefixed
-    col_id_prefixed <- valid_html_id(col_id_i[i], tbl_id)
-    cell_headers <- c(cell_headers, col_id_prefixed)
-    
-    # Set the headers for this cell
-    headers[i] <- paste(cell_headers, collapse = " ")
   }
 
-  # For stub cells, use the already-prefixed row_id_i directly 
+  # For stub cells, use the already-prefixed row_id_i directly
   base_attributes <- ifelse(
     has_stub_class,
     paste0("id=\"", row_id_i, "\" ", "scope=\"", scope, "\" "),

--- a/tests/testthat/test-table_id.R
+++ b/tests/testthat/test-table_id.R
@@ -1,0 +1,82 @@
+test_that("Table ID is used as prefix for element IDs", {
+  # Create a table with a specified ID
+  tbl <- exibble %>%
+    gt(rowname_col = "row", id = "test-table") %>%
+    tab_spanner(label = "Spanner", columns = c(datetime, date, time)) %>%
+    tab_footnote(footnote = "A footnote", locations = cells_body(columns = num, rows = 1))
+  
+  # Generate HTML
+  html_str <- as.character(as.tags(tbl))
+  
+  # Test that the table's div has the correct ID
+  expect_true(grepl('id="test-table"', html_str, fixed = TRUE))
+  
+  # Test that element IDs use the table ID as prefix
+  expect_true(grepl('id="test-table-', html_str, fixed = TRUE))
+  
+  # Test that column headers have the prefixed IDs
+  expect_true(grepl('id="test-table-num"', html_str, fixed = TRUE))
+  
+  # Test that spanner has the prefixed ID
+  expect_true(grepl('id="test-table-Spanner"', html_str, fixed = TRUE))
+})
+
+test_that("Random IDs are consistently applied within a table", {
+  # Create a table without specifying an ID
+  tbl <- exibble %>%
+    gt(rowname_col = "row") %>%
+    tab_spanner(label = "Group", columns = c(datetime, date, time))
+  
+  # Render table to HTML
+  html_str <- as.character(as.tags(tbl))
+  
+  # Extract the auto-generated ID from the outer div
+  auto_id <- regmatches(html_str, regexpr('id="[^"]*"', html_str))
+  auto_id <- sub('id="', '', sub('"$', '', auto_id))
+  
+  # Test that the auto_id is not empty
+  expect_false(auto_id == "")
+  
+  # Test that element IDs within the table use the auto-generated ID as prefix
+  expect_true(grepl(paste0('id="', auto_id, '-'), html_str, fixed = TRUE))
+  
+  # Test that the auto-generated ID is used for the spanner
+  expect_true(grepl(paste0('id="', auto_id, '-Group"'), html_str, fixed = TRUE))
+  
+  # Test that one of the column IDs uses the auto-generated ID prefix
+  expect_true(grepl(paste0('id="', auto_id, '-num"'), html_str, fixed = TRUE))
+  
+  # Ensure that multiple renderings of the same table produce the same prefix for stability
+  html_str2 <- as.character(as.tags(tbl))
+  auto_id2 <- regmatches(html_str2, regexpr('id="[^"]*"', html_str2))
+  auto_id2 <- sub('id="', '', sub('"$', '', auto_id2))
+  
+  # The IDs should be different between renderings since they're randomly generated each time
+  expect_false(auto_id == auto_id2)
+  
+  # But both renderings should have consistent internal prefixing
+  expect_true(grepl(paste0('id="', auto_id2, '-Group"'), html_str2, fixed = TRUE))
+})
+
+test_that("Multiple tables have unique element IDs", {
+  # Create two tables with the same structure but different IDs
+  tbl1 <- exibble %>%
+    gt(rowname_col = "row", id = "table1") %>%
+    tab_spanner(label = "Group", columns = c(datetime, date, time))
+  
+  tbl2 <- exibble %>%
+    gt(rowname_col = "row", id = "table2") %>%
+    tab_spanner(label = "Group", columns = c(datetime, date, time))
+  
+  # Generate HTML for both tables
+  html_str1 <- as.character(as.tags(tbl1))
+  html_str2 <- as.character(as.tags(tbl2))
+  
+  # Test that each table uses its own ID as a prefix
+  expect_true(grepl('id="table1-Group"', html_str1, fixed = TRUE))
+  expect_true(grepl('id="table2-Group"', html_str2, fixed = TRUE))
+  
+  # This ensures that if multiple tables are on the same page, they won't have ID conflicts
+  expect_false(grepl('id="table1-Group"', html_str2, fixed = TRUE))
+  expect_false(grepl('id="table2-Group"', html_str1, fixed = TRUE))
+})


### PR DESCRIPTION
# Summary

Initial implementation of prefixing element ids with the table id. This doesn't totally solve for potential duplicate IDs within a page, but should at least remove one of the most common sources (multiple tables with same column names).

This is a pretty big codebase. Happy to try to package this up more nicely but might need some pointers if there are interactions I'm missing.

# Related GitHub Issues and PRs

- Ref: #1247 


# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
