### PR TITLE
fix: add license and attribution for knitr utility functions

### DIFF
--- a/R/knitr-utils.R
+++ b/R/knitr-utils.R
@@ -21,6 +21,14 @@
 #
 #------------------------------------------------------------------------------#
 
+# The functions below are adapted from the knitr package
+# (https://github.com/yihui/knitr), which is licensed under GPL-2 or later.
+# Copyright (c) 2012-2025 Yihui Xie
+# Original source: https://github.com/yihui/knitr/blob/main/R/utils.R
+#
+# These functions are copies of unexported functions from knitr and are
+# included here under the terms of the GPL-2 license.
+
 
 kable_caption <- function(label, caption, format) {
   # create a label for bookdown if applicable


### PR DESCRIPTION
This PR updates the documentation in `R/knitr-utils.R` to clarify the origin and licensing of several utility functions. The main change is the addition of comments explicitly stating that the functions are adapted from the knitr package and are included under the terms of the GPL-2 license.

Fixes: https://github.com/rstudio/gt/issues/890