### PR TITLE
fix: LaTeX renders incorrectly when `cols_merge()` uses angle brackets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # gt (development version)
 
 * Numeric formatting functions (`fmt_number()`, `fmt_scientific()`, `fmt_engineering()`, `fmt_percent()`, `fmt_currency()`, and others) gain a `drop_leading_zero` argument. Setting this to `TRUE` removes the leading zero from values between -1 and 1 (e.g., `0.75` becomes `.75`), which is useful for displaying correlations, p-values, and other bounded statistics (#2146).
+* Fixed `cols_merge()` with `<<`/`>>` patterns producing corrupted output when data values contain `<` or `>` characters, particularly in LaTeX output (#2153).
 * Update RTF handling of stub columns and spans to handle multicolumn stubs (#2118)
 * Expand functionality of `gt_group()` to allow `gt_group` objects to be combined with `gt_tbls` (#2128)
 * gt no longer exports `%>%`. You may either switch to the base pipe or call `library(magrittr)`. (#2150)

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -398,6 +398,8 @@ resolve_secondary_pattern <- function(x) {
 
     matched <- unlist(regmatches(x, m))[1]
 
+    if (is.na(matched)) break
+
     m_start <- as.integer(m[[1]])
     m_length <- attr(m[[1]], "match.length")
 
@@ -510,9 +512,20 @@ perform_col_merge <- function(data, context) {
           "i" = "Review {.arg pattern} provided to {.fn cols_merge}."
         ))
       }
+
+      has_secondary <- grepl("<<.*?>>", pattern)
+
+      if (has_secondary) {
+        glue_src_data <-
+          lapply(glue_src_data, function(vals) {
+            vals <- gsub("<", "\x01", vals, fixed = TRUE)
+            gsub(">", "\x02", vals, fixed = TRUE)
+          })
+      }
+
       glued_cols <- as.character(glue_gt(glue_src_data, pattern))
 
-      if (grepl("<<.*?>>", pattern)) {
+      if (has_secondary) {
 
         glued_cols <-
           vapply(
@@ -523,6 +536,8 @@ perform_col_merge <- function(data, context) {
           )
 
         glued_cols <- gsub("<<|>>", "", glued_cols)
+        glued_cols <- gsub("\x01", "<", glued_cols, fixed = TRUE)
+        glued_cols <- gsub("\x02", ">", glued_cols, fixed = TRUE)
       }
 
       glued_cols <- gsub(missing_val_token, "NA", glued_cols, fixed = TRUE)

--- a/tests/testthat/test-cols_merge.R
+++ b/tests/testthat/test-cols_merge.R
@@ -293,6 +293,35 @@ test_that("The secondary pattern language works well in `cols_merge()`", {
     (tbl_gt_13 |> render_formats_test("html"))[["a"]],
     c("11TRUE", "2", "33X", "4")
   )
+
+  # Angle brackets in data values should not break `<<`/`>>` pattern
+  # processing (#2153)
+  tbl_angle <- gt(data.frame(a = "A", b = "<B", stringsAsFactors = FALSE))
+
+  expect_equal(
+    (tbl_angle |>
+       cols_merge(columns = c(a, b), pattern = "<<{1}{2}>>") |>
+       render_formats_test("latex"))[["a"]],
+    "A<B"
+  )
+
+  expect_equal(
+    (tbl_angle |>
+       cols_merge(columns = c(a, b), pattern = "<<{1}{2}>>") |>
+       render_formats_test("html"))[["a"]],
+    "A&lt;B"
+  )
+
+  tbl_angle_miss <- gt(data.frame(
+    a = c("A", "C"), b = c("<B", NA), stringsAsFactors = FALSE
+  ))
+
+  expect_equal(
+    (tbl_angle_miss |>
+       cols_merge(columns = c(a, b), pattern = "{1} <<({2})>>") |>
+       render_formats_test("latex"))[["a"]],
+    c("A (<B)", "C ")
+  )
 })
 
 test_that("cols_merge_uncert() works correctly", {


### PR DESCRIPTION
This PR addresses a bug in the `cols_merge()` function where using `<<`/`>>` patterns could produce corrupted output if data values contained `<` or `>` characters, especially in LaTeX output. The update ensures that angle brackets in data values are handled safely during pattern processing. Additional tests are included to verify the fix, and documentation is updated accordingly.

Fixes: https://github.com/rstudio/gt/issues/2153