### PR TITLE
fix: make `text_transform()` safely unescape certain HTML entities after the transformation is applied

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Fixed `cols_merge()` with `<<`/`>>` patterns producing corrupted output when data values contain `<` or `>` characters, particularly in LaTeX output (#2153).
 * Fixed `gt_split()` failing on grouped data.frames by filtering stale row group metadata after subsetting rows (#2089).
 * Fixed `md()` in a column label causing the column to expand to full page width (`\linewidth`) in LaTeX/PDF output when no explicit column width is set (#2124).
+* Fixed `text_transform()` passing HTML-escaped text (e.g., `&amp;`) to the user-supplied function instead of the original display text; functions like `stringr::str_to_title()` now receive and transform plain text as expected (#2033).
 * Fixed multi-column stub rowspans incorrectly crossing row-group boundaries when adjacent groups share the same stub value, which caused group labels to appear in the wrong rows (#2121).
 * Update RTF handling of stub columns and spans to handle multicolumn stubs (#2118)
 * Expand functionality of `gt_group()` to allow `gt_group` objects to be combined with `gt_tbls` (#2128)

--- a/R/text_transform.R
+++ b/R/text_transform.R
@@ -654,8 +654,11 @@ text_transform_at_location.cells_body <- function(
 
     if (col %in% colnames(body)) {
 
-      body[[col]][stub_df$rownum_i %in% loc$rows] <-
-        fn(body[[col]][stub_df$rownum_i %in% loc$rows])
+      rows_i <- stub_df$rownum_i %in% loc$rows
+      # Decode HTML entities (e.g. &amp; -> &) so that fn() receives plain
+      # display text rather than HTML-escaped text; fn() output is treated
+      # as HTML, consistent with text_transform()'s documented contract
+      body[[col]][rows_i] <- fn(decode_html_entities(body[[col]][rows_i]))
     }
   }
 
@@ -693,8 +696,8 @@ text_transform_at_location.cells_stub <- function(
   # Apply transformation to each specified stub column
   for (stub_var in target_columns) {
     if (stub_var %in% colnames(body)) {
-      body[[stub_var]][stub_df$rownum_i %in% loc$rows] <-
-        fn(body[[stub_var]][stub_df$rownum_i %in% loc$rows])
+      rows_i <- stub_df$rownum_i %in% loc$rows
+      body[[stub_var]][rows_i] <- fn(decode_html_entities(body[[stub_var]][rows_i]))
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1043,6 +1043,18 @@ unescape_html <- function(text) {
   text
 }
 
+# Decode only the five standard HTML character entities that htmlEscape() inserts.
+# Unlike unescape_html(), this does NOT touch <br> tags, so it is safe to use
+# on values that may already contain HTML markup (e.g. from fmt_* functions).
+decode_html_entities <- function(text) {
+  text <- gsub("&amp;",  "&",  text, fixed = TRUE)
+  text <- gsub("&lt;",   "<",  text, fixed = TRUE)
+  text <- gsub("&gt;",   ">",  text, fixed = TRUE)
+  text <- gsub("&quot;", '"',  text, fixed = TRUE)
+  text <- gsub("&#39;",  "'",  text, fixed = TRUE)
+  text
+}
+
 
 #' apply a double newline for implementing universal line break in markdown
 #' @noRd

--- a/tests/testthat/test-text_transform.R
+++ b/tests/testthat/test-text_transform.R
@@ -492,3 +492,41 @@ test_that("text_replace() works", {
 
   expect_match_html(tr, "---")
 })
+
+test_that("text_transform() decodes HTML entities before calling fn", {
+
+  # Ampersands and other special characters must arrive at fn() as plain text,
+  # not as HTML entities, so that simple string functions work correctly.
+  tbl_amp <- dplyr::tibble(
+    pairs = c("MAC & CHEESE", "STRAWBERRY & VANILLA", "LEMON & GINGER")
+  )
+
+  result_html <- tbl_amp |>
+    gt() |>
+    text_transform(
+      fn = function(x) tools::toTitleCase(tolower(x)),
+      locations = cells_body(columns = pairs)
+    ) |>
+    as_raw_html()
+
+  # Must not contain the wrongly title-cased entity &Amp;
+  expect_false(grepl("&Amp;", result_html, fixed = TRUE))
+
+  # Must render the title-cased ampersand correctly
+  expect_true(grepl("Mac & Cheese", result_html, fixed = TRUE))
+  expect_true(grepl("Strawberry & Vanilla", result_html, fixed = TRUE))
+
+  # HTML injection from fn() must still work
+  tbl_bold <- dplyr::tibble(x = "hello")
+
+  result_bold <-
+    tbl_bold |>
+    gt() |>
+    text_transform(
+      fn = function(x) paste0("<b>", x, "</b>"),
+      locations = cells_body(columns = x)
+    ) |>
+    as_raw_html()
+
+  expect_true(grepl("<b>hello</b>", result_bold, fixed = TRUE))
+})


### PR DESCRIPTION
This PR fixes an issue with `text_transform()` where user-supplied functions were receiving HTML-escaped text (such as `&amp;`) instead of the original display text. Now, transformation functions receive plain text, ensuring that string operations behave as expected.

Fixes: https://github.com/rstudio/gt/issues/2033