### PR TITLE
Add `as.gtable()` S3 method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Suggests:
     fontawesome (>= 0.5.2),
     ggplot2,
     grid,
-    gtable,
+    gtable (>= 0.3.6),
     katex (>= 1.4.1),
     knitr,
     lubridate,

--- a/R/export.R
+++ b/R/export.R
@@ -760,6 +760,8 @@ as_gtable <- function(data, plot = FALSE, text_grob = grid::textGrob) {
   gtable
 }
 
+as.gtable.gt_tbl <- function(x, ...) as_gtable(x, ...)
+
 combine_components <- function(
     caption = NULL,
     heading = NULL,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -174,6 +174,9 @@ gt_default_options <-
   toset <- !(names(gt_default_options) %in% names(op))
   if (any(toset)) options(gt_default_options[toset])
 
+  # Only register S3 method once package is loaded
+  vctrs::s3_register("gtable::as.gtable", "gt_tbl")
+
   invisible()
 }
 


### PR DESCRIPTION
# Summary

This PR aims to fix #1972. It uses `gt::as_gtable()` to write an S3 method for the `gtable::as.gtable()` generic.
It resolves the registering a method for a suggested package via `vctrs::s3_register()`.
I'm not sure it merits any tests or news bullets, but I'd be happy to add them if needed.

# Related GitHub Issues and PRs

- Ref: #1972

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
