### PR TITLE
docs: add Supported by Posit badge in website header

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -8,6 +8,9 @@ home:
 template:
   bootstrap: 5
   light-switch: true
+  includes:
+    in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js"></script>
   assets: pkgdown/assets
 
 authors:


### PR DESCRIPTION
This adds the Supported by Posit badge in the header of the pkgdown site.