### PR TITLE
Fix column spanners not displaying correctly with multi-column stub

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * gt no longer exports `%>%`. You may either switch to the base pipe or call `library(magrittr)`. (#2150)
 * gt no longer export deprecated `dplyr::vars()` and `dplyr::one_of()`. (#2150)
 * Ensure `keep_with_next` parameter is applied consistently in `as_word` (#2149)
+* Fixed higher-level column spanners not displaying correctly when multi-column stub is present (#2170)
 
 # gt 1.3.0
 

--- a/R/utils_render_html.R
+++ b/R/utils_render_html.R
@@ -1043,12 +1043,14 @@ create_columns_component_h <- function(data) {
 
       if (length(stub_layout) > 0 && i == 1) {
 
+        n_stub_cols <- get_stub_column_count(data)
+
         level_i_spanners <-
           htmltools::tagList(
             htmltools::tags$th(
               rowspan = max(higher_spanner_rows_idx),
-              colspan = length(stub_layout),
-              scope = ifelse(length(stub_layout) > 1, "colgroup", "col")
+              colspan = n_stub_cols,
+              scope = ifelse(n_stub_cols > 1, "colgroup", "col")
             ),
             level_i_spanners
           )

--- a/tests/testthat/test-utils_render_html.R
+++ b/tests/testthat/test-utils_render_html.R
@@ -55,3 +55,21 @@ test_that("bookdown-style crossrefs are added when appropriate", {
 
   expect_caption_eq("test", "test")
 })
+
+test_that("Higher-level column spanner is displayed correctly when multi-column stub is present", {
+  gt_tab <- gtcars[1:2, 1:5] |>
+    gt(rowname_col = c("mfr", "model")) |>
+    tab_spanner(label = "spanner1", columns = 3:5) |>
+    tab_spanner(label = "spanner2", columns = 3:5)
+
+  tbl_html <- gt_tab |> gt::as_raw_html()
+
+  doc <- xml2::read_html(tbl_html)
+
+  # The first <th> in the first header row is the empty top-left corner cell
+  top_left_th <- xml2::xml_find_first(doc, "(//thead/tr)[1]/th[1]")
+
+  # The stub occupies 2 columns here (row-group label + row label), so the
+  # corner cell must colspan across both -- not just 1.
+  expect_identical(xml2::xml_attr(top_left_th, "colspan"), "2")
+})


### PR DESCRIPTION
# Summary

This PR fixes a minor bug in `create_columns_component_h`: In the multi-column stub branch, `colspan` was incorrectly set to `length(stub_layout)` (which always seems to be `1`) but should be `get_stub_column_count(data)`, the number of stub columns present. This minor change resolves the below-mentioned issue.

# Related GitHub Issues and PRs

- Ref: #2170

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/gt/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/gt/tree/master/tests/testthat) for any new functionality.
