### PR TITLE
fix: row groups unintentionally merging

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Numeric formatting functions (`fmt_number()`, `fmt_scientific()`, `fmt_engineering()`, `fmt_percent()`, `fmt_currency()`, and others) gain a `drop_leading_zero` argument. Setting this to `TRUE` removes the leading zero from values between -1 and 1 (e.g., `0.75` becomes `.75`), which is useful for displaying correlations, p-values, and other bounded statistics (#2146).
 * Fixed `cols_merge()` with `<<`/`>>` patterns producing corrupted output when data values contain `<` or `>` characters, particularly in LaTeX output (#2153).
 * Fixed `gt_split()` failing on grouped data.frames by filtering stale row group metadata after subsetting rows (#2089).
+* Fixed multi-column stub rowspans incorrectly crossing row-group boundaries when adjacent groups share the same stub value, which caused group labels to appear in the wrong rows (#2121).
 * Update RTF handling of stub columns and spans to handle multicolumn stubs (#2118)
 * Expand functionality of `gt_group()` to allow `gt_group` objects to be combined with `gt_tbls` (#2128)
 * gt no longer exports `%>%`. You may either switch to the base pipe or call `library(magrittr)`. (#2150)

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -2336,10 +2336,13 @@ build_row_styles <- function(
 
   # If stub columns exist, apply stub styles
   if (n_stub_cols > 0) {
+
     # Handle colnum == 0 (applies to all stub columns for backward compatibility)
     idx_0 <- styles_resolved_row$colnum == 0
     stub_style <- styles_resolved_row$html_style[idx_0]
+
     if (!is_empty(stub_style)) {
+
       # Apply to all stub columns
       for (i in seq_len(n_stub_cols)) {
         result[i] <- stub_style
@@ -2378,19 +2381,27 @@ build_row_styles_with_stub_columns <- function(
 
       # Apply per-column stub styles
       for (j in seq_len(nrow(stub_column_styles))) {
+
         col_name <- stub_column_styles$colname[j]
+
         if (col_name %in% names(stub_positions)) {
+
           stub_pos <- stub_positions[col_name]
+
           # Apply style to the correct stub position
           # Each stub column has its own position in the row_styles array
           if (stub_pos <= length(row_styles)) {
-            # MERGE styles instead of overwriting
+
+            # Merge styles instead of overwriting
             existing_style <- row_styles[stub_pos]
             new_style <- stub_column_styles$html_style[j]
 
             if (is.na(existing_style) || existing_style == "") {
+
               row_styles[stub_pos] <- new_style
+
             } else if (!is.na(new_style) && new_style != "") {
+
               # Merge CSS styles by combining them
               row_styles[stub_pos] <- paste(existing_style, new_style, sep = "; ")
             }
@@ -2485,8 +2496,26 @@ calculate_hierarchical_stub_rowspans <- function(data) {
     return(NULL)
   }
 
-  # Create a matrix of stub values (excluding the rightmost column which is the row identifier)
-  hierarchy_vars <- stub_vars[-length(stub_vars)]  # Remove rightmost stub column
+  # Build a per-row group-id vector so that spans never cross group boundaries.
+  # Two consecutive rows with the same stub value but in different row groups
+  # must not be merged.
+  groups_rows_df <- dt_groups_rows_get(data = data)
+  row_group_ids <- rep(NA_character_, n_rows)
+
+  for (gi in seq_len(nrow(groups_rows_df))) {
+
+    g_start <- groups_rows_df$row_start[[gi]]
+    g_end <- groups_rows_df$row_end[[gi]]
+
+    if (!is.na(g_start) && !is.na(g_end) && g_start <= n_rows) {
+      row_group_ids[seq(g_start, min(g_end, n_rows))] <-
+        groups_rows_df$group_id[[gi]]
+    }
+  }
+
+  # Create a matrix of stub values (excluding the rightmost column which is the
+  # row identifier)
+  hierarchy_vars <- stub_vars[-length(stub_vars)]  # Remove rightmost stub col
   stub_matrix <- as.matrix(original_body[, hierarchy_vars, drop = FALSE])
 
   # Initialize rowspan information
@@ -2507,6 +2536,11 @@ calculate_hierarchical_stub_rowspans <- function(data) {
     for (row_idx in 2:n_rows) {
       # Check if current row should continue the span from previous row
       should_continue_span <- TRUE
+
+      # Never merge cells across row-group boundaries
+      if (!identical(row_group_ids[row_idx], row_group_ids[row_idx - 1])) {
+        should_continue_span <- FALSE
+      }
 
       # Must match current column value (handle NAs properly)
       curr_val <- col_values[row_idx]
@@ -2530,14 +2564,19 @@ calculate_hierarchical_stub_rowspans <- function(data) {
       }
 
       if (should_continue_span) {
+
         # Continue the current span
         display_mask[row_idx] <- FALSE
+
       } else {
+
         # End current span and start a new one
         span_length <- row_idx - current_span_start
+
         if (span_length > 1) {
           rowspans[current_span_start] <- span_length
         }
+
         current_span_start <- row_idx
       }
     }

--- a/tests/testthat/test-multicolumn_stub.R
+++ b/tests/testthat/test-multicolumn_stub.R
@@ -1494,3 +1494,53 @@ test_that("Stub styles with colnum=0 apply to all stub columns", {
   expect_equal(nrow(stub_styles), 16)
   expect_setequal(unique(stub_styles$colname), c("char", "fctr"))
 })
+
+test_that("Multicolumn stub rowspans do not cross row-group boundaries", {
+
+  # When a stub column value is the same at the boundary between two row groups,
+  # the rowspan mustn't cross that boundary. Groups C and D both start with
+  # symbol=1, so the C/D boundary was being merged incorrectly, causing group
+  # labels to appear in the wrong rows.
+  sample_data <- dplyr::tibble(
+    subject = c(rep("A", 3), rep("B", 4), rep("C", 2), rep("D", 2), rep("E", 3)),
+    symbol  = c(1, 1, 2,  1, 1, 2, 2,  1, 1,  1, 2,  2, 2, 1),
+    value   = seq_len(14) * 0.1
+  )
+
+  gt_tbl <-
+    gt(
+      sample_data,
+      rowname_col = c("symbol", "value"),
+      groupname_col = "subject"
+    )
+
+  # Build the rowspan info and verify group boundaries are respected
+  built <- gt:::build_data(gt_tbl, context = "html")
+  rowspan_info <- gt:::calculate_hierarchical_stub_rowspans(built)
+
+  # `symbol` is the only hierarchy column (value is rightmost, excluded).
+  expect_true("symbol" %in% names(rowspan_info))
+
+  rowspans <- rowspan_info[["symbol"]]$rowspans
+  display  <- rowspan_info[["symbol"]]$display_mask
+
+  # Row 9 ends group C (symbol=1). Row 10 starts group D (also symbol=1).
+  # The display mask for row 10 must be TRUE (its own cell, not hidden by a
+  # cross-group rowspan).
+  expect_true(display[10])
+
+  # Similarly, row 11 ends group D (symbol=2). Row 12 starts group E (symbol=2).
+  expect_true(display[12])
+
+  # Spans within the same group are still allowed:
+  # Group A rows 1-2 both have symbol=1, so row 1 should span 2 and row 2 hidden.
+  expect_equal(rowspans[1], 2L)
+  expect_false(display[2])
+
+  # Group C rows 8-9 both have symbol=1, so row 8 should span 2 and row 9 hidden.
+  expect_equal(rowspans[8], 2L)
+  expect_false(display[9])
+
+  # Rendering must not error
+  expect_no_error(as_raw_html(gt_tbl))
+})


### PR DESCRIPTION
This PR fixes a bug where multi-column stub rowspans could incorrectly cross row-group boundaries if adjacent groups shared the same stub value, causing group labels to appear in the wrong rows. The fix now ensures that rowspans for stub columns are restricted within their respective row groups.

Fixes: https://github.com/rstudio/gt/issues/2121