### PR TITLE
Fix resolve_hierarchical_stub_indices matching wrong group leader

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * gt no longer exports `%>%`. You may either switch to the base pipe or call `library(magrittr)`. (#2150)
 * gt no longer export deprecated `dplyr::vars()` and `dplyr::one_of()`. (#2150)
 * Ensure `keep_with_next` parameter is applied consistently in `as_word` (#2149)
+* Fixed `cells_stub()` incorrectly resolving footnote row indices when a multi-column stub has repeated labels across non-contiguous groups. (#2168)
 
 # gt 1.3.0
 

--- a/R/resolver.R
+++ b/R/resolver.R
@@ -1321,10 +1321,15 @@ resolve_hierarchical_stub_indices <- function(
 
   #
   # For hierarchical stubs, we need to map each row to its group leader
-  # The group leader is the first row with the same values in all columns
-  # to the left of (and including) the target column
+  # The group leader is the highest row in the contiguous block of cells
+  # with the same values in all columns to the left of (and including)
+  # the target column
+  # Searching only within the block of contiguous cells avoids targeting
+  # a row with identical values in an unrelated, non-adjacant group further
+  # up the table
   #
 
+  grouping_cols <- stub_vars[1:target_pos]
   corrected_indices <- integer(length(row_indices))
 
   for (i in seq_along(row_indices)) {
@@ -1338,24 +1343,25 @@ resolve_hierarchical_stub_indices <- function(
 
     # Get the values for the hierarchical grouping columns (up to and
     # including the target)
-    grouping_cols <- stub_vars[1:target_pos]
     target_values <- data_tbl[row_idx, grouping_cols, drop = FALSE]
 
-    # Find the first row that has the same values in all grouping columns
-    group_leader <- NA
+    # Find the highest row in the contiguous block of cells that has the same
+    # values in all grouping columns
+    group_leader <- row_idx
 
-    for (j in 1:nrow(data_tbl)) {
+    for (j in rev(seq_len(row_idx - 1L))) {
 
       current_values <- data_tbl[j, grouping_cols, drop = FALSE]
 
-      if (all(target_values == current_values, na.rm = TRUE)) {
-        group_leader <- j
-        break
-      }
+      # Stop when contiguous block of identical cells ends, when NA values are
+      # encountered or when the top of the table is reached (loop ends)
+      if (!isTRUE(all(target_values == current_values))) break
+      group_leader <- j
     }
 
-    # Use the group leader if found, otherwise use the original index
-    corrected_indices[i] <- if (!is.na(group_leader)) group_leader else row_idx
+    # Use the group leader (which in case of no contiguous group is simply the
+    # original index)
+    corrected_indices[i] <- group_leader
   }
 
   return(corrected_indices)

--- a/tests/testthat/test-multicolumn_stub.R
+++ b/tests/testthat/test-multicolumn_stub.R
@@ -466,6 +466,16 @@ test_that("Two-column stub footnotes", {
   expect_snapshot(cat(as_raw_html(gt_tbl)))
 })
 
+test_that("Multi-column stub cell targeting with repeated labels", {
+
+  # Create table with repeated labels in non-contiguous blocks
+  gt_tab <- data.frame(a = c("a", "b", "a"), b = 1:3, c = 11:13) |>
+    gt(rowname_col = c("a", "b")) |>
+    tab_footnote("Footnote", cells_stub(rows = 3, columns = 1))
+
+  expect_identical(gt_tab$`_footnotes`$rownum, 3L)
+})
+
 test_that("Single stub column footnotes (regression test)", {
 
   # Create table with single stub column (should still work)


### PR DESCRIPTION
# Summary

`resolve_hierarchical_stub_indices()` contains a bug, resulting in group leaders being determined incorrectly when cell labels repeat in non-contiguous groups. The PR fixes this by searching for the group leader starting at `row_idx` upwards until a different group is encountered -- instead of starting in the first row and searching downwards for the first match, which can be an unrelated, non-adjacant group further up the table.

# Related GitHub Issues and PRs

- Ref: #2168 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
