### PR TITLE
fix: `md()` used with column in LaTeX

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Numeric formatting functions (`fmt_number()`, `fmt_scientific()`, `fmt_engineering()`, `fmt_percent()`, `fmt_currency()`, and others) gain a `drop_leading_zero` argument. Setting this to `TRUE` removes the leading zero from values between -1 and 1 (e.g., `0.75` becomes `.75`), which is useful for displaying correlations, p-values, and other bounded statistics (#2146).
 * Fixed `cols_merge()` with `<<`/`>>` patterns producing corrupted output when data values contain `<` or `>` characters, particularly in LaTeX output (#2153).
 * Fixed `gt_split()` failing on grouped data.frames by filtering stale row group metadata after subsetting rows (#2089).
+* Fixed `md()` in a column label causing the column to expand to full page width (`\linewidth`) in LaTeX/PDF output when no explicit column width is set (#2124).
 * Fixed multi-column stub rowspans incorrectly crossing row-group boundaries when adjacent groups share the same stub value, which caused group labels to appear in the wrong rows (#2121).
 * Update RTF handling of stub columns and spans to handle multicolumn stubs (#2118)
 * Expand functionality of `gt_group()` to allow `gt_group` objects to be combined with `gt_tbls` (#2128)

--- a/R/utils_render_latex.R
+++ b/R/utils_render_latex.R
@@ -513,6 +513,9 @@ create_columns_component_l <- function(data, colwidth_df) {
 
     if(sum(colwidth_heading_i$unspec > 0)){
       width <- ""
+      # Strip \parbox{\linewidth} that markdown_to_latex() inserts for <br> in md() labels;
+      # without a column width, \linewidth expands to the full text width (same strip done for body cells)
+      headings_labels[i] <- gsub("\\\\parbox\\{\\\\linewidth\\}\\{(.+?)\\}", "\\1", headings_labels[i])
     }else{
       width <- create_singlecolumn_width_text_l(pt = colwidth_heading_i$pt, lw = colwidth_heading_i$lw)
     }

--- a/tests/testthat/test-utils_render_latex.R
+++ b/tests/testthat/test-utils_render_latex.R
@@ -122,3 +122,18 @@ test_that("spanner widths are calculated correctly",{
   # Hidden stub columns
   expect_match_latex(hidden_stub, pattern_2)
 })
+
+test_that("md() with <br> in column label does not produce \\linewidth in LaTeX output", {
+
+  gt_tbl <-
+    countrypops |>
+    head(5) |>
+    gt() |>
+    cols_label(country_code_2 ~ md("country<br>code"))
+
+  latex_out <- as.character(as_latex(gt_tbl))
+
+  # The header should use \shortstack for line breaking, but NOT \parbox{\linewidth}
+  expect_false(grepl("\\parbox{\\linewidth}", latex_out, fixed = TRUE))
+  expect_true(grepl("\\shortstack", latex_out, fixed = TRUE))
+})


### PR DESCRIPTION
This PR addresses a rendering issue in LaTeX/PDF output where using `md()` with a column label caused the column to expand to the full page width when no explicit column width was set. The fix ensures that such labels no longer trigger `\parbox{\linewidth}` in the LaTeX output, and adds corresponding tests to prevent regressions.

Fixes: https://github.com/rstudio/gt/issues/2124