### PR TITLE
fix: `text_replace()` in LaTeX should operate on non-escaped text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Fixed `gt_split()` failing on grouped data.frames by filtering stale row group metadata after subsetting rows (#2089).
 * Fixed `md()` in a column label causing the column to expand to full page width (`\linewidth`) in LaTeX/PDF output when no explicit column width is set (#2124).
 * Fixed `text_transform()` passing HTML-escaped text (e.g., `&amp;`) to the user-supplied function instead of the original display text; functions like `stringr::str_to_title()` now receive and transform plain text as expected (#2033).
+* Fixed `text_replace()` failing to match patterns containing LaTeX special characters (e.g., underscores) in LaTeX/PDF output. The same plain-text pattern now works consistently in both HTML and LaTeX (#1592).
 * Tables with no data rows now display a locale-appropriate message (e.g., `"Table has no data"`) in the body area for both HTML and LaTeX output. The message can be customized via `tab_options(table.no_data_message = "...")` or suppressed by setting it to `""` (#1881).
 * Fixed multi-column stub rowspans incorrectly crossing row-group boundaries when adjacent groups share the same stub value, which caused group labels to appear in the wrong rows (#2121).
 * Update RTF handling of stub columns and spans to handle multicolumn stubs (#2118)

--- a/R/dt_transforms.R
+++ b/R/dt_transforms.R
@@ -36,12 +36,12 @@ dt_transforms_init <- function(data) {
   dt_transforms_set(data = data, transforms = list())
 }
 
-dt_transforms_add <- function(data, loc, fn) {
+dt_transforms_add <- function(data, loc, fn, plain_text = FALSE) {
 
   existing_transforms <- dt_transforms_get(data = data)
   resolved <- resolve_location(loc = loc, data = data)
 
-  added_transform <- list(resolved = resolved, fn = fn)
+  added_transform <- list(resolved = resolved, fn = fn, plain_text = plain_text)
 
   transforms <-
     c(

--- a/R/text_transform.R
+++ b/R/text_transform.R
@@ -111,7 +111,8 @@ text_replace <- function(
     locations = locations,
     fn = function(x) {
       gsub(pattern = pattern, replacement = replacement, x, perl = TRUE)
-    }
+    },
+    plain_text = TRUE
   )
 }
 
@@ -606,7 +607,7 @@ text_transform <- function(
 }
 
 # Helper function to create text_*()
-text_transform_impl <- function(data, fn, locations, call = rlang::caller_env()) {
+text_transform_impl <- function(data, fn, locations, plain_text = FALSE, call = rlang::caller_env()) {
 
   # Resolve into a list of locations
   locations <- as_locations(locations = locations)
@@ -616,7 +617,7 @@ text_transform_impl <- function(data, fn, locations, call = rlang::caller_env())
   for (loc in locations) {
     withCallingHandlers(
       # Personalize call if text_case_match() or other.
-      data <- dt_transforms_add(data = data, loc = loc, fn = fn),
+      data <- dt_transforms_add(data = data, loc = loc, fn = fn, plain_text = plain_text),
       error = function(e) {
         cli::cli_abort("Failed to resolve location.", parent = e, call = call)
       })
@@ -631,7 +632,7 @@ text_transform_impl <- function(data, fn, locations, call = rlang::caller_env())
 # specified location with fn(contents). The `fn` may be invoked several times,
 # as the location may not be naturally vectorizable as a single call. The return
 # value is the transformed `data`
-text_transform_at_location <- function(loc, data, fn = identity) {
+text_transform_at_location <- function(loc, data, fn = identity, plain_text = FALSE) {
   UseMethod("text_transform_at_location")
 }
 
@@ -640,7 +641,8 @@ text_transform_at_location <- function(loc, data, fn = identity) {
 text_transform_at_location.cells_body <- function(
     loc,
     data,
-    fn = identity
+    fn = identity,
+    plain_text = FALSE
 ) {
 
   body <- dt_body_get(data = data)
@@ -649,16 +651,28 @@ text_transform_at_location.cells_body <- function(
 
   stub_df <- dt_stub_df_get(data = data)
 
+  build_context <- dt__get(data, "_build_context") %||% "html"
+  is_latex <- identical(build_context, "latex")
+
   # Do one vectorized operation per column
   for (col in loc$colnames) {
 
     if (col %in% colnames(body)) {
 
       rows_i <- stub_df$rownum_i %in% loc$rows
-      # Decode HTML entities (e.g. &amp; -> &) so that fn() receives plain
-      # display text rather than HTML-escaped text; fn() output is treated
-      # as HTML, consistent with text_transform()'s documented contract
-      body[[col]][rows_i] <- fn(decode_html_entities(body[[col]][rows_i]))
+      vals <- body[[col]][rows_i]
+
+      if (plain_text && is_latex) {
+        # For plain-text operations in LaTeX: decode special chars before fn()
+        # so the pattern sees display text, then re-escape the result so the
+        # output remains valid LaTeX.
+        body[[col]][rows_i] <- escape_latex(fn(decode_latex_special_chars(vals)))
+      } else {
+        # For HTML (and non-plain-text LaTeX): decode HTML entities so fn()
+        # receives display text rather than &amp;-encoded text. fn() output is
+        # treated as raw HTML, consistent with text_transform()'s contract.
+        body[[col]][rows_i] <- fn(decode_html_entities(vals))
+      }
     }
   }
 
@@ -670,7 +684,8 @@ text_transform_at_location.cells_body <- function(
 text_transform_at_location.cells_stub <- function(
     loc,
     data,
-    fn = identity
+    fn = identity,
+    plain_text = FALSE
 ) {
 
   body <- dt_body_get(data = data)
@@ -693,11 +708,19 @@ text_transform_at_location.cells_stub <- function(
     stub_vars  # Apply to all stub columns if none specified
   }
 
+  build_context <- dt__get(data, "_build_context") %||% "html"
+  is_latex <- identical(build_context, "latex")
+
   # Apply transformation to each specified stub column
   for (stub_var in target_columns) {
     if (stub_var %in% colnames(body)) {
       rows_i <- stub_df$rownum_i %in% loc$rows
-      body[[stub_var]][rows_i] <- fn(decode_html_entities(body[[stub_var]][rows_i]))
+      vals <- body[[stub_var]][rows_i]
+      if (plain_text && is_latex) {
+        body[[stub_var]][rows_i] <- escape_latex(fn(decode_latex_special_chars(vals)))
+      } else {
+        body[[stub_var]][rows_i] <- fn(decode_html_entities(vals))
+      }
     }
   }
 
@@ -709,7 +732,8 @@ text_transform_at_location.cells_stub <- function(
 text_transform_at_location.cells_column_labels <- function(
     loc,
     data,
-    fn = identity
+    fn = identity,
+    plain_text = FALSE
 ) {
 
   boxh <- dt_boxhead_get(data = data)
@@ -741,7 +765,8 @@ text_transform_at_location.cells_column_labels <- function(
 text_transform_at_location.cells_column_spanners <- function(
     loc,
     data,
-    fn = identity
+    fn = identity,
+    plain_text = FALSE
 ) {
 
   spanners_df <- dt_spanners_get(data = data)
@@ -769,7 +794,8 @@ text_transform_at_location.cells_column_spanners <- function(
 text_transform_at_location.cells_row_groups <- function(
     loc,
     data,
-    fn = identity
+    fn = identity,
+    plain_text = FALSE
 ) {
 
   row_group_vec <- dt_row_groups_get(data = data)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1067,6 +1067,20 @@ decode_html_entities <- function(text) {
   text
 }
 
+decode_latex_special_chars <- function(text) {
+  text <- gsub("\\_",               "_",  text, fixed = TRUE)
+  text <- gsub("\\&",               "&",  text, fixed = TRUE)
+  text <- gsub("\\%",               "%",  text, fixed = TRUE)
+  text <- gsub("\\$",               "$",  text, fixed = TRUE)
+  text <- gsub("\\#",               "#",  text, fixed = TRUE)
+  text <- gsub("\\{",               "{",  text, fixed = TRUE)
+  text <- gsub("\\}",               "}",  text, fixed = TRUE)
+  text <- gsub("\\textasciitilde{}", "~",  text, fixed = TRUE)
+  text <- gsub("\\textasciicircum{}", "^", text, fixed = TRUE)
+  text <- gsub("\\textbackslash{}", "\\", text, fixed = TRUE)
+  text
+}
+
 
 #' apply a double newline for implementing universal line break in markdown
 #' @noRd

--- a/R/utils_render_common.R
+++ b/R/utils_render_common.R
@@ -252,7 +252,9 @@ migrate_unformatted_to_output <- function(data, context) {
     }
   }
 
-  dt_body_set(data = data, body = body)
+  data <- dt_body_set(data = data, body = body)
+  data <- dt__set(data, "_build_context", context)
+  data
 }
 
 #' Perform any text transformations
@@ -268,7 +270,8 @@ perform_text_transforms <- function(data) {
       text_transform_at_location(
         loc = transform$resolved,
         data = data,
-        fn = transform$fn
+        fn = transform$fn,
+        plain_text = isTRUE(transform$plain_text)
       )
   }
 

--- a/tests/testthat/test-text_transform.R
+++ b/tests/testthat/test-text_transform.R
@@ -129,8 +129,8 @@ test_that("text_transform() works correctly", {
 
   # Expect that each component of `transforms` has the names
   # `resolved` and `fn`
-  expect_named(transforms[[1]], c("resolved", "fn"))
-  expect_named(transforms[[2]], c("resolved", "fn"))
+  expect_named(transforms[[1]], c("resolved", "fn", "plain_text"))
+  expect_named(transforms[[2]], c("resolved", "fn", "plain_text"))
 
   # Expect that `resolved` subcomponent of `transforms` has the names
   # `columns` and `rows`
@@ -529,4 +529,56 @@ test_that("text_transform() decodes HTML entities before calling fn", {
     as_raw_html()
 
   expect_true(grepl("<b>hello</b>", result_bold, fixed = TRUE))
+})
+
+test_that("text_replace() matches plain-text patterns consistently in LaTeX output", {
+
+  tbl <-
+    dplyr::tibble(
+      names = c("test_x", "test_y", "test_z"),
+      col1 = 1:3
+    )
+
+  latex_out <-
+    tbl |>
+    gt() |>
+    text_replace(pattern = "test_x", replacement = "Worked!") |>
+    as_latex() |>
+    as.character()
+
+  # Pattern with underscore matches in LaTeX just as it does in HTML
+  expect_true(grepl("Worked!", latex_out, fixed = TRUE))
+
+  # Non-targeted rows remain LaTeX-escaped
+  expect_true(grepl("test\\_y", latex_out, fixed = TRUE))
+  expect_true(grepl("test\\_z", latex_out, fixed = TRUE))
+
+  # Plain-text replacement containing LaTeX special chars is re-escaped
+  latex_out2 <-
+    tbl |>
+    gt() |>
+    text_replace(
+      pattern = "test_x",
+      replacement = "R&D"
+    ) |>
+    as_latex() |>
+    as.character()
+
+  expect_true(grepl("R\\&D", latex_out2, fixed = TRUE))
+
+  # text_transform() in LaTeX still receives/returns LaTeX-escaped content
+  # (toupper preserves the \_ escape so the output is valid LaTeX)
+  tbl2 <- dplyr::tibble(names = "hello_world", col1 = 1)
+
+  latex_out3 <-
+    tbl2 |>
+    gt() |>
+    text_transform(
+      locations = cells_body(columns = names),
+      fn = function(x) toupper(x)
+    ) |>
+    as_latex() |>
+    as.character()
+
+  expect_true(grepl("HELLO\\_WORLD", latex_out3, fixed = TRUE))
 })


### PR DESCRIPTION
This PR improves the consistency of text replacement and transformation functions in both HTML and LaTeX/PDF table outputs, particularly for patterns containing LaTeX special characters. It introduces a mechanism to decode and re-escape LaTeX special characters for plain-text operations, ensuring that functions like `text_replace()` work the same way in both output formats.

Fixes: https://github.com/rstudio/gt/issues/1592