### PR TITLE
Fix gt_split producing table of NAs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # gt (development version)
 
 * Expand functionality of `gt_group()` to allow `gt_group` objects to be combined with `gt_tbls` (#2128)
+* Fixed an issue where `gt_split` objects only contained data for the first split table and all other splits contained NA (#2130)
 
 # gt 1.3.0
 

--- a/R/gt_split.R
+++ b/R/gt_split.R
@@ -177,7 +177,7 @@ gt_split <- function(
     gt_tbl_i <- gt_tbl_main
 
     gt_tbl_i[["_data"]] <- gt_tbl_i[["_data"]][row_range_list[[i]], ]
-    gt_tbl_i[["_stub_df"]] <- gt_tbl_i[["_stub_df"]][1:length(row_range_list[[i]]), ]
+    gt_tbl_i[["_stub_df"]] <- gt_tbl_i[["_stub_df"]][seq_along(row_range_list[[i]]), ]
 
     if (!is.null(col_slice_at)) {
 

--- a/R/gt_split.R
+++ b/R/gt_split.R
@@ -177,7 +177,7 @@ gt_split <- function(
     gt_tbl_i <- gt_tbl_main
 
     gt_tbl_i[["_data"]] <- gt_tbl_i[["_data"]][row_range_list[[i]], ]
-    gt_tbl_i[["_stub_df"]] <- gt_tbl_i[["_stub_df"]][row_range_list[[i]], ]
+    gt_tbl_i[["_stub_df"]] <- gt_tbl_i[["_stub_df"]][1:length(row_range_list[[i]]), ]
 
     if (!is.null(col_slice_at)) {
 


### PR DESCRIPTION
# Summary

My colleague @sbreitbart-NOAA and I are working on a project that uses `gt` to make tables for reports. We utilize the `gt_split` function in order to break up tables to span multiple pages efficiently. After the v1.3 update, we noticed that the split tables were only working for the first element when splitting by rows. Most tables after that had all NAs and the data was not displayed (for more details and reprex see #2130).

In this PR, I change the element of the split table row dimensions (rownum_i) to match the number of rows that the split contains instead of the initial table split row numbers (this is what I believe was causing the issue). For example, when using `gt_split` to split a table with 10 rows at row 5 (row_every_n = 5), `gt_object$gt_tbls$gt_tbl[[2]]$`_stub_df`$rownum_i` resulted in a split of rows for 6 7 8 9 10 for the second split which make sense when splitting the data initially, but once you use this to call the split table, technically this indexing no longer exists for _data in the "sub-table" resulting in NAs. I address this issue by changing the sequence of row numbers for that element in the object to the sequence matching the same number of elements from the split (i.e. 1 2 3 4 5). I tested the fix using the examples found in the documentation and they work. I also ran devtools::check() and it passed with one note.

# Related GitHub Issues and PRs

- Ref: #2130

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
