### PR TITLE
fix: `gt_split()` fails with grouped df

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Numeric formatting functions (`fmt_number()`, `fmt_scientific()`, `fmt_engineering()`, `fmt_percent()`, `fmt_currency()`, and others) gain a `drop_leading_zero` argument. Setting this to `TRUE` removes the leading zero from values between -1 and 1 (e.g., `0.75` becomes `.75`), which is useful for displaying correlations, p-values, and other bounded statistics (#2146).
 * Fixed `cols_merge()` with `<<`/`>>` patterns producing corrupted output when data values contain `<` or `>` characters, particularly in LaTeX output (#2153).
+* Fixed `gt_split()` failing on grouped data.frames by filtering stale row group metadata after subsetting rows (#2089).
 * Update RTF handling of stub columns and spans to handle multicolumn stubs (#2118)
 * Expand functionality of `gt_group()` to allow `gt_group` objects to be combined with `gt_tbls` (#2128)
 * gt no longer exports `%>%`. You may either switch to the base pipe or call `library(magrittr)`. (#2150)

--- a/R/gt_split.R
+++ b/R/gt_split.R
@@ -179,6 +179,10 @@ gt_split <- function(
     gt_tbl_i[["_data"]] <- gt_tbl_i[["_data"]][row_range_list[[i]], ]
     gt_tbl_i[["_stub_df"]] <- gt_tbl_i[["_stub_df"]][row_range_list[[i]], ]
 
+    groups_in_slice <- unique(gt_tbl_i[["_stub_df"]][["group_id"]])
+    gt_tbl_i[["_row_groups"]] <-
+      gt_tbl_i[["_row_groups"]][gt_tbl_i[["_row_groups"]] %in% groups_in_slice]
+
     if (!is.null(col_slice_at)) {
 
       # Get all visible vars in their finalized order

--- a/tests/testthat/test-gt_split.R
+++ b/tests/testthat/test-gt_split.R
@@ -139,3 +139,44 @@ test_that("Splitting a table into multiple works", {
   capture_output(expect_s3_class(testthat::testthat_print(tbl_group_04), "shiny.tag.list"))
   capture_output(expect_s3_class(testthat::testthat_print(tbl_group_04), "list"))
 })
+
+test_that("gt_split() works correctly with grouped data.frames", {
+
+  grouped_tbl <-
+    dplyr::tibble(
+      group = c("A", "A", "B", "B", "C", "C"),
+      x = 1:6,
+      y = letters[1:6]
+    ) |>
+    gt(groupname_col = "group")
+
+  tbl_group_05 <- gt_split(grouped_tbl, row_every_n = 2)
+
+  # Expect three splits (2 rows each)
+  expect_equal(length(tbl_group_05$gt_tbls$i), 3)
+  expect_equal(tbl_group_05$gt_tbls$n_rows_data, c(2, 2, 2))
+
+  # Each split should only contain the row groups present in its rows
+  split_1 <- tbl_group_05$gt_tbls$gt_tbl[[1]]
+  split_2 <- tbl_group_05$gt_tbls$gt_tbl[[2]]
+  split_3 <- tbl_group_05$gt_tbls$gt_tbl[[3]]
+
+  expect_equal(split_1[["_row_groups"]], "A")
+  expect_equal(split_2[["_row_groups"]], "B")
+  expect_equal(split_3[["_row_groups"]], "C")
+
+  # Splitting across group boundaries should retain only relevant groups
+  tbl_group_06 <- gt_split(grouped_tbl, row_every_n = 3)
+
+  expect_equal(length(tbl_group_06$gt_tbls$i), 2)
+
+  split_4 <- tbl_group_06$gt_tbls$gt_tbl[[1]]
+  split_5 <- tbl_group_06$gt_tbls$gt_tbl[[2]]
+
+  expect_equal(split_4[["_row_groups"]], c("A", "B"))
+  expect_equal(split_5[["_row_groups"]], c("B", "C"))
+
+  # Each split should render without error
+  capture_output(expect_s3_class(testthat::testthat_print(tbl_group_05), "shiny.tag.list"))
+  capture_output(expect_s3_class(testthat::testthat_print(tbl_group_06), "shiny.tag.list"))
+})


### PR DESCRIPTION
This PR addresses a bug in the `gt_split()` function where splitting a grouped data frame could result in incorrect or stale row group metadata. The fix ensures that each split table only contains the relevant row groups present in its data. Additionally, some tests have been added to verify correct behavior when splitting grouped tables.

Fixes: https://github.com/rstudio/gt/issues/2089