### PR TITLE
Fix grand summaries with multicolumn stubs

### DIFF
--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -2100,8 +2100,7 @@ summary_rows_for_group_h <- function(
   default_vars <- dt_boxhead_get_vars_default(data = data)
 
   stub_layout <- get_stub_layout(data = data)
-
-  stub_is_2 <- length(stub_layout) > 1
+  n_stub_cols <- get_stub_column_count(data = data)
 
   summary_row_lines <- list()
 
@@ -2138,8 +2137,8 @@ summary_rows_for_group_h <- function(
   # Get the number of columns for the body cells only
   n_data_cols <- get_number_of_visible_data_columns(data = data)
 
-  if (stub_is_2) {
-    n_cols_total <- n_cols_total - 1
+  if (n_stub_cols > 1L) {
+    n_cols_total <- n_cols_total - (n_stub_cols - 1L)
   }
 
   extra_classes <- rep_len(list(NULL), n_cols_total)
@@ -2148,8 +2147,8 @@ summary_rows_for_group_h <- function(
   # Create a default list of colspan values for the summary row
   col_span_vals <- rep_len(list(NULL), n_cols_total)
 
-  if (stub_is_2 && summary_row_type == "grand") {
-    col_span_vals[[1]] <- 2L
+  if (n_stub_cols > 1L && summary_row_type == "grand") {
+    col_span_vals[[1]] <- n_stub_cols
   }
 
   # Default to a left alignment for the summary row labels and obtain the
@@ -2201,8 +2200,8 @@ summary_rows_for_group_h <- function(
         }
     }
 
-    # For summary rows, use 1 stub column (the summary label column)
-    # unless we have a two-column stub which is handled separately
+    # Summary rows have one rendered stub cell; with multicolumn stubs,
+    # that cell spans the applicable stub columns
     row_styles <-
       build_row_styles(
         styles_resolved_row = styles_resolved_row,

--- a/tests/testthat/test-multicolumn_stub.R
+++ b/tests/testthat/test-multicolumn_stub.R
@@ -214,6 +214,40 @@ test_that("`get_stub_layout()` works with summary rows", {
   expect_equal(stub_vars, c("mfr", "model"))
 })
 
+test_that("grand summary rows render correctly with multicolumn stubs (#2164)", {
+
+  sample_data <-
+    data.frame(
+      cat1 = c("aeroplane", "aeroplane", "helicopter", "helicopter"),
+      cat2 = c("Cessna Skyhawk", "Piper Cherokee", "Robinson R22", "Bell 47G"),
+      Count = c(123, 45, 30, 12)
+    )
+
+  gt_tbl <-
+    sample_data |>
+    gt(rowname_col = c("cat1", "cat2")) |>
+    grand_summary_rows(
+      columns = "Count",
+      fns = list(Total = ~ sum(., na.rm = TRUE))
+    )
+
+  expect_no_warning(
+    html <- gt_tbl |> render_as_html() |> xml2::read_html()
+  )
+
+  summary_row <-
+    xml2::xml_find_first(
+      html,
+      ".//tr[contains(@class, 'gt_grand_summary_row')]"
+    )
+
+  summary_cells <- xml2::xml_find_all(summary_row, "./th | ./td")
+
+  expect_length(summary_cells, 2)
+  expect_equal(xml2::xml_text(summary_cells), c("Total", "210"))
+  expect_equal(xml2::xml_attr(summary_cells[[1]], "colspan"), "2")
+})
+
 test_that("Basic multicolumn stub footnotes render correctly", {
 
   # Create table with multicolumn stub and footnotes


### PR DESCRIPTION
# Summary

This fixes the rendering of grand summary rows when multiple columns are supplied to `rowname_col`.

The HTML renderer now uses the actual number of stub columns to:

* prevent recycling between the summary data and rendered table cells
* span the grand-summary label across all stub columns
* keep the calculated value aligned under its intended data column

A regression test reproduces the two-column example and verifies that `Total` appears once, `210` appears under `Count`, and the label cell has the correct colspan.

# Related GitHub issues and PRs

* Fixes #2164

# Testing

* Added a regression test in `test-multicolumn_stub.R`
* `git diff --check` passes
* The test suite was not run locally because R is unavailable in the Codespace; CI will perform runtime validation

# Checklist

* [x] I understand and agree to the [[Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
* [x] I have listed any major changes in the [[NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md)](https://github.com/rstudio/gt/blob/master/NEWS.md).
* [x] I have added [[testthat](https://github.com/r-lib/testthat)](https://github.com/r-lib/testthat) unit tests to [`[tests/testthat](https://github.com/rstudio/gt/tree/master/tests/testthat)`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.