### PR TITLE
Delete extra backtick in tab_options(latex.tbl.pos) helpfile text

### DIFF
--- a/R/tab_options.R
+++ b/R/tab_options.R
@@ -539,7 +539,7 @@
 #'   *Specify latex floating position*
 #'
 #'   The latex position indicator for a floating environment (e.g., `"tb"`,
-#'   `"h"`). If not specified, latex position will default to `"t"``. It should be
+#'   `"h"`). If not specified, latex position will default to `"t"`. It should be
 #'   specified without square brackets. Quarto users should instead set the
 #'   floating position within the code chunk argument `tbl-pos`. The output
 #'   table will only float if `latex.use_longtable = FALSE`.

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -664,7 +664,10 @@ pages.}
 \item{latex.tbl.pos}{\emph{Specify latex floating position}
 
 The latex position indicator for a floating environment (e.g., \code{"tb"},
-\code{"h"}). If not specified, latex position will default to \verb{"t"``. It should be specified without square brackets. Quarto users should instead set the floating position within the code chunk argument }tbl-pos\verb{. The output table will only float if }latex.use_longtable = FALSE`.}
+\code{"h"}). If not specified, latex position will default to \code{"t"}. It should be
+specified without square brackets. Quarto users should instead set the
+floating position within the code chunk argument \code{tbl-pos}. The output
+table will only float if \code{latex.use_longtable = FALSE}.}
 }
 \value{
 An object of class \code{gt_tbl}.


### PR DESCRIPTION
I noticed there is a tiny typo in the helpfile for `tab_options(latex.tbl.pos)` - you can see this in your pkgdown site at <https://gt.rstudio.com/reference/tab_options.html#arg-latex-tbl-pos>, i.e.,

<img width="819" alt="Screenshot 2025-04-03 at 14 54 39" src="https://github.com/user-attachments/assets/c89bf8ad-faa3-477f-a6e5-1e1ff50e7f35" />

which is now fixed to

<img width="840" alt="Screenshot 2025-04-03 at 14 58 47" src="https://github.com/user-attachments/assets/65a8ba87-a7b6-4f73-aa79-28889cf9d772" />


# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
